### PR TITLE
CNF-13357: Enable extra labels to be configured through ClusterInstance

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -175,6 +175,10 @@ type NodeSpec struct {
 	// +optional
 	ExtraAnnotations map[string]map[string]string `json:"extraAnnotations,omitempty"`
 
+	// Additional node-level labels to be applied to the rendered templates
+	// +optional
+	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
+
 	// SuppressedManifests is a list of node-level manifest names to be excluded from the template rendering process
 	// +optional
 	SuppressedManifests []string `json:"suppressedManifests,omitempty"`
@@ -282,6 +286,10 @@ type ClusterInstanceSpec struct {
 	// Additional cluster-wide annotations to be applied to the rendered templates
 	// +optional
 	ExtraAnnotations map[string]map[string]string `json:"extraAnnotations,omitempty"`
+
+	// Additional cluster-wide labels to be applied to the rendered templates
+	// +optional
+	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
 
 	// ClusterLabels is used to assign labels to the cluster to assist with policy binding.
 	// +optional

--- a/api/v1alpha1/clusterinstance_utils.go
+++ b/api/v1alpha1/clusterinstance_utils.go
@@ -30,3 +30,18 @@ func (node *NodeSpec) ExtraAnnotationSearch(kind string, cluster *ClusterInstanc
 	}
 	return cluster.ExtraAnnotationSearch(kind)
 }
+
+// ExtraLabelSearch Looks up a specific manifest label for this cluster
+func (c *ClusterInstanceSpec) ExtraLabelSearch(kind string) (map[string]string, bool) {
+	labels, ok := c.ExtraLabels[kind]
+	return labels, ok
+}
+
+// ExtraLabelSearch Looks up a specific manifest label for this node, with fallback to cluster
+func (node *NodeSpec) ExtraLabelSearch(kind string, cluster *ClusterInstanceSpec) (map[string]string, bool) {
+	labels, ok := node.ExtraLabels[kind]
+	if ok {
+		return labels, ok
+	}
+	return cluster.ExtraLabelSearch(kind)
+}

--- a/api/v1alpha1/clusterinstance_utils_test.go
+++ b/api/v1alpha1/clusterinstance_utils_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClusterInstanceSpecExtraAnnotationSearch(t *testing.T) {
+	tests := []struct {
+		name             string
+		extraAnnotations map[string]map[string]string
+		kind             string
+		want             map[string]string
+		ok               bool
+	}{
+		{
+			name: "extra annotations for resource defined",
+			extraAnnotations: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra annotations for resource not defined",
+			extraAnnotations: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "NotDefined",
+			want: nil,
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ClusterInstanceSpec{
+				ExtraAnnotations: tt.extraAnnotations,
+			}
+			got, ok := c.ExtraAnnotationSearch(tt.kind)
+			if ok != tt.ok {
+				t.Errorf("ClusterInstanceSpec.ExtraAnnotationSearch() ok = %v, want %v", ok, tt.ok)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ClusterInstanceSpec.ExtraAnnotationSearch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeSpecExtraAnnotationSearch(t *testing.T) {
+	tests := []struct {
+		name                     string
+		specExtraAnnotations     map[string]map[string]string
+		nodeSpecExtraAnnotations map[string]map[string]string
+		kind                     string
+		want                     map[string]string
+		ok                       bool
+	}{
+		{
+			name: "extra annotations for resource defined at cluster-level",
+			specExtraAnnotations: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra annotations for resource defined at node-level",
+			nodeSpecExtraAnnotations: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra annotations for resource not defined at either cluster or node-level",
+			nodeSpecExtraAnnotations: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "NotDefined",
+			want: nil,
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ClusterInstanceSpec{
+				ExtraAnnotations: tt.specExtraAnnotations,
+				Nodes: []NodeSpec{
+					{
+						ExtraAnnotations: tt.nodeSpecExtraAnnotations,
+					},
+				},
+			}
+			got, ok := c.Nodes[0].ExtraAnnotationSearch(tt.kind, c)
+			if ok != tt.ok {
+				t.Errorf("NodeSpec.ExtraAnnotationSearch() ok = %v, want %v", ok, tt.ok)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodeSpec.ExtraAnnotationSearch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterInstanceSpecExtraLabelSearch(t *testing.T) {
+	tests := []struct {
+		name        string
+		extraLabels map[string]map[string]string
+		kind        string
+		want        map[string]string
+		ok          bool
+	}{
+		{
+			name: "extra label for resource defined",
+			extraLabels: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra label for resource not defined",
+			extraLabels: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "NotDefined",
+			want: nil,
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ClusterInstanceSpec{
+				ExtraLabels: tt.extraLabels,
+			}
+			got, ok := c.ExtraLabelSearch(tt.kind)
+			if ok != tt.ok {
+				t.Errorf("ClusterInstanceSpec.ExtraLabelSearch() ok = %v, want %v", ok, tt.ok)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ClusterInstanceSpec.ExtraLabelSearch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeSpecExtraLabelSearch(t *testing.T) {
+	tests := []struct {
+		name                string
+		specExtraLabels     map[string]map[string]string
+		nodeSpecExtraLabels map[string]map[string]string
+		kind                string
+		want                map[string]string
+		ok                  bool
+	}{
+		{
+			name: "extra labels for resource defined at cluster-level",
+			specExtraLabels: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra labels for resource defined at node-level",
+			nodeSpecExtraLabels: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "TestKind",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			ok: true,
+		},
+		{
+			name: "extra labels for resource not defined at either cluster or node-level",
+			nodeSpecExtraLabels: map[string]map[string]string{
+				"TestKind": {
+					"foo": "bar",
+				},
+			},
+			kind: "NotDefined",
+			want: nil,
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ClusterInstanceSpec{
+				ExtraLabels: tt.specExtraLabels,
+				Nodes: []NodeSpec{
+					{
+						ExtraLabels: tt.nodeSpecExtraLabels,
+					},
+				},
+			}
+			got, ok := c.Nodes[0].ExtraLabelSearch(tt.kind, c)
+			if ok != tt.ok {
+				t.Errorf("NodeSpec.ExtraLabelSearch() ok = %v, want %v", ok, tt.ok)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodeSpec.ExtraLabelSearch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -155,6 +155,24 @@ func (in *ClusterInstanceSpec) DeepCopyInto(out *ClusterInstanceSpec) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.ExtraLabels != nil {
+		in, out := &in.ExtraLabels, &out.ExtraLabels
+		*out = make(map[string]map[string]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.ClusterLabels != nil {
 		in, out := &in.ClusterLabels, &out.ClusterLabels
 		*out = make(map[string]string, len(*in))
@@ -351,6 +369,24 @@ func (in *NodeSpec) DeepCopyInto(out *NodeSpec) {
 	}
 	if in.ExtraAnnotations != nil {
 		in, out := &in.ExtraAnnotations, &out.ExtraAnnotations
+		*out = make(map[string]map[string]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
+	if in.ExtraLabels != nil {
+		in, out := &in.ExtraLabels, &out.ExtraLabels
 		*out = make(map[string]map[string]string, len(*in))
 		for key, val := range *in {
 			var outVal map[string]string

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -152,6 +152,14 @@ spec:
                 description: Additional cluster-wide annotations to be applied to
                   the rendered templates
                 type: object
+              extraLabels:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: Additional cluster-wide labels to be applied to the rendered
+                  templates
+                type: object
               extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
                   additional manifests to be applied to the cluster.
@@ -263,6 +271,14 @@ spec:
                         type: object
                       description: Additional node-level annotations to be applied
                         to the rendered templates
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description: Additional node-level labels to be applied to the
+                        rendered templates
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -152,6 +152,14 @@ spec:
                 description: Additional cluster-wide annotations to be applied to
                   the rendered templates
                 type: object
+              extraLabels:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: Additional cluster-wide labels to be applied to the rendered
+                  templates
+                type: object
               extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
                   additional manifests to be applied to the cluster.
@@ -263,6 +271,14 @@ spec:
                         type: object
                       description: Additional node-level annotations to be applied
                         to the rendered templates
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description: Additional node-level labels to be applied to the
+                        rendered templates
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host

--- a/internal/controller/clusterinstance/template_engine.go
+++ b/internal/controller/clusterinstance/template_engine.go
@@ -204,10 +204,20 @@ func (te *TemplateEngine) renderManifestFromTemplate(
 		if extraManifestAnnotations, ok := clusterInstance.Spec.ExtraAnnotationSearch(kind); ok {
 			manifest = appendManifestAnnotations(extraManifestAnnotations, manifest)
 		}
+
+		// Append cluster-level user provided extra labels if exist
+		if extraManifestLabels, ok := clusterInstance.Spec.ExtraLabelSearch(kind); ok {
+			manifest = appendManifestLabels(extraManifestLabels, manifest)
+		}
 	} else {
 		// Append node-level user provided extra annotations if exist
 		if extraManifestAnnotations, ok := node.ExtraAnnotationSearch(kind, &clusterInstance.Spec); ok {
 			manifest = appendManifestAnnotations(extraManifestAnnotations, manifest)
+		}
+
+		// Append node-level user provided extra labels if exist
+		if extraManifestLabels, ok := node.ExtraLabelSearch(kind, &clusterInstance.Spec); ok {
+			manifest = appendManifestLabels(extraManifestLabels, manifest)
 		}
 	}
 


### PR DESCRIPTION
# Summary
This PR enables the user to configure additional labels to both cluster and node manifests through new `ExtraLabels` fields in the `ClusterInstance` API. 

# Examples of rendered manifests
Below are examples of rendered manifests with extra labels applied by the SiteConfig operator for the given `ClusterInstance`:

```yaml
apiVersion: siteconfig.open-cluster-management.io/v1alpha1
kind: ClusterInstance
metadata:
  name: "cnfdg6"
  namespace: "cnfdg6"
spec:
  ...
  clusterName: "cnfdg6"
  extraLabels:
    ManagedCluster:
      common: "true"
      group-du-48core: ""
      sites : "cnfdg6"
      vendor: "auto-detect"
  nodes:
    - hostName: "cnfdg6.ptp.eng.rdu2.dc.redhat.com"
      role: "master"
      extraLabels:
        BareMetalHost:
          "testExtraLabel": "success"
      ...
```

## Cluster-scoped resource: ManagedCluster
```sh
$ oc get managedclusters cnfdg6 -ojsonpath='{.metadata.labels}' | jq
{
  "cluster.open-cluster-management.io/clusterset": "default",
  "common": "true",
  "group-du-48core": "",
  "name": "cnfdg6",
  "siteconfig.open-cluster-management.io/owned-by": "cnfdg6_cnfdg6",
  "sites": "cnfdg6",
  "vendor": "auto-detect"
}
```

## Namespace-scoped resource: BareMetalHost
```sh
$ oc get bmh cnfdg6.ptp.eng.rdu2.dc.redhat.com -n cnfdg6 -ojsonpath='{.metadata.labels}' | jq
{
  "infraenvs.agent-install.openshift.io": "cnfdg6",
  "siteconfig.open-cluster-management.io/owned-by": "cnfdg6_cnfdg6",
  "testExtraLabel": "success"
}
```