### PR TITLE
CNF-13987: Add ObservedGeneration to ClusterInstance.Status

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -370,7 +370,6 @@ type ManifestReference struct {
 
 // ClusterInstanceStatus defines the observed state of ClusterInstance
 type ClusterInstanceStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// List of conditions pertaining to actions performed on the ClusterInstance resource.
@@ -388,6 +387,9 @@ type ClusterInstanceStatus struct {
 	// List of manifests that have been rendered along with their status.
 	// +optional
 	ManifestsRendered []ManifestReference `json:"manifestsRendered,omitempty"`
+
+	// Track the observed generation to avoid unnecessary reconciles
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -665,6 +665,10 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              observedGeneration:
+                description: Track the observed generation to avoid unnecessary reconciles
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -665,6 +665,10 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              observedGeneration:
+                description: Track the observed generation to avoid unnecessary reconciles
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -91,7 +91,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	updateCIProvisionedStatus(clusterDeployment, clusterInstance, r.Log)
 	updateCIDeploymentConditions(clusterDeployment, clusterInstance)
-	if updateErr := conditions.PatchStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
+	if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
 		return requeueWithError(updateErr)
 	}
 
@@ -109,13 +109,13 @@ func clusterInstallConditionTypes() []hivev1.ClusterDeploymentConditionType {
 
 func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.ClusterInstance, log logr.Logger) {
 
-	installStopped := conditions.FindConditionType(cd.Status.Conditions,
+	installStopped := conditions.FindCDConditionType(cd.Status.Conditions,
 		hivev1.ClusterInstallStoppedClusterDeploymentCondition)
 
-	installCompleted := conditions.FindConditionType(cd.Status.Conditions,
+	installCompleted := conditions.FindCDConditionType(cd.Status.Conditions,
 		hivev1.ClusterInstallCompletedClusterDeploymentCondition)
 
-	installFailed := conditions.FindConditionType(cd.Status.Conditions,
+	installFailed := conditions.FindCDConditionType(cd.Status.Conditions,
 		hivev1.ClusterInstallFailedClusterDeploymentCondition)
 
 	if installStopped == nil || installCompleted == nil || installFailed == nil {
@@ -169,7 +169,7 @@ func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.Cluste
 func updateCIDeploymentConditions(cd *hivev1.ClusterDeployment, ci *v1alpha1.ClusterInstance) {
 	// Compare ClusterInstance.Status.installConditions to clusterDeployment.Conditions
 	for _, cond := range clusterInstallConditionTypes() {
-		installCond := conditions.FindConditionType(cd.Status.Conditions, cond)
+		installCond := conditions.FindCDConditionType(cd.Status.Conditions, cond)
 		if installCond == nil {
 			// not found, initialize with Unknown fields
 			installCond = &hivev1.ClusterDeploymentCondition{
@@ -182,7 +182,7 @@ func updateCIDeploymentConditions(cd *hivev1.ClusterDeployment, ci *v1alpha1.Clu
 		now := metav1.NewTime(time.Now())
 
 		// Search ClusterInstance status DeploymentConditions for the installCond
-		ciCond := conditions.FindConditionType(ci.Status.DeploymentConditions, installCond.Type)
+		ciCond := conditions.FindCDConditionType(ci.Status.DeploymentConditions, installCond.Type)
 		if ciCond == nil {
 			installCond.LastTransitionTime = now
 			installCond.LastProbeTime = now

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(len(ci.Status.DeploymentConditions)).To(Equal(len(expectedConditions)))
 
 		for _, cond := range expectedConditions {
-			found := conditions.FindConditionType(ci.Status.DeploymentConditions, cond.Type)
+			found := conditions.FindCDConditionType(ci.Status.DeploymentConditions, cond.Type)
 			Expect(found).ToNot(BeNil(), "Condition %s was not found", cond.Type)
 			Expect(found.Status).To(Equal(cond.Status))
 		}
@@ -230,7 +230,7 @@ var _ = Describe("Reconcile", func() {
 			conditions.InProgress,
 			metav1.ConditionTrue,
 			"Provisioning cluster")
-		err := conditions.UpdateStatus(ctx, c, clusterInstance)
+		err := conditions.UpdateCIStatus(ctx, c, clusterInstance)
 		Expect(err).ToNot(HaveOccurred())
 
 		ci := &v1alpha1.ClusterInstance{}
@@ -304,7 +304,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(c.Get(ctx, key, ci)).To(Succeed())
 
 			for _, cond := range deploymentCondition {
-				found := conditions.FindConditionType(ci.Status.DeploymentConditions, cond.Type)
+				found := conditions.FindCDConditionType(ci.Status.DeploymentConditions, cond.Type)
 				Expect(found).ToNot(BeNil(), "Condition %s was not found", cond.Type)
 				Expect(found.Status).To(Equal(cond.Status))
 				Expect(found.Message).To(Equal(cond.Message))

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -65,7 +65,7 @@ func SetStatusCondition(
 	)
 }
 
-func UpdateStatus(ctx context.Context, c client.Client, clusterInstance *v1alpha1.ClusterInstance) error {
+func UpdateCIStatus(ctx context.Context, c client.Client, clusterInstance *v1alpha1.ClusterInstance) error {
 	if err := retry.RetryOnConflictOrRetriable(retry.RetryBackoff30Seconds, func() error {
 		return c.Status().Update(ctx, clusterInstance) //nolint:wrapcheck
 	}); err != nil {
@@ -75,9 +75,14 @@ func UpdateStatus(ctx context.Context, c client.Client, clusterInstance *v1alpha
 	return nil
 }
 
-func PatchStatus(ctx context.Context, c client.Client, siteConfig *v1alpha1.ClusterInstance, patch client.Patch) error {
+func PatchCIStatus(
+	ctx context.Context,
+	c client.Client,
+	clusterInstance *v1alpha1.ClusterInstance,
+	patch client.Patch,
+) error {
 	if err := retry.RetryOnConflictOrRetriable(retry.RetryBackoff30Seconds, func() error {
-		return c.Status().Patch(ctx, siteConfig, patch) //nolint:wrapcheck
+		return c.Status().Patch(ctx, clusterInstance, patch) //nolint:wrapcheck
 	}); err != nil {
 		return fmt.Errorf("failed to update ClusterInstance status: %w", err)
 	}
@@ -85,8 +90,8 @@ func PatchStatus(ctx context.Context, c client.Client, siteConfig *v1alpha1.Clus
 	return nil
 }
 
-// FindConditionType finds the conditionType in ClusterDeployment conditions.
-func FindConditionType(
+// FindCDConditionType finds the conditionType in ClusterDeployment conditions.
+func FindCDConditionType(
 	conditions []hivev1.ClusterDeploymentCondition,
 	condType hivev1.ClusterDeploymentConditionType,
 ) *hivev1.ClusterDeploymentCondition {

--- a/internal/controller/conditions/conditions_test.go
+++ b/internal/controller/conditions/conditions_test.go
@@ -1,0 +1,132 @@
+package conditions
+
+import (
+	"reflect"
+	"testing"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindCDConditionType(t *testing.T) {
+	condition := hivev1.ClusterDeploymentCondition{
+		Type:   hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+		Status: corev1.ConditionTrue,
+	}
+	type args struct {
+		conditions []hivev1.ClusterDeploymentCondition
+		condType   hivev1.ClusterDeploymentConditionType
+	}
+	tests := []struct {
+		name string
+		args args
+		want *hivev1.ClusterDeploymentCondition
+	}{
+		{
+			name: "ClusterDeployment condition exists",
+			args: args{
+				conditions: []hivev1.ClusterDeploymentCondition{
+					{
+						Type: hivev1.ClusterHibernatingCondition,
+					},
+					{
+						Type: hivev1.ClusterHibernatingCondition,
+					},
+					condition,
+					{
+						Type: hivev1.ClusterInstallFailedClusterDeploymentCondition,
+					},
+				},
+				condType: condition.Type,
+			},
+			want: &condition,
+		},
+		{
+			name: "ClusterDeployment condition does not exist",
+			args: args{
+				conditions: []hivev1.ClusterDeploymentCondition{
+					{
+						Type: hivev1.ClusterHibernatingCondition,
+					},
+					{
+						Type: hivev1.ClusterHibernatingCondition,
+					},
+					{
+						Type: hivev1.ClusterInstallFailedClusterDeploymentCondition,
+					},
+				},
+				condType: condition.Type,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindCDConditionType(tt.args.conditions, tt.args.condType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindCDConditionType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindStatusCondition(t *testing.T) {
+	condition := metav1.Condition{
+		Type:   string(ClusterInstanceValidated),
+		Status: metav1.ConditionTrue,
+	}
+	type args struct {
+		conditions    []metav1.Condition
+		conditionType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *metav1.Condition
+	}{
+		{
+			name: "Status condition exists",
+			args: args{
+				conditions: []metav1.Condition{
+					{
+						Type: string(RenderedTemplates),
+					},
+					{
+						Type: string(RenderedTemplatesValidated),
+					},
+					condition,
+					{
+						Type: string(RenderedTemplatesApplied),
+					},
+				},
+				conditionType: condition.Type,
+			},
+			want: &condition,
+		},
+		{
+			name: "Status condition does not exist",
+			args: args{
+				conditions: []metav1.Condition{
+					{
+						Type: string(RenderedTemplates),
+					},
+					{
+						Type: string(RenderedTemplatesValidated),
+					},
+					{
+						Type: string(RenderedTemplatesApplied),
+					},
+				},
+				conditionType: condition.Type,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindStatusCondition(tt.args.conditions, tt.args.conditionType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindStatusCondition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary

This PR introduces an API change to `ClusterInstance.Status`. Specifically, the `ObservedGeneration` field is added. This field is updated to match the `ClusterInstance.ObectMeta.Generation` field each time an update/patch request is made to the `ClusterInstance`.

This change allows for avoiding unnecessary reconciles of the `ClusterInstance` CR which can be triggered when there is no change in the `ClusterInstance` spec fields and the controller pod is restarted (either due to an error or an upgrade).

The PR also introduces cosmetic changes by renaming some of the update/patch/find functions in `conditions.go`.

# Manual verification

The PR was manually tested by provisioning a cluster with the default assisted-installer templates. After provisioning was completed, the controller-manager pod was restarted. There were no additional changes to the `ClusterInstance` CR. Thus, when the pod restarted, the reconcile ended early with the log messages shown below. Note the following log-entry:

```sh
2024-08-15T02:41:43Z	INFO	controllers.ClusterInstance	ObservedGeneration and ObjectMeta.Generation are the same	{"ClusterInstance": {"name":"cnfdg6","namespace":"cnfdg6"}}
```

**Log** 
```sh
$ oc logs -n siteconfig-operator --selector app.kubernetes.io/name=siteconfig-controller -c manager --follow --tail=-1
2024-08-15T02:41:42Z	INFO	setup	created default reference template ConfigMap siteconfig-operator/ai-cluster-templates-v1
2024-08-15T02:41:42Z	INFO	setup	created default reference template ConfigMap siteconfig-operator/ai-node-templates-v1
2024-08-15T02:41:42Z	INFO	setup	created default reference template ConfigMap siteconfig-operator/ibi-cluster-templates-v1
2024-08-15T02:41:42Z	INFO	setup	created default reference template ConfigMap siteconfig-operator/ibi-node-templates-v1
2024-08-15T02:41:42Z	INFO	setup	starting manager
2024-08-15T02:41:42Z	INFO	controller-runtime.metrics	Starting metrics server
2024-08-15T02:41:42Z	INFO	starting server	{"kind": "health probe", "addr": "[::]:8081"}
2024-08-15T02:41:42Z	INFO	controller-runtime.metrics	Serving metrics server	{"bindAddress": "127.0.0.1:8080", "secure": false}
I0815 02:41:42.930947       1 leaderelection.go:250] attempting to acquire leader lease siteconfig-operator/manager.siteconfig.open-cluster-management.io...
I0815 02:41:42.939547       1 leaderelection.go:260] successfully acquired lease siteconfig-operator/manager.siteconfig.open-cluster-management.io
2024-08-15T02:41:42Z	INFO	Starting EventSource	{"controller": "clusterinstance", "controllerGroup": "siteconfig.open-cluster-management.io", "controllerKind": "ClusterInstance", "source": "kind source: *v1alpha1.ClusterInstance"}
2024-08-15T02:41:42Z	INFO	Starting Controller	{"controller": "clusterinstance", "controllerGroup": "siteconfig.open-cluster-management.io", "controllerKind": "ClusterInstance"}
2024-08-15T02:41:42Z	DEBUG	events	siteconfig-controller-manager-58c6b86d8f-b7bgv_ceee782d-300a-454c-ba00-3ac97e958322 became leader	{"type": "Normal", "object": {"kind":"Lease","namespace":"siteconfig-operator","name":"manager.siteconfig.open-cluster-management.io","uid":"ba2c1dac-4831-4700-b384-a2027d864756","apiVersion":"coordination.k8s.io/v1","resourceVersion":"213038180"}, "reason": "LeaderElection"}
2024-08-15T02:41:42Z	INFO	Starting EventSource	{"controller": "clusterDeploymentReconciler", "controllerGroup": "hive.openshift.io", "controllerKind": "ClusterDeployment", "source": "kind source: *v1.ClusterDeployment"}
2024-08-15T02:41:42Z	INFO	Starting EventSource	{"controller": "clusterDeploymentReconciler", "controllerGroup": "hive.openshift.io", "controllerKind": "ClusterDeployment", "source": "kind source: *v1alpha1.ClusterInstance"}
2024-08-15T02:41:42Z	INFO	Starting Controller	{"controller": "clusterDeploymentReconciler", "controllerGroup": "hive.openshift.io", "controllerKind": "ClusterDeployment"}
2024-08-15T02:41:43Z	INFO	Starting workers	{"controller": "clusterinstance", "controllerGroup": "siteconfig.open-cluster-management.io", "controllerKind": "ClusterInstance", "worker count": 1}
2024-08-15T02:41:43Z	INFO	controllers.ClusterInstance	Start reconciling ClusterInstance	{"name": {"name":"cnfdg6","namespace":"cnfdg6"}}
2024-08-15T02:41:43Z	INFO	controllers.ClusterInstance	Loaded ClusterInstance	{"name": {"name":"cnfdg6","namespace":"cnfdg6"}, "version": "213036289"}
2024-08-15T02:41:43Z	INFO	controllers.ClusterInstance	ObservedGeneration and ObjectMeta.Generation are the same	{"ClusterInstance": {"name":"cnfdg6","namespace":"cnfdg6"}}
2024-08-15T02:41:43Z	INFO	controllers.ClusterInstance	Finish reconciling ClusterInstance	{"name": {"name":"cnfdg6","namespace":"cnfdg6"}}
2024-08-15T02:41:43Z	INFO	Starting workers	{"controller": "clusterDeploymentReconciler", "controllerGroup": "hive.openshift.io", "controllerKind": "ClusterDeployment", "worker count": 1}
```

The corresponding `ClusterInstance` CR is shown below.

```yaml
apiVersion: siteconfig.open-cluster-management.io/v1alpha1
kind: ClusterInstance
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      <retracted>
  creationTimestamp: "2024-08-15T01:57:20Z"
  finalizers:
  - clusterinstance.siteconfig.open-cluster-management.io/finalizer
  generation: 3
  name: cnfdg6
  namespace: cnfdg6
  resourceVersion: "213036289"
  uid: 274f3221-9dfe-4eae-8d7f-95790be71621
spec:
...
status:
  clusterDeploymentRef:
    name: cnfdg6
  conditions:
  - lastTransitionTime: "2024-08-15T01:58:25Z"
    message: Validation succeeded
    reason: Completed
    status: "True"
    type: ClusterInstanceValidated
  - lastTransitionTime: "2024-08-15T01:58:25Z"
    message: Rendered templates successfully
    reason: Completed
    status: "True"
    type: RenderedTemplates
  - lastTransitionTime: "2024-08-15T01:58:25Z"
    message: Rendered templates validation succeeded
    reason: Completed
    status: "True"
    type: RenderedTemplatesValidated
  - lastTransitionTime: "2024-08-15T01:58:25Z"
    message: Applied site config manifests
    reason: Completed
    status: "True"
    type: RenderedTemplatesApplied
  - lastTransitionTime: "2024-08-15T02:39:41Z"
    message: Provisioning completed
    reason: Completed
    status: "True"
    type: Provisioned
  deploymentConditions:
  - lastProbeTime: "2024-08-15T02:39:43Z"
    lastTransitionTime: "2024-08-15T01:58:25Z"
    message: The cluster installation stopped
    reason: ClusterInstallationStopped
    status: "True"
    type: ClusterInstallRequirementsMet
  - lastProbeTime: "2024-08-15T02:39:43Z"
    lastTransitionTime: "2024-08-15T01:58:25Z"
    message: 'The installation has completed: Cluster is installed'
    reason: InstallationCompleted
    status: "True"
    type: ClusterInstallCompleted
  - lastProbeTime: "2024-08-15T02:39:43Z"
    lastTransitionTime: "2024-08-15T01:58:25Z"
    message: The installation has not failed
    reason: InstallationNotFailed
    status: "False"
    type: ClusterInstallFailed
  - lastProbeTime: "2024-08-15T02:39:43Z"
    lastTransitionTime: "2024-08-15T01:58:25Z"
    message: The installation has stopped because it completed successfully
    reason: InstallationCompleted
    status: "True"
    type: ClusterInstallStopped
  manifestsRendered:
  - apiGroup: extensions.hive.openshift.io/v1beta1
    kind: AgentClusterInstall
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6
    namespace: cnfdg6
    status: rendered
    syncWave: 1
  - apiGroup: metal3.io/v1alpha1
    kind: BareMetalHost
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6.ptp.eng.rdu2.dc.redhat.com
    namespace: cnfdg6
    status: rendered
    syncWave: 1
  - apiGroup: hive.openshift.io/v1
    kind: ClusterDeployment
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6
    namespace: cnfdg6
    status: rendered
    syncWave: 1
  - apiGroup: agent-install.openshift.io/v1beta1
    kind: InfraEnv
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6
    namespace: cnfdg6
    status: rendered
    syncWave: 1
  - apiGroup: agent-install.openshift.io/v1beta1
    kind: NMStateConfig
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6.ptp.eng.rdu2.dc.redhat.com
    namespace: cnfdg6
    status: rendered
    syncWave: 1
  - apiGroup: agent.open-cluster-management.io/v1
    kind: KlusterletAddonConfig
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6
    namespace: cnfdg6
    status: rendered
    syncWave: 2
  - apiGroup: cluster.open-cluster-management.io/v1
    kind: ManagedCluster
    lastAppliedTime: "2024-08-15T01:58:25Z"
    name: cnfdg6
    status: rendered
    syncWave: 2
  observedGeneration: 3
```