### PR TITLE
Add LICENCE and USER to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,11 @@ COPY --from=builder \
     /opt/app-root/src/build/manager \
     /usr/local/bin/
 
+# Copy the licence
+COPY LICENSE /licenses/LICENSE
+
+ENV USER_UID=1001
+
+USER ${USER_UID}
+
 ENTRYPOINT ["/usr/local/bin/manager"]


### PR DESCRIPTION
This PR addresses the following ecosystem-cert-preflight-check issues:
- add LICENCE: addresses `"Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"`
- declare a non-root USER: addresses `"Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"`