### PR TITLE
CNF-13443: Change APIGroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# metaclusterinstall.openshift.io/siteconfig-bundle:$VERSION and metaclusterinstall.openshift.io/siteconfig-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/sakhoury/siteconfig-manager
+# open-cluster-management.io/siteconfig-bundle:$VERSION and open-cluster-management.io/siteconfig-catalog:$VERSION.
+IMAGE_TAG_BASE ?= quay.io/stolostron/siteconfig-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/PROJECT
+++ b/PROJECT
@@ -2,22 +2,22 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: metaclusterinstall.openshift.io
+domain: open-cluster-management.io
 layout:
 - go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: siteconfig
-repo: github.com/sakhoury/siteconfig
+repo: github.com/stolostron/siteconfig
 resources:
 - api:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: metaclusterinstall.openshift.io
-  group: metaclusterinstall.openshift.io
+  domain: open-cluster-management.io
+  group: siteconfig
   kind: SiteConfig
-  path: github.com/sakhoury/siteconfig/api/v1alpha1
-  version: v1
+  path: github.com/stolostron/siteconfig/api/v1alpha1
+  version: v1alpha1
 version: "3"

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the metaclusterinstall.openshift.io v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the siteconfig v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=metaclusterinstall.openshift.io
+// +groupName=siteconfig.open-cluster-management.io
 package v1alpha1
 
 import (
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	Group          = "metaclusterinstall.openshift.io"
+	Group          = "siteconfig.open-cluster-management.io"
 	Version        = "v1alpha1"
 	SiteConfigKind = "SiteConfig"
 )

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "metaclusterinstall.openshift.io/v1alpha1",
+          "apiVersion": "siteconfig.open-cluster-management.io/v1alpha1",
           "kind": "SiteConfig",
           "metadata": {
             "name": "site-sno-du-1",
@@ -212,8 +212,15 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: SiteConfig
-      name: siteconfigs.metaclusterinstall.openshift.io
+    - description: SiteConfig is the Schema for the siteconfigs API
+      displayName: Site Config
+      kind: SiteConfig
+      name: siteconfigs.siteconfig.open-cluster-management.io
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1alpha1
   description: Manage SiteConfig
   displayName: siteconfig
@@ -355,32 +362,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - metaclusterinstall.openshift.io
-          resources:
-          - siteconfigs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - metaclusterinstall.openshift.io
-          resources:
-          - siteconfigs/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - metaclusterinstall.openshift.io
-          resources:
-          - siteconfigs/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - metal3.io
           resources:
           - baremetalhosts
@@ -412,6 +393,32 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - siteconfig.open-cluster-management.io
+          resources:
+          - siteconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - siteconfig.open-cluster-management.io
+          resources:
+          - siteconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - siteconfig.open-cluster-management.io
+          resources:
+          - siteconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -479,7 +486,7 @@ spec:
                 - --leader-elect
                 command:
                 - /usr/local/bin/manager
-                image: quay.io/sakhoury/siteconfig-manager:4.16.0
+                image: quay.io/stolostron/siteconfig-operator:4.16.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/siteconfig.open-cluster-management.io_siteconfigs.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_siteconfigs.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
-  name: siteconfigs.metaclusterinstall.openshift.io
+  name: siteconfigs.siteconfig.open-cluster-management.io
 spec:
-  group: metaclusterinstall.openshift.io
+  group: siteconfig.open-cluster-management.io
   names:
     kind: SiteConfig
     listKind: SiteConfigList

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,7 @@ import (
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift/assisted-service/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/internal/controller/retry"
+	"github.com/stolostron/siteconfig/internal/controller/retry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sretry "k8s.io/client-go/util/retry"
@@ -45,10 +45,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
-	"github.com/sakhoury/siteconfig/internal/controller"
-	assistedinstaller "github.com/sakhoury/siteconfig/internal/templates/assisted-installer"
-	imagebasedinstall "github.com/sakhoury/siteconfig/internal/templates/image-based-install"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller"
+	assistedinstaller "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
+	imagebasedinstall "github.com/stolostron/siteconfig/internal/templates/image-based-install"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -102,7 +102,7 @@ func main() {
 		//Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "siteconfig.metaclusterinstall.openshift.io",
+		LeaderElectionID:       "siteconfig.open-cluster-management.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/crd/bases/siteconfig.open-cluster-management.io_siteconfigs.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_siteconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-  name: siteconfigs.metaclusterinstall.openshift.io
+  name: siteconfigs.siteconfig.open-cluster-management.io
 spec:
-  group: metaclusterinstall.openshift.io
+  group: siteconfig.open-cluster-management.io
   names:
     kind: SiteConfig
     listKind: SiteConfigList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/metaclusterinstall.openshift.io_siteconfigs.yaml
+- bases/siteconfig.open-cluster-management.io_siteconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This file is for teaching kustomize how to substitute name and namespace reference in CRD
 nameReference:
 - kind: Service
-  version: v1alpha1
+  version: v1
   fieldSpecs:
   - kind: CustomResourceDefinition
-    version: v1alpha1
+    version: v1
     group: apiextensions.k8s.io
     path: spec/conversion/webhook/clientConfig/service/name
 
 namespace:
 - kind: CustomResourceDefinition
-  version: v1alpha1
+  version: v1
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false

--- a/config/crd/patches/cainjection_in_siteconfigs.yaml
+++ b/config/crd/patches/cainjection_in_siteconfigs.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: siteconfigs.metaclusterinstall.openshift.io
+  name: siteconfigs.siteconfig.open-cluster-management.io

--- a/config/crd/patches/webhook_in_siteconfigs.yaml
+++ b/config/crd/patches/webhook_in_siteconfigs.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1alpha1
 kind: CustomResourceDefinition
 metadata:
-  name: siteconfigs.metaclusterinstall.openshift.io
+  name: siteconfigs.siteconfig.open-cluster-management.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/sakhoury/siteconfig-manager
+  newName: quay.io/stolostron/siteconfig-operator
   newTag: 4.16.0

--- a/config/manifests/bases/siteconfig.clusterserviceversion.yaml
+++ b/config/manifests/bases/siteconfig.clusterserviceversion.yaml
@@ -8,7 +8,18 @@ metadata:
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: SiteConfig is the Schema for the siteconfigs API
+      displayName: Site Config
+      kind: SiteConfig
+      name: siteconfigs.siteconfig.open-cluster-management.io
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
   description: Manage SiteConfig
   displayName: siteconfig
   icon:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -135,32 +135,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - metaclusterinstall.openshift.io
-  resources:
-  - siteconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - metaclusterinstall.openshift.io
-  resources:
-  - siteconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - metaclusterinstall.openshift.io
-  resources:
-  - siteconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts
@@ -192,3 +166,29 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - siteconfig.open-cluster-management.io
+  resources:
+  - siteconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - siteconfig.open-cluster-management.io
+  resources:
+  - siteconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - siteconfig.open-cluster-management.io
+  resources:
+  - siteconfigs/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/siteconfig_editor_role.yaml
+++ b/config/rbac/siteconfig_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: siteconfig-editor-role
 rules:
 - apiGroups:
-  - metaclusterinstall.openshift.io
+  - siteconfig.open-cluster-management.io
   resources:
   - siteconfigs
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - metaclusterinstall.openshift.io
+  - siteconfig.open-cluster-management.io
   resources:
   - siteconfigs/status
   verbs:

--- a/config/rbac/siteconfig_viewer_role.yaml
+++ b/config/rbac/siteconfig_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: siteconfig-viewer-role
 rules:
 - apiGroups:
-  - metaclusterinstall.openshift.io
+  - siteconfig.open-cluster-management.io
   resources:
   - siteconfigs
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - metaclusterinstall.openshift.io
+  - siteconfig.open-cluster-management.io
   resources:
   - siteconfigs/status
   verbs:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
-- metaclusterinstall.openshift.io_v1alpha1_siteconfig.yaml
+- siteconfig_v1alpha1_siteconfig.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/siteconfig_v1alpha1_siteconfig.yaml
+++ b/config/samples/siteconfig_v1alpha1_siteconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: metaclusterinstall.openshift.io/v1alpha1
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1
 kind: SiteConfig
 metadata:
   name: "site-sno-du-1"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
-module github.com/sakhoury/siteconfig
+module github.com/stolostron/siteconfig
 
 go 1.21
-
-//toolchain go1.21.3
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
-	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -22,8 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
-	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -146,7 +146,7 @@ var _ = Describe("Reconcile", func() {
 				Namespace: clusterNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						APIVersion: "siteconfig.open-cluster-management.io/v1alpha1",
 						Kind:       v1alpha1.SiteConfigKind,
 						Name:       clusterName,
 					},
@@ -210,7 +210,7 @@ var _ = Describe("Reconcile", func() {
 				Namespace: clusterNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						APIVersion: "siteconfig.open-cluster-management.io/v1alpha1",
 						Kind:       v1alpha1.SiteConfigKind,
 						Name:       clusterName,
 					},
@@ -324,7 +324,7 @@ var _ = Describe("Reconcile", func() {
 				Namespace: clusterNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						APIVersion: "siteconfig.open-cluster-management.io/v1alpha1",
 						Kind:       v1alpha1.SiteConfigKind,
 						Name:       clusterName,
 					},

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
-	"github.com/sakhoury/siteconfig/internal/controller/retry"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller/retry"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/siteconfig_builder.go
+++ b/internal/controller/siteconfig_builder.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/siteconfig_builder_test.go
+++ b/internal/controller/siteconfig_builder_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +48,7 @@ metadata:
 {{ if .SpecialVars.InstallConfigOverrides }}
     agent-install.openshift.io/install-config-overrides: '{{ .SpecialVars.InstallConfigOverrides }}'
 {{ end }}
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
     name: "{{ .Site.ClusterName }}"
@@ -97,7 +97,7 @@ func getMockNMStateConfigTemplate() string {
 kind: NMStateConfig
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Site.ClusterName }}"
   labels:
@@ -263,7 +263,7 @@ func TestSiteConfigBuilder_render(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"annotations": map[string]interface{}{
 						"agent-install.openshift.io/install-config-overrides": "{\"networking\":{\"networkType\":\"OVNKubernetes\"},\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}",
-						"metaclusterinstall.openshift.io/sync-wave":           "1"},
+						"siteconfig.open-cluster-management.io/sync-wave":     "1"},
 					"name":      "site-sno-du-1",
 					"namespace": "site-sno-du-1",
 				},
@@ -294,7 +294,7 @@ func TestSiteConfigBuilder_render(t *testing.T) {
 				"apiVersion": "agent-install.openshift.io/v1beta1",
 				"kind":       "NMStateConfig",
 				"metadata": map[string]interface{}{
-					"annotations": map[string]interface{}{"metaclusterinstall.openshift.io/sync-wave": "1"},
+					"annotations": map[string]interface{}{"siteconfig.open-cluster-management.io/sync-wave": "1"},
 					"labels":      map[string]interface{}{"nmstate-label": "site-sno-du-1"},
 					"name":        "node1",
 					"namespace":   "site-sno-du-1",

--- a/internal/controller/siteconfig_controller.go
+++ b/internal/controller/siteconfig_controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
-const siteConfigFinalizer = "metaclusterinstall.openshift.io/finalizer"
+const siteConfigFinalizer = "siteconfig.open-cluster-management.io/finalizer"
 
 // SiteConfigReconciler reconciles a SiteConfig object
 type SiteConfigReconciler struct {
@@ -88,9 +88,9 @@ func requeueWithCustomInterval(interval time.Duration) ctrl.Result {
 	return ctrl.Result{RequeueAfter: interval}
 }
 
-//+kubebuilder:rbac:groups=metaclusterinstall.openshift.io,resources=siteconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=metaclusterinstall.openshift.io,resources=siteconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=metaclusterinstall.openshift.io,resources=siteconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=siteconfig.open-cluster-management.io,resources=siteconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=siteconfig.open-cluster-management.io,resources=siteconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=siteconfig.open-cluster-management.io,resources=siteconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;create;update;patch;delete

--- a/internal/controller/siteconfig_controller_test.go
+++ b/internal/controller/siteconfig_controller_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
-	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -575,7 +575,7 @@ metadata:
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 kind: Test
 spec:
   name: "{{ .Site.ClusterNamee }}"`
@@ -633,7 +633,7 @@ metadata:
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 kind: Test
 spec:
   name: "{{ .Site.ClusterName }}"`

--- a/internal/controller/siteconfig_helper.go
+++ b/internal/controller/siteconfig_helper.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	sprig "github.com/go-task/slim-sprig"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "sigs.k8s.io/yaml"
 )

--- a/internal/controller/siteconfig_helper_test.go
+++ b/internal/controller/siteconfig_helper_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/controller/siteconfig_validator.go
+++ b/internal/controller/siteconfig_validator.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/controller/siteconfig_validator_test.go
+++ b/internal/controller/siteconfig_validator_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,7 +29,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
-	siteconfigv1alpha1 "github.com/sakhoury/siteconfig/api/v1alpha1"
+	siteconfigv1alpha1 "github.com/stolostron/siteconfig/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -24,7 +24,7 @@ metadata:
 {{ if .SpecialVars.InstallConfigOverrides }}
     agent-install.openshift.io/install-config-overrides: '{{ .SpecialVars.InstallConfigOverrides }}'
 {{ end }}
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
     name: "{{ .Site.ClusterName }}"
@@ -73,7 +73,7 @@ metadata:
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   baseDomain: "{{ .Site.BaseDomain }}"
   clusterInstallRef:
@@ -94,7 +94,7 @@ const InfraEnv = `apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
 spec:
@@ -119,7 +119,7 @@ const KlusterletAddonConfig = `apiVersion: agent.open-cluster-management.io/v1
 kind: KlusterletAddonConfig
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "2"
+    siteconfig.open-cluster-management.io/sync-wave: "2"
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
 spec:
@@ -143,7 +143,7 @@ const NMStateConfig = `apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Site.ClusterName }}"
   labels:
@@ -161,7 +161,7 @@ metadata:
   labels:
 {{ .Site.ClusterLabels | toYaml | indent 4 }}
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "2"
+    siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:
   hubAcceptsClient: true`
 
@@ -171,7 +171,7 @@ metadata:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
 {{ if .SpecialVars.CurrentNode.NodeLabels }}
     bmac.agent-install.openshift.io.node-label:

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -21,7 +21,7 @@ metadata:
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
     name: "{{ .Site.ClusterName }}"
@@ -58,7 +58,7 @@ metadata:
   name: "{{ .Site.ClusterName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   baseDomain: "{{ .Site.BaseDomain }}"
   clusterInstallRef:
@@ -79,7 +79,7 @@ const NetworkConfigMap = `apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Site.ClusterName }}"
 data:
@@ -91,7 +91,7 @@ const KlusterletAddonConfig = `apiVersion: agent.open-cluster-management.io/v1
 kind: KlusterletAddonConfig
 metadata:
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "2"
+    siteconfig.open-cluster-management.io/sync-wave: "2"
   labels:
     installer.name: multiclusterhub
     installer.namespace: open-cluster-management
@@ -121,7 +121,7 @@ metadata:
   labels:
 {{ .Site.ClusterLabels | toYaml | indent 4 }}
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "2"
+    siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:
   hubAcceptsClient: true`
 
@@ -131,7 +131,7 @@ metadata:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Site.ClusterName }}"
   annotations:
-    metaclusterinstall.openshift.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
 {{ if .SpecialVars.CurrentNode.NodeLabels }}
     bmac.agent-install.openshift.io.node-label:


### PR DESCRIPTION
This PR contains changes to support moving from `metaclusterinstall.openshift.io` APIGroup to `cluster.open-cluster-management.io`.

The project files have also been updated to reflect `stolostron` instead of `sakhoury`.

There are no functional changes to the underlying code.

/cc @carbonin @jnpacker 