### PR TITLE
Add quotes to json string fields in default AI and IBI templates

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -108,7 +108,7 @@ spec:
 {{ end }}
   pullSecretRef:
     name: "{{ .Spec.PullSecretRef.Name }}"
-  ignitionConfigOverride: {{ .Spec.IgnitionConfigOverride }}
+  ignitionConfigOverride: '{{ .Spec.IgnitionConfigOverride }}'
   nmStateConfigLabelSelector:
     matchLabels:
       nmstate-label: "{{ .Spec.ClusterName }}"
@@ -182,7 +182,7 @@ metadata:
     bmac.agent-install.openshift.io/installer-args: {{ .SpecialVars.CurrentNode.InstallerArgs  }}
 {{ end }}
 {{ if .SpecialVars.CurrentNode.IgnitionConfigOverride }}
-    bmac.agent-install.openshift.io/ignition-config-overrides: {{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}
+    bmac.agent-install.openshift.io/ignition-config-overrides: '{{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}'
 {{ end }}
     bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
   labels:

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -142,7 +142,7 @@ metadata:
     bmac.agent-install.openshift.io/installer-args: {{ .SpecialVars.CurrentNode.InstallerArgs  }}
 {{ end }}
 {{ if .SpecialVars.CurrentNode.IgnitionConfigOverride }}
-    bmac.agent-install.openshift.io/ignition-config-overrides: {{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}
+    bmac.agent-install.openshift.io/ignition-config-overrides: '{{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}'
 {{ end }}
     bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
   labels:


### PR DESCRIPTION
This PR contains changes to the default templates in the SiteConfig operator. Specifically, the templates which have fields that are json strings are updated with quotes.