### PR TITLE
CNF-13328: Handle ordered deletion of rendered manifests

### DIFF
--- a/api/v1alpha1/siteconfig_types.go
+++ b/api/v1alpha1/siteconfig_types.go
@@ -329,8 +329,12 @@ type ManifestReference struct {
 	APIGroup *string `json:"apiGroup,omitempty"`
 	// Kind is the type of resource being referenced
 	Kind string `json:"kind,omitempty"`
-	// Name is the name of resource being referenced
+	// Name is the name of the resource being referenced
 	Name string `json:"name,omitempty"`
+	// Namespace is the namespace of the resource being referenced
+	Namespace string `json:"namespace,omitempty"`
+	//SyncWave is the order in which the resource should be processed: created in ascending order, deleted in descending order.
+	SyncWave int `json:"syncWave,omitempty"`
 	// Status is the status of the manifest
 	Status string `json:"status,omitempty"`
 	// lastAppliedTime is the last time the manifest was applied.

--- a/bundle/manifests/metaclusterinstall.openshift.io_siteconfigs.yaml
+++ b/bundle/manifests/metaclusterinstall.openshift.io_siteconfigs.yaml
@@ -617,11 +617,20 @@ spec:
                       maxLength: 32768
                       type: string
                     name:
-                      description: Name is the name of resource being referenced
+                      description: Name is the name of the resource being referenced
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the resource being
+                        referenced
                       type: string
                     status:
                       description: Status is the status of the manifest
                       type: string
+                    syncWave:
+                      description: 'SyncWave is the order in which the resource should
+                        be processed: created in ascending order, deleted in descending
+                        order.'
+                      type: integer
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -241,6 +241,8 @@ spec:
           resources:
           - namespaces
           verbs:
+          - create
+          - delete
           - get
           - list
           - patch
@@ -263,6 +265,7 @@ spec:
           - infraenvs
           verbs:
           - create
+          - delete
           - get
           - patch
           - update
@@ -272,6 +275,7 @@ spec:
           - nmstateconfigs
           verbs:
           - create
+          - delete
           - get
           - patch
           - update
@@ -281,6 +285,7 @@ spec:
           - klusterletaddonconfigs
           verbs:
           - create
+          - delete
           - get
           - patch
           - update
@@ -308,6 +313,7 @@ spec:
           - agentclusterinstalls
           verbs:
           - create
+          - delete
           - get
           - patch
           - update
@@ -327,6 +333,7 @@ spec:
           - clusterdeployments
           verbs:
           - create
+          - delete
           - get
           - list
           - patch
@@ -379,6 +386,7 @@ spec:
           - baremetalhosts
           verbs:
           - create
+          - delete
           - get
           - patch
           - update
@@ -388,6 +396,7 @@ spec:
           - hostfirmwaresettings
           verbs:
           - create
+          - delete
           - get
           - patch
           - update

--- a/config/crd/bases/metaclusterinstall.openshift.io_siteconfigs.yaml
+++ b/config/crd/bases/metaclusterinstall.openshift.io_siteconfigs.yaml
@@ -617,11 +617,20 @@ spec:
                       maxLength: 32768
                       type: string
                     name:
-                      description: Name is the name of resource being referenced
+                      description: Name is the name of the resource being referenced
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the resource being
+                        referenced
                       type: string
                     status:
                       description: Status is the status of the manifest
                       type: string
+                    syncWave:
+                      description: 'SyncWave is the order in which the resource should
+                        be processed: created in ascending order, deleted in descending
+                        order.'
+                      type: integer
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,8 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -43,6 +45,7 @@ rules:
   - infraenvs
   verbs:
   - create
+  - delete
   - get
   - patch
   - update
@@ -52,6 +55,7 @@ rules:
   - nmstateconfigs
   verbs:
   - create
+  - delete
   - get
   - patch
   - update
@@ -61,6 +65,7 @@ rules:
   - klusterletaddonconfigs
   verbs:
   - create
+  - delete
   - get
   - patch
   - update
@@ -88,6 +93,7 @@ rules:
   - agentclusterinstalls
   verbs:
   - create
+  - delete
   - get
   - patch
   - update
@@ -107,6 +113,7 @@ rules:
   - clusterdeployments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -159,6 +166,7 @@ rules:
   - baremetalhosts
   verbs:
   - create
+  - delete
   - get
   - patch
   - update
@@ -168,6 +176,7 @@ rules:
   - hostfirmwaresettings
   verbs:
   - create
+  - delete
   - get
   - patch
   - update

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/openshift/assisted-service/api v0.0.0-20240405132132-484ec5c683c6
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	open-cluster-management.io/api v0.13.0
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -79,7 +80,6 @@ require (
 	go.mongodb.org/mongo-driver v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect


### PR DESCRIPTION
This commit refactors the SiteConfig finalizer to handle ordered deletion of rendered manifests by descending order of the sync-wave.