### PR TITLE
CNF-14021: Migrate buildah from 0.1 to 0.2

### DIFF
--- a/.tekton/siteconfig-main-pull-request.yaml
+++ b/.tekton/siteconfig-main-pull-request.yaml
@@ -250,8 +250,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -277,8 +275,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/siteconfig-main-push.yaml
+++ b/.tekton/siteconfig-main-push.yaml
@@ -247,8 +247,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -274,8 +272,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
This commit migrates the konflux-ci buildah from 0.1 to 0.2. The migration steps are outlined here: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md.