### PR TITLE
CNF-13563: Rename ClusterData Site field to Spec

### DIFF
--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -40,7 +40,7 @@ type SpecialVars struct {
 
 // ClusterData is a special object that provides an interface to the ClusterInstance spec fields for use in rendering templates
 type ClusterData struct {
-	Site        v1alpha1.ClusterInstanceSpec
+	Spec        v1alpha1.ClusterInstanceSpec
 	SpecialVars SpecialVars
 }
 
@@ -147,7 +147,7 @@ func buildClusterData(clusterInstance *v1alpha1.ClusterInstance, node *v1alpha1.
 	}
 
 	data = &ClusterData{
-		Site: clusterInstance.Spec,
+		Spec: clusterInstance.Spec,
 		SpecialVars: SpecialVars{
 			CurrentNode:            currentNode,
 			InstallConfigOverrides: installConfigOverrides,

--- a/internal/controller/clusterinstance/helper_test.go
+++ b/internal/controller/clusterinstance/helper_test.go
@@ -156,7 +156,7 @@ func Test_buildClusterData(t *testing.T) {
 			},
 			node: nil,
 			expected: ClusterData{
-				Site: v1alpha1.ClusterInstanceSpec{
+				Spec: v1alpha1.ClusterInstanceSpec{
 					NetworkType:            NetworkType,
 					InstallConfigOverrides: InstallConfigOverrides,
 					CPUPartitioning:        CPUPartitioning,
@@ -209,7 +209,7 @@ func Test_buildClusterData(t *testing.T) {
 				Role:     "master",
 			},
 			expected: ClusterData{
-				Site: v1alpha1.ClusterInstanceSpec{
+				Spec: v1alpha1.ClusterInstanceSpec{
 					NetworkType:            NetworkType,
 					InstallConfigOverrides: InstallConfigOverrides,
 					CPUPartitioning:        CPUPartitioning,

--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -256,7 +256,7 @@ var _ = Describe("renderTemplates", func() {
 		clusterTemplates := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "cluster-level", Namespace: "test"},
 			Data: map[string]string{
-				"TestA": "{{.Site.doesNotExist}}",
+				"TestA": "{{.Spec.doesNotExist}}",
 			},
 		}
 		Expect(c.Create(ctx, clusterTemplates)).To(Succeed())

--- a/internal/controller/clusterinstance/test_utils.go
+++ b/internal/controller/clusterinstance/test_utils.go
@@ -121,8 +121,8 @@ func GetMockAgentClusterInstallTemplate() string {
 	return `apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
 {{ if .SpecialVars.InstallConfigOverrides }}
     agent-install.openshift.io/install-config-overrides: '{{ .SpecialVars.InstallConfigOverrides }}'
@@ -130,31 +130,31 @@ metadata:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
-    name: "{{ .Site.ClusterName }}"
-  holdInstallation: {{ .Site.HoldInstallation }}
+    name: "{{ .Spec.ClusterName }}"
+  holdInstallation: {{ .Spec.HoldInstallation }}
   imageSetRef:
-    name: "{{ .Site.ClusterImageSetNameRef }}"
-{{ if .Site.ApiVIPs }}
+    name: "{{ .Spec.ClusterImageSetNameRef }}"
+{{ if .Spec.ApiVIPs }}
   apiVIPs:
-{{ .Site.ApiVIPs | toYaml | indent 4 }}
+{{ .Spec.ApiVIPs | toYaml | indent 4 }}
 {{ end }}
-{{ if .Site.IngressVIPs }}
+{{ if .Spec.IngressVIPs }}
   ingressVIPs:
-{{ .Site.IngressVIPs | toYaml | indent 4 }}
+{{ .Spec.IngressVIPs | toYaml | indent 4 }}
 {{ end }}
   networking:
-{{ if .Site.ClusterNetwork }}
+{{ if .Spec.ClusterNetwork }}
     clusterNetwork:
-{{ .Site.ClusterNetwork | toYaml | indent 6 }}
+{{ .Spec.ClusterNetwork | toYaml | indent 6 }}
 {{ end }}
-{{ if .Site.MachineNetwork }}
+{{ if .Spec.MachineNetwork }}
     machineNetwork:
-{{ .Site.MachineNetwork | toYaml | indent 6 }}
+{{ .Spec.MachineNetwork | toYaml | indent 6 }}
 {{ end }}
-{{ if .Site.ServiceNetwork }}
+{{ if .Spec.ServiceNetwork }}
     serviceNetwork:
 {{ $serviceNetworks := list }}
-{{ range .Site.ServiceNetwork }}
+{{ range .Spec.ServiceNetwork }}
 {{ $serviceNetworks = append $serviceNetworks .CIDR }}
 {{ end }}
 {{ $serviceNetworks | toYaml | indent 6 }}
@@ -162,13 +162,13 @@ spec:
   provisionRequirements:
     controlPlaneAgents: {{ .SpecialVars.ControlPlaneAgents }}
     workerAgents: {{ .SpecialVars.WorkerAgents }}
-{{ if (anyFieldDefined .Site.Proxy) }}
+{{ if (anyFieldDefined .Spec.Proxy) }}
   proxy:
-{{ .Site.Proxy | toYaml | indent 4 }}
+{{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
-  sshPublicKey: "{{ .Site.SSHPublicKey }}"
+  sshPublicKey: "{{ .Spec.SSHPublicKey }}"
   manifestsConfigMapRef:
-    name: "{{ .Site.ClusterName }}"`
+    name: "{{ .Spec.ClusterName }}"`
 }
 
 func GetMockNMStateConfigTemplate() string {
@@ -178,9 +178,9 @@ metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   labels:
-    nmstate-label: "{{ .Site.ClusterName }}"
+    nmstate-label: "{{ .Spec.ClusterName }}"
 spec:
   config:
 {{ .SpecialVars.CurrentNode.NodeNetwork.NetConfig  | toYaml | indent 4}}
@@ -254,7 +254,7 @@ func GetMockBasicClusterTemplate(kind string) string {
 	return fmt.Sprintf(`apiVersion: test.io/v1
 kind: %s
 spec:
-  name: "{{ .Site.ClusterName }}"`, kind)
+  name: "{{ .Spec.ClusterName }}"`, kind)
 }
 
 func GetMockBasicNodeTemplate(kind string) string {

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -573,13 +573,13 @@ var _ = Describe("handleRenderTemplates", func() {
 
 		templateStr := `apiVersion: test.io/v1
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 kind: Test
 spec:
-  name: "{{ .Site.ClusterNamee }}"`
+  name: "{{ .Spec.ClusterNamee }}"`
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -631,13 +631,13 @@ spec:
 
 		templateStr := `apiVersion: test.io/v1
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 kind: Test
 spec:
-  name: "{{ .Site.ClusterName }}"`
+  name: "{{ .Spec.ClusterName }}"`
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -18,8 +18,8 @@ package assistedinstaller
 const AgentClusterInstall = `apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
 {{ if .SpecialVars.InstallConfigOverrides }}
     agent-install.openshift.io/install-config-overrides: '{{ .SpecialVars.InstallConfigOverrides }}'
@@ -27,31 +27,31 @@ metadata:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
-    name: "{{ .Site.ClusterName }}"
-  holdInstallation: {{ .Site.HoldInstallation }}
+    name: "{{ .Spec.ClusterName }}"
+  holdInstallation: {{ .Spec.HoldInstallation }}
   imageSetRef:
-    name: "{{ .Site.ClusterImageSetNameRef }}"
-{{ if .Site.ApiVIPs }}
+    name: "{{ .Spec.ClusterImageSetNameRef }}"
+{{ if .Spec.ApiVIPs }}
   apiVIPs:
-{{ .Site.ApiVIPs | toYaml | indent 4 }}
+{{ .Spec.ApiVIPs | toYaml | indent 4 }}
 {{ end }}
-{{ if .Site.IngressVIPs }}
+{{ if .Spec.IngressVIPs }}
   ingressVIPs:
-{{ .Site.IngressVIPs | toYaml | indent 4 }}
+{{ .Spec.IngressVIPs | toYaml | indent 4 }}
 {{ end }}
   networking:
-{{ if .Site.ClusterNetwork }}
+{{ if .Spec.ClusterNetwork }}
     clusterNetwork:
-{{ .Site.ClusterNetwork | toYaml | indent 6 }}
+{{ .Spec.ClusterNetwork | toYaml | indent 6 }}
 {{ end }}
-{{ if .Site.MachineNetwork }}
+{{ if .Spec.MachineNetwork }}
     machineNetwork:
-{{ .Site.MachineNetwork | toYaml | indent 6 }}
+{{ .Spec.MachineNetwork | toYaml | indent 6 }}
 {{ end }}
-{{ if .Site.ServiceNetwork }}
+{{ if .Spec.ServiceNetwork }}
     serviceNetwork:
 {{ $serviceNetworks := list }}
-{{ range .Site.ServiceNetwork }}
+{{ range .Spec.ServiceNetwork }}
 {{ $serviceNetworks = append $serviceNetworks .CIDR }}
 {{ end }}
 {{ $serviceNetworks | toYaml | indent 6 }}
@@ -59,72 +59,72 @@ spec:
   provisionRequirements:
     controlPlaneAgents: {{ .SpecialVars.ControlPlaneAgents }}
     workerAgents: {{ .SpecialVars.WorkerAgents }}
-{{ if (anyFieldDefined .Site.Proxy) }}
+{{ if (anyFieldDefined .Spec.Proxy) }}
   proxy:
-{{ .Site.Proxy | toYaml | indent 4 }}
+{{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
-  sshPublicKey: "{{ .Site.SSHPublicKey }}"
+  sshPublicKey: "{{ .Spec.SSHPublicKey }}"
   manifestsConfigMapRef:
-    name: "{{ .Site.ClusterName }}"`
+    name: "{{ .Spec.ClusterName }}"`
 
 const ClusterDeployment = `apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
-  baseDomain: "{{ .Site.BaseDomain }}"
+  baseDomain: "{{ .Spec.BaseDomain }}"
   clusterInstallRef:
     group: extensions.hive.openshift.io
     kind: AgentClusterInstall
-    name: "{{ .Site.ClusterName }}"
+    name: "{{ .Spec.ClusterName }}"
     version: v1beta1
-  clusterName: "{{ .Site.ClusterName }}"
+  clusterName: "{{ .Spec.ClusterName }}"
   platform:
     agentBareMetal:
       agentSelector:
         matchLabels:
-          cluster-name: "{{ .Site.ClusterName }}"
+          cluster-name: "{{ .Spec.ClusterName }}"
   pullSecretRef:
-    name: "{{ .Site.PullSecretRef.Name }}"`
+    name: "{{ .Spec.PullSecretRef.Name }}"`
 
 const InfraEnv = `apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 spec:
   clusterRef:
-    name: "{{ .Site.ClusterName }}"
-    namespace: "{{ .Site.ClusterName }}"
-  sshAuthorizedKey: "{{ .Site.SSHPublicKey }}"
-{{ if (anyFieldDefined .Site.Proxy) }}
+    name: "{{ .Spec.ClusterName }}"
+    namespace: "{{ .Spec.ClusterName }}"
+  sshAuthorizedKey: "{{ .Spec.SSHPublicKey }}"
+{{ if (anyFieldDefined .Spec.Proxy) }}
   proxy:
-{{ .Site.Proxy | toYaml | indent 4 }}
+{{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
   pullSecretRef:
-    name: "{{ .Site.PullSecretRef.Name }}"
-  ignitionConfigOverride: {{ .Site.IgnitionConfigOverride }}
+    name: "{{ .Spec.PullSecretRef.Name }}"
+  ignitionConfigOverride: {{ .Spec.IgnitionConfigOverride }}
   nmStateConfigLabelSelector:
     matchLabels:
-      nmstate-label: "{{ .Site.ClusterName }}"
+      nmstate-label: "{{ .Spec.ClusterName }}"
   additionalNTPSources:
-{{ .Site.AdditionalNTPSources | toYaml | indent 4 }}`
+{{ .Spec.AdditionalNTPSources | toYaml | indent 4 }}`
 
 const KlusterletAddonConfig = `apiVersion: agent.open-cluster-management.io/v1
 kind: KlusterletAddonConfig
 metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 spec:
-  clusterName: "{{ .Site.ClusterName }}"
-  clusterNamespace: "{{ .Site.ClusterName }}"
+  clusterName: "{{ .Spec.ClusterName }}"
+  clusterNamespace: "{{ .Spec.ClusterName }}"
   clusterLabels:
     cloud: auto-detect
     vendor: auto-detect
@@ -145,9 +145,9 @@ metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   labels:
-    nmstate-label: "{{ .Site.ClusterName }}"
+    nmstate-label: "{{ .Spec.ClusterName }}"
 spec:
   config:
 {{ .SpecialVars.CurrentNode.NodeNetwork.NetConfig | toYaml | indent 4}}
@@ -157,9 +157,9 @@ spec:
 const ManagedCluster = `apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
-  name: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
   labels:
-{{ .Site.ClusterLabels | toYaml | indent 4 }}
+{{ .Spec.ClusterLabels | toYaml | indent 4 }}
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:
@@ -169,7 +169,7 @@ const BareMetalHost = `apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
@@ -186,7 +186,7 @@ metadata:
 {{ end }}
     bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
   labels:
-    infraenvs.agent-install.openshift.io: "{{ .Site.ClusterName }}"
+    infraenvs.agent-install.openshift.io: "{{ .Spec.ClusterName }}"
 spec:
   bootMode: "{{ .SpecialVars.CurrentNode.BootMode }}"
   bmc:

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -18,62 +18,62 @@ package imagebasedinstall
 const ImageClusterInstall = `apiVersion: extensions.hive.openshift.io/v1alpha1
 kind: ImageClusterInstall
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
   clusterDeploymentRef:
-    name: "{{ .Site.ClusterName }}"
+    name: "{{ .Spec.ClusterName }}"
   imageSetRef:
-    name: "{{ .Site.ClusterImageSetNameRef }}"
+    name: "{{ .Spec.ClusterImageSetNameRef }}"
   hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
-  sshKey: "{{ .Site.SSHPublicKey }}"
-{{ if .Site.CaBundleRef.Name }}
+  sshKey: "{{ .Spec.SSHPublicKey }}"
+{{ if .Spec.CaBundleRef.Name }}
   caBundleRef:
-{{ .Site.CaBundleRef | toYaml | indent 4 }}
+{{ .Spec.CaBundleRef | toYaml | indent 4 }}
 {{ end }}
   networkConfigRef:
     name: "{{ .SpecialVars.CurrentNode.HostName }}"
-{{ if gt (len .Site.ExtraManifestsRefs) 0 }}
+{{ if gt (len .Spec.ExtraManifestsRefs) 0 }}
   extraManifestsRef:
-{{ .Site.ExtraManifestsRefs | toYaml | indent 4 }}
+{{ .Spec.ExtraManifestsRefs | toYaml | indent 4 }}
 {{ end }}
   bareMetalHostRef:
     name: "{{ .SpecialVars.CurrentNode.HostName }}"
-    namespace: "{{ .Site.ClusterName }}"
-{{ if .Site.MachineNetwork }}
+    namespace: "{{ .Spec.ClusterName }}"
+{{ if .Spec.MachineNetwork }}
 machineNetwork:
-{{ .Site.MachineNetwork | toYaml | indent 4 }}
+{{ .Spec.MachineNetwork | toYaml | indent 4 }}
 {{ end }}
-{{ if (anyFieldDefined .Site.Proxy) }}
+{{ if (anyFieldDefined .Spec.Proxy) }}
   proxy:
-{{ .Site.Proxy | toYaml | indent 4 }}
+{{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
 `
 
 const ClusterDeployment = `apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment
 metadata:
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
 spec:
-  baseDomain: "{{ .Site.BaseDomain }}"
+  baseDomain: "{{ .Spec.BaseDomain }}"
   clusterInstallRef:
     group: extensions.hive.openshift.io
     kind: ImageClusterInstall
-    name: "{{ .Site.ClusterName }}"
+    name: "{{ .Spec.ClusterName }}"
     version: v1alpha1
-  clusterName: "{{ .Site.ClusterName }}"
+  clusterName: "{{ .Spec.ClusterName }}"
   platform:
     agentBareMetal:
       agentSelector:
         matchLabels:
-          cluster-name: "{{ .Site.ClusterName }}"
+          cluster-name: "{{ .Spec.ClusterName }}"
   pullSecretRef:
-    name: "{{ .Site.PullSecretRef.Name }}"`
+    name: "{{ .Spec.PullSecretRef.Name }}"`
 
 const NetworkConfigMap = `apiVersion: v1
 kind: ConfigMap
@@ -81,7 +81,7 @@ metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 data:
   network-config: |
 {{ .SpecialVars.CurrentNode.NodeNetwork.Config | toYaml | indent 4}}
@@ -95,11 +95,11 @@ metadata:
   labels:
     installer.name: multiclusterhub
     installer.namespace: open-cluster-management
-  name: "{{ .Site.ClusterName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 spec:
-  clusterName: "{{ .Site.ClusterName }}"
-  clusterNamespace: "{{ .Site.ClusterName }}"
+  clusterName: "{{ .Spec.ClusterName }}"
+  clusterNamespace: "{{ .Spec.ClusterName }}"
   clusterLabels:
     cloud: auto-detect
     vendor: auto-detect
@@ -117,9 +117,9 @@ spec:
 const ManagedCluster = `apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
-  name: "{{ .Site.ClusterName }}"
+  name: "{{ .Spec.ClusterName }}"
   labels:
-{{ .Site.ClusterLabels | toYaml | indent 4 }}
+{{ .Spec.ClusterLabels | toYaml | indent 4 }}
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:
@@ -129,7 +129,7 @@ const BareMetalHost = `apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
-  namespace: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
@@ -146,7 +146,7 @@ metadata:
 {{ end }}
     bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
   labels:
-    infraenvs.agent-install.openshift.io: "{{ .Site.ClusterName }}"
+    infraenvs.agent-install.openshift.io: "{{ .Spec.ClusterName }}"
 spec:
   bootMode: "{{ .SpecialVars.CurrentNode.BootMode }}"
   bmc:


### PR DESCRIPTION
This PR contains the change to rename the `ClusterData` object `Site` field to `Spec`.