### PR TITLE
CNF-14211: Delete manifests owned by the ClusterInstance

### DIFF
--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
 	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,12 +116,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "foobar.group.io",
-						Kind:       "foobar",
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, "not-the-owner"),
 				},
 			},
 			Status: hivev1.ClusterDeploymentStatus{
@@ -154,12 +151,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ClusterInstanceApiVersion,
-						Kind:       v1alpha1.ClusterInstanceKind,
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
 				},
 			},
 		}
@@ -213,12 +206,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ClusterInstanceApiVersion,
-						Kind:       v1alpha1.ClusterInstanceKind,
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
 				},
 			},
 		}
@@ -323,12 +312,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ClusterInstanceApiVersion,
-						Kind:       v1alpha1.ClusterInstanceKind,
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
 				},
 			},
 			Spec: hivev1.ClusterDeploymentSpec{
@@ -393,12 +378,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ClusterInstanceApiVersion,
-						Kind:       v1alpha1.ClusterInstanceKind,
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
 				},
 			},
 			Spec: hivev1.ClusterDeploymentSpec{
@@ -464,12 +445,8 @@ var _ = Describe("Reconcile", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: ClusterInstanceApiVersion,
-						Kind:       v1alpha1.ClusterInstanceKind,
-						Name:       clusterName,
-					},
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
 				},
 			},
 			Spec: hivev1.ClusterDeploymentSpec{

--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -24,6 +24,7 @@ import (
 
 	sprig "github.com/go-task/slim-sprig"
 	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
 	k8syaml "sigs.k8s.io/yaml"
 )
 
@@ -275,4 +276,20 @@ func funcMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	f["toYaml"] = toYaml
 	return f
+}
+
+// GenerateOwnedByLabelValue is a utility function that generates the ownedBy label value
+// using the ClusterInstance namespace and name
+func GenerateOwnedByLabelValue(namespace, name string) string {
+	return fmt.Sprintf("%s_%s", namespace, name)
+}
+
+// GetNamespacedNameFromOwnedByLabel extracts the namespace and name from the ownedBy label value
+func GetNamespacedNameFromOwnedByLabel(ownedByLabel string) (types.NamespacedName, error) {
+	res := strings.Split(ownedByLabel, "_")
+	if len(res) != 2 {
+		return types.NamespacedName{}, fmt.Errorf("expecting single underscore delimiter in %s label value", ownedByLabel)
+	}
+
+	return types.NamespacedName{Namespace: res[0], Name: res[1]}, nil
 }

--- a/internal/controller/clusterinstance/template_engine.go
+++ b/internal/controller/clusterinstance/template_engine.go
@@ -196,7 +196,7 @@ func (te *TemplateEngine) renderManifestFromTemplate(
 
 	// Add owned-by label
 	manifest = appendManifestLabels(map[string]string{
-		OwnedByLabel: fmt.Sprintf("%s_%s", clusterInstance.Namespace, clusterInstance.Name),
+		OwnedByLabel: GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
 	}, manifest)
 
 	if node == nil {

--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -18,7 +18,6 @@ package clusterinstance
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -293,7 +292,7 @@ var _ = Describe("renderTemplates", func() {
 			"kind":       "TestB",
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
-					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel: GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 				},
 			},
 			"spec": map[string]interface{}{
@@ -329,7 +328,7 @@ var _ = Describe("renderTemplates", func() {
 			"kind":       "TestD",
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
-					OwnedByLabel: fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel: GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 				},
 			},
 			"spec": map[string]interface{}{
@@ -377,7 +376,7 @@ var _ = Describe("renderTemplates", func() {
 					"extra-annotation-l2": "test",
 				},
 				"labels": map[string]interface{}{
-					OwnedByLabel:      fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel:      GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 					"extra-labels-l1": "test",
 					"extra-labels-l2": "test",
 				},
@@ -428,7 +427,7 @@ var _ = Describe("renderTemplates", func() {
 					"extra-node-annotation-l2": "test",
 				},
 				"labels": map[string]interface{}{
-					OwnedByLabel:      fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel:      GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 					"extra-labels-l1": "test",
 					"extra-labels-l2": "test",
 				},
@@ -479,7 +478,7 @@ var _ = Describe("renderTemplates", func() {
 					"extra-node-annotation-l2": "test",
 				},
 				"labels": map[string]interface{}{
-					OwnedByLabel:           fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel:           GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 					"extra-node-labels-l1": "test",
 					"extra-node-labels-l2": "test",
 				},
@@ -649,7 +648,7 @@ var _ = Describe("ProcessTemplates", func() {
 					"extra-annotation-l1": "test",
 				},
 				"labels": map[string]interface{}{
-					OwnedByLabel:     fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel:     GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 					"extra-label-l1": "test",
 				},
 			},
@@ -667,7 +666,7 @@ var _ = Describe("ProcessTemplates", func() {
 					"extra-node-annotation-l1": "test",
 				},
 				"labels": map[string]interface{}{
-					OwnedByLabel:          fmt.Sprintf("%s_%s", TestClusterInstance.Namespace, TestClusterInstance.Name),
+					OwnedByLabel:          GenerateOwnedByLabelValue(TestClusterInstance.Namespace, TestClusterInstance.Name),
 					"extra-node-label-l1": "test",
 				},
 			},


### PR DESCRIPTION
# Summary
This PR contains the changes to enable a user to retain resources rendered by the SiteConfig operator upon deletion of the `ClusterInstance` object responsible for its creation. This is accomplished by filtering on rendered resources that contain a matching `ownedBy` label corresponding to the `ClusterInstance` object.
    
This PR also removes the setting of the Kubernetes `OwnerReference` as it only applies to Namespace-scoped resources whereas the previously added `ownedBy` label supports ownership of both Cluster-scoped and Namespace-scoped resources.
