### PR TITLE
CNF-14191: Add owned-by label to rendered manifests

### DIFF
--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	cpuPartitioningKey = "cpuPartitioningMode"
+	AnnotationsKey     = "annotations"
+	LabelsKey          = "labels"
 )
 
 type SpecialVars struct {
@@ -223,27 +225,39 @@ func mergeJSONCommonKey(mergeWith, mergeTo, key string) (string, error) {
 	return string(mergedJSON), nil
 }
 
-func appendManifestAnnotations(extraAnnotations map[string]string, manifest map[string]interface{}) map[string]interface{} {
-	if manifest["metadata"] == nil && len(extraAnnotations) > 0 {
+func appendToManifestMetadata(
+	appendData map[string]string,
+	field string,
+	manifest map[string]interface{},
+) map[string]interface{} {
+	if manifest["metadata"] == nil && len(appendData) > 0 {
 		manifest["metadata"] = make(map[string]interface{})
 	}
 	metadata, _ := manifest["metadata"].(map[string]interface{})
 
-	if metadata["annotations"] == nil && len(extraAnnotations) > 0 {
-		metadata["annotations"] = make(map[string]interface{})
+	if metadata[field] == nil && len(appendData) > 0 {
+		metadata[field] = make(map[string]interface{})
 	}
-	annotations, _ := metadata["annotations"].(map[string]interface{})
+	data, _ := metadata[field].(map[string]interface{})
 
-	for key, value := range extraAnnotations {
-		if _, found := annotations[key]; !found {
-			// It's a new annotation, adding
-			if annotations == nil {
-				annotations = make(map[string]interface{})
+	for key, value := range appendData {
+		if _, found := data[key]; !found {
+			// It's a new data-item, adding
+			if data == nil {
+				data = make(map[string]interface{})
 			}
-			annotations[key] = value
+			data[key] = value
 		}
 	}
 	return manifest
+}
+
+func appendManifestAnnotations(extraAnnotations map[string]string, manifest map[string]interface{}) map[string]interface{} {
+	return appendToManifestMetadata(extraAnnotations, AnnotationsKey, manifest)
+}
+
+func appendManifestLabels(extraLabels map[string]string, manifest map[string]interface{}) map[string]interface{} {
+	return appendToManifestMetadata(extraLabels, LabelsKey, manifest)
 }
 
 // toYaml marshals a given field to Yaml

--- a/internal/controller/clusterinstance/helper_test.go
+++ b/internal/controller/clusterinstance/helper_test.go
@@ -313,7 +313,105 @@ func Test_suppressManifest(t *testing.T) {
 	}
 }
 
-func Test_appendManifestAnnotations(t *testing.T) {
+func TestAppendToManifestMetadata(t *testing.T) {
+	type args struct {
+		appendData map[string]string
+		field      string
+		manifest   map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "add new metadata field",
+			args: args{
+				appendData: map[string]string{
+					"foo": "bar",
+				},
+				field: "newField",
+				manifest: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"newField": map[string]interface{}{
+							"test": "ok",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"newField": map[string]interface{}{
+						"test": "ok",
+						"foo":  "bar",
+					},
+				},
+			},
+		},
+
+		{
+			name: "should not modify existing field",
+			args: args{
+				appendData: map[string]string{
+					"test": "foobar",
+				},
+				field: "testField",
+				manifest: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"testField": map[string]interface{}{
+							"test": "ok",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"testField": map[string]interface{}{
+						"test": "ok",
+					},
+				},
+			},
+		},
+
+		{
+			name: "edge-case: create missing metadata map in addition to new field",
+			args: args{
+				appendData: map[string]string{
+					"foo": "bar",
+				},
+				field: "newField",
+				manifest: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"field1": map[string]interface{}{
+							"subField1": "ok",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"newField": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+				"spec": map[string]interface{}{
+					"field1": map[string]interface{}{
+						"subField1": "ok",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendToManifestMetadata(tt.args.appendData, tt.args.field, tt.args.manifest); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendToManifestMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendManifestAnnotations(t *testing.T) {
 	type args struct {
 		extraAnnotations map[string]string
 		manifest         map[string]interface{}
@@ -378,6 +476,73 @@ func Test_appendManifestAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendManifestLabels(t *testing.T) {
+	type args struct {
+		extraLabels map[string]string
+		manifest    map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "add new label",
+			args: args{
+				extraLabels: map[string]string{
+					"foo": "bar",
+				},
+				manifest: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"test": "ok",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"test": "ok",
+						"foo":  "bar",
+					},
+				},
+			},
+		},
+
+		{
+			name: "should not modify existing label",
+			args: args{
+				extraLabels: map[string]string{
+					"test": "foobar",
+				},
+				manifest: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"test": "ok",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"test": "ok",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendManifestLabels(tt.args.extraLabels, tt.args.manifest); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendManifestLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_mergeJSONCommonKey(t *testing.T) {
 	type args struct {
 		mergeWith string

--- a/internal/controller/clusterinstance/template_engine.go
+++ b/internal/controller/clusterinstance/template_engine.go
@@ -35,6 +35,7 @@ import (
 const (
 	WaveAnnotation        = v1alpha1.Group + "/sync-wave"
 	DefaultWaveAnnotation = "0"
+	OwnedByLabel          = v1alpha1.Group + "/owned-by"
 )
 
 type TemplateEngine struct {
@@ -192,6 +193,11 @@ func (te *TemplateEngine) renderManifestFromTemplate(
 			kind, clusterInstance.Name))
 		return nil, nil
 	}
+
+	// Add owned-by label
+	manifest = appendManifestLabels(map[string]string{
+		OwnedByLabel: fmt.Sprintf("%s_%s", clusterInstance.Namespace, clusterInstance.Name),
+	}, manifest)
 
 	if node == nil {
 		// Append cluster-level user provided extra annotations if exist

--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -18,6 +18,7 @@ package clusterinstance
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -290,6 +291,11 @@ var _ = Describe("renderTemplates", func() {
 		Expect(got[0]).To(Equal(map[string]interface{}{
 			"apiVersion": "test.io/v1",
 			"kind":       "TestB",
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+				},
+			},
 			"spec": map[string]interface{}{
 				"name": "site-sno-du-1",
 			},
@@ -321,6 +327,11 @@ var _ = Describe("renderTemplates", func() {
 		Expect(got[0]).To(Equal(map[string]interface{}{
 			"apiVersion": "test.io/v1",
 			"kind":       "TestD",
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+				},
+			},
 			"spec": map[string]interface{}{
 				"name": "node1",
 			},
@@ -358,6 +369,9 @@ var _ = Describe("renderTemplates", func() {
 				"annotations": map[string]interface{}{
 					"extra-annotation-l1": "test",
 					"extra-annotation-l2": "test",
+				},
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
 				},
 			},
 			"spec": map[string]interface{}{
@@ -399,6 +413,9 @@ var _ = Describe("renderTemplates", func() {
 					"extra-node-annotation-l1": "test",
 					"extra-node-annotation-l2": "test",
 				},
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+				},
 			},
 			"spec": map[string]interface{}{
 				"name": "node1",
@@ -438,6 +455,9 @@ var _ = Describe("renderTemplates", func() {
 				"annotations": map[string]interface{}{
 					"extra-node-annotation-l1": "test",
 					"extra-node-annotation-l2": "test",
+				},
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
 				},
 			},
 			"spec": map[string]interface{}{
@@ -592,6 +612,9 @@ var _ = Describe("ProcessTemplates", func() {
 				"annotations": map[string]interface{}{
 					"extra-annotation-l1": "test",
 				},
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+				},
 			},
 			"spec": map[string]interface{}{
 				"name": "site-sno-du-1",
@@ -605,6 +628,9 @@ var _ = Describe("ProcessTemplates", func() {
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
 					"extra-node-annotation-l1": "test",
+				},
+				"labels": map[string]interface{}{
+					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
 				},
 			},
 			"spec": map[string]interface{}{


### PR DESCRIPTION
# Summary
This PR adds the following `owned-by` label to all rendered manifests (both cluster-scoped and namespace-scoped resources):
```yaml
siteconfig.open-cluster-management.io/owned-by: <clusterinstance-namespace>_<clusterinstance-name>
```
This label is required since the SiteConfig operator is namespace-scoped and cannot set the `OwnerRef` on cluster-scoped resources such as Namespaces and ManagedClusters.

This label will be used to handle pruning and deletion of rendered manifests.

# Examples of rendered manifests
Below are examples of rendered manifests with the new label applied by the SiteConfig operator:

## Cluster-scoped resource: ManagedCluster
```yaml
apiVersion: cluster.open-cluster-management.io/v1
kind: ManagedCluster
metadata:
  ...
  labels:
    cluster.open-cluster-management.io/clusterset: default
    common: "true"
    group-du-48core: ""
    hare: krsna
    name: cnfdg6
    siteconfig.open-cluster-management.io/owned-by: cnfdg6_cnfdg6
    sites: cnfdg6
    vendor: auto-detect
  name: cnfdg6
...
```

## Namespace-scoped resource: BareMetalHost
```yaml
apiVersion: metal3.io/v1alpha1
kind: BareMetalHost
metadata:
  ...
  labels:
    infraenvs.agent-install.openshift.io: cnfdg6
    siteconfig.open-cluster-management.io/owned-by: cnfdg6_cnfdg6
  name: cnfdg6.ptp.eng.rdu2.dc.redhat.com
  namespace: cnfdg6
...
```
