### PR TITLE
Update AgentClusterInstall template to use manifestsConfigMapRefs

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -64,8 +64,10 @@ spec:
 {{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
   sshPublicKey: "{{ .Spec.SSHPublicKey }}"
-  manifestsConfigMapRef:
-    name: "{{ .Spec.ClusterName }}"`
+{{ if gt (len .Spec.ExtraManifestsRefs) 0 }}
+  manifestsConfigMapRefs:
+{{ .Spec.ExtraManifestsRefs | toYaml | indent 4 }}
+{{ end }}`
 
 const ClusterDeployment = `apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment


### PR DESCRIPTION
This PR contains the change to replace the deprecated `AgentClusterInstall` template field `manifestsConfigMapRef` with `manifestsConfigMapRefs`.

The sample ACI CR below confirms the change.

```yaml
apiVersion: extensions.hive.openshift.io/v1beta1
kind: AgentClusterInstall
metadata:
  annotations:
    agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"},"capabilities":{"baselineCapabilitySet": "None", "additionalEnabledCapabilities": [ "marketplace", "NodeTuning" ] }}'
    siteconfig.open-cluster-management.io/sync-wave: "1"
  creationTimestamp: "2024-07-11T14:23:21Z"
  finalizers:
    - agentclusterinstall.agent-install.openshift.io/ai-deprovision
  generation: 4
  name: cnfdg6
  namespace: cnfdg6
  ownerReferences:
    - apiVersion: siteconfig.open-cluster-management.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: ClusterInstance
      name: cnfdg6
      uid: 3869ddbe-705f-4723-99f8-a5990ad23c05
    - apiVersion: hive.openshift.io/v1
      kind: ClusterDeployment
      name: cnfdg6
      uid: c2677e18-a869-4c6f-886e-7eb7c11ee0d7
  resourceVersion: "172384110"
  uid: 117b9af9-573c-427f-abed-6f176ce33744
spec:
  clusterDeploymentRef:
    name: cnfdg6
  imageSetRef:
    name: img4.14.9-x86-64-appsub
  manifestsConfigMapRefs:
    - name: extra-machine-configs
    - name: enable-crun
  networking:
    clusterNetwork:
      - cidr: 10.128.0.0/14
        hostPrefix: 23
    machineNetwork:
      - cidr: 10.6.34.0/24
    serviceNetwork:
      - 172.30.0.0/16
    userManagedNetworking: true
  provisionRequirements:
    controlPlaneAgents: 1
  sshPublicKey: <retracted>
status:
  conditions:
    - lastProbeTime: "2024-07-11T14:23:21Z"
      lastTransitionTime: "2024-07-11T14:23:21Z"
      message: SyncOK
      reason: SyncOK
      status: "True"
      type: SpecSynced
...
```