### PR TITLE
CNF-13781: Refine ClusterInstance Provisioned condition status

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -393,8 +393,8 @@ type ClusterInstanceStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=clusterinstances,scope=Namespaced
-//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.conditions[-1:].reason"
-//+kubebuilder:printcolumn:name="Details",type="string",JSONPath=".status.conditions[-1:].message"
+//+kubebuilder:printcolumn:name="ProvisionStatus",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].reason"
+//+kubebuilder:printcolumn:name="ProvisionDetails",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].message"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ClusterInstance is the Schema for the clusterinstances API

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -15,11 +15,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].reason
-      name: State
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
+      name: ProvisionStatus
       type: string
-    - jsonPath: .status.conditions[-1:].message
-      name: Details
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].message
+      name: ProvisionDetails
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -15,11 +15,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].reason
-      name: State
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
+      name: ProvisionStatus
       type: string
-    - jsonPath: .status.conditions[-1:].message
-      name: Details
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].message
+      name: ProvisionDetails
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -29,11 +29,12 @@ type ConditionReason string
 
 // The following constants define the different reasons that conditions will be set for
 const (
-	Completed  ConditionReason = "Completed"
-	Failed     ConditionReason = "Failed"
-	TimedOut   ConditionReason = "TimedOut"
-	InProgress ConditionReason = "InProgress"
-	Unknown    ConditionReason = "Unknown"
+	Completed       ConditionReason = "Completed"
+	Failed          ConditionReason = "Failed"
+	TimedOut        ConditionReason = "TimedOut"
+	InProgress      ConditionReason = "InProgress"
+	Unknown         ConditionReason = "Unknown"
+	StaleConditions ConditionReason = "StaleConditions"
 )
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and
@@ -84,12 +85,23 @@ func PatchStatus(ctx context.Context, c client.Client, siteConfig *v1alpha1.Clus
 	return nil
 }
 
+// FindConditionType finds the conditionType in ClusterDeployment conditions.
 func FindConditionType(
 	conditions []hivev1.ClusterDeploymentCondition,
 	condType hivev1.ClusterDeploymentConditionType,
 ) *hivev1.ClusterDeploymentCondition {
 	for i := range conditions {
 		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// FindStatusCondition finds the conditionType in status conditions.
+func FindStatusCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
 			return &conditions[i]
 		}
 	}


### PR DESCRIPTION
## Summary 
This PR updates the `ClusterInstance` `Provisioned` condition status to reflect the following:
- `Failed` provisioning when the `ClusterDeployment.Status.Conditions` are as follows: `ClusterInstallStopped.Status==True` and `ClusterInstallFailed.Status==True`,
- `Unknown` status when `ClusterDeployment.Spec.Installed==True` but the `ClusterDeployment.Status.Conditions` have not been updated,
- Successful provisioning (`Completed`) is now only set when the `ClusterDeployment.Status.Conditions` are as follows: `ClusterInstallCompleted.Status==True` and `ClusterInstallStopped.Status==True`.

The `ClusterInstance` columns are also updated to reflect the provisioning status:
```sh
$ oc get clusterinstance -A
NAMESPACE   NAME     PROVISIONSTATUS   PROVISIONDETAILS       AGE
cnfdg6      cnfdg6   InProgress        Provisioning cluster   88s
```
### Case: Successful cluster provisioning

Below is an example illustrating a successful cluster provisioning status:
```sh
$ oc get clusterinstance -A
NAMESPACE   NAME     PROVISIONSTATUS   PROVISIONDETAILS         AGE
cnfdg6      cnfdg6   Completed         Provisioning completed   112m
```

The  corresponding `ClusterInstance` status conditions are shown below.
```sh
$ oc get clusterinstance cnfdg6 -n cnfdg6 -o jsonpath='{.status.conditions}' | jq
[
  {
    "lastTransitionTime": "2024-07-26T13:36:08Z",
    "message": "Validation succeeded",
    "reason": "Completed",
    "status": "True",
    "type": "ClusterInstanceValidated"
  },
  {
    "lastTransitionTime": "2024-07-26T13:36:08Z",
    "message": "Rendered templates successfully",
    "reason": "Completed",
    "status": "True",
    "type": "RenderedTemplates"
  },
  {
    "lastTransitionTime": "2024-07-26T13:36:08Z",
    "message": "Rendered templates validation succeeded",
    "reason": "Completed",
    "status": "True",
    "type": "RenderedTemplatesValidated"
  },
  {
    "lastTransitionTime": "2024-07-26T13:36:08Z",
    "message": "Applied site config manifests",
    "reason": "Completed",
    "status": "True",
    "type": "RenderedTemplatesApplied"
  },
  {
    "lastTransitionTime": "2024-07-26T14:08:45Z",
    "message": "Provisioning completed",
    "reason": "Completed",
    "status": "True",
    "type": "Provisioned"
  }
]
```

### Case: ClusterDeployment.Installed=true with stale conditions

Below is an example illustrating the case when `ClusterDeployment.Spec.Installed==True` but the `ClusterDeployment.Status.Conditions` have not been updated:
```sh
$ oc get clusterinstance -A
NAMESPACE   NAME     PROVISIONSTATUS   PROVISIONDETAILS                                                               AGE
cnfdg6      cnfdg6   StaleConditions   ClusterDeployment Spec.Installed=true, but Status.Conditions are not updated   82m
```

Here is the corresponding `ClusterDeployment` object:
```sh
$ oc get clusterdeployment cnfdg6 -n cnfdg6 -oyaml | yq
apiVersion: hive.openshift.io/v1
kind: ClusterDeployment
metadata:
  <redacted>
  name: cnfdg6
  namespace: cnfdg6
spec:
  baseDomain: <redacted>
  clusterInstallRef:
    group: extensions.hive.openshift.io
    kind: AgentClusterInstall
    name: cnfdg6
    version: v1beta1
  clusterMetadata:
    <redacted>
  clusterName: cnfdg6
  controlPlaneConfig:
    servingCertificates: {}
  installed: true
  platform:
    agentBareMetal:
      agentSelector:
        matchLabels:
          cluster-name: cnfdg6
  pullSecretRef:
    name: pull-secret
status:
  cliImage: <redacted>
  conditions:
    - lastProbeTime: "2024-07-25T23:13:42Z"
      lastTransitionTime: "2024-07-25T23:13:42Z"
      message: The installation has not yet started
      reason: InstallationNotStarted
      status: "False"
      type: ClusterInstallCompleted
    - lastProbeTime: "2024-07-25T23:13:42Z"
      lastTransitionTime: "2024-07-25T23:13:42Z"
      message: The cluster is not ready to begin the installation
      reason: ClusterNotReady
      status: "False"
      type: ClusterInstallRequirementsMet
    - lastProbeTime: "2024-07-25T23:13:42Z"
      lastTransitionTime: "2024-07-25T23:13:42Z"
      message: The installation has not failed
      reason: InstallationNotFailed
      status: "False"
      type: ClusterInstallFailed
    - lastProbeTime: "2024-07-25T23:13:42Z"
      lastTransitionTime: "2024-07-25T23:13:42Z"
      message: The installation is waiting to start or in progress
      reason: InstallationNotStopped
      status: "False"
      type: ClusterInstallStopped
    <redacted>
  installVersion: 4.14.9
  installedTimestamp: "2024-07-25T23:13:31Z"
  installerImage: <redacted>
  powerState: Running
```