### PR TITLE
CNF-14215: Remove ClusterLabels from ClusterInstance API

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -291,10 +291,6 @@ type ClusterInstanceSpec struct {
 	// +optional
 	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
 
-	// ClusterLabels is used to assign labels to the cluster to assist with policy binding.
-	// +optional
-	ClusterLabels map[string]string `json:"clusterLabels,omitempty"`
-
 	// InstallConfigOverrides is a Json formatted string that provides a generic way of passing
 	// install-config parameters.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -173,13 +173,6 @@ func (in *ClusterInstanceSpec) DeepCopyInto(out *ClusterInstanceSpec) {
 			(*out)[key] = outVal
 		}
 	}
-	if in.ClusterLabels != nil {
-		in, out := &in.ClusterLabels, &out.ClusterLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.DiskEncryption != nil {
 		in, out := &in.DiskEncryption, &out.DiskEncryption
 		*out = new(DiskEncryption)

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -20,11 +20,6 @@ metadata:
             "caBundleRef": {
               "name": "my-bundle-ref"
             },
-            "clusterLabels": {
-              "common": "true",
-              "group-du-sno": "test",
-              "sites": "site-sno-du-1"
-            },
             "clusterName": "site-sno-du-1",
             "clusterNetwork": [
               {
@@ -41,6 +36,13 @@ metadata:
                 }
               ],
               "type": "nbde"
+            },
+            "extraLabels": {
+              "ManagedCluster": {
+                "common": "true",
+                "group-du-sno": "test",
+                "sites": "site-sno-du-1"
+              }
             },
             "extraManifestsRefs": [
               {

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -79,12 +79,6 @@ spec:
                 description: ClusterImageSetNameRef is the name of the ClusterImageSet
                   resource indicating which OpenShift version to deploy.
                 type: string
-              clusterLabels:
-                additionalProperties:
-                  type: string
-                description: ClusterLabels is used to assign labels to the cluster
-                  to assist with policy binding.
-                type: object
               clusterName:
                 description: ClusterName is the name of the cluster.
                 type: string

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -79,12 +79,6 @@ spec:
                 description: ClusterImageSetNameRef is the name of the ClusterImageSet
                   resource indicating which OpenShift version to deploy.
                 type: string
-              clusterLabels:
-                additionalProperties:
-                  type: string
-                description: ClusterLabels is used to assign labels to the cluster
-                  to assist with policy binding.
-                type: object
               clusterName:
                 description: ClusterName is the name of the cluster.
                 type: string

--- a/config/samples/siteconfig_v1alpha1_clusterinstance.yaml
+++ b/config/samples/siteconfig_v1alpha1_clusterinstance.yaml
@@ -18,10 +18,11 @@ spec:
     - name: foobar2
   networkType: OVNKubernetes
   installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
-  clusterLabels:
-    group-du-sno: "test"
-    common: "true"
-    sites : "site-sno-du-1"
+  extraLabels:
+    ManagedCluster:
+      group-du-sno: "test"
+      common: "true"
+      sites : "site-sno-du-1"
   clusterNetwork:
     - cidr: 203.0.113.0/24
       hostPrefix: 23

--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -58,7 +58,7 @@ func TestTemplateEngine_render(t *testing.T) {
 			ClusterNetwork:         []v1alpha1.ClusterNetworkEntry{{CIDR: "203.0.113.0/24", HostPrefix: 23}},
 			ServiceNetwork:         []v1alpha1.ServiceNetworkEntry{{CIDR: "203.0.113.0/24"}},
 			NetworkType:            "OVNKubernetes",
-			ClusterLabels:          map[string]string{"group-du-sno": "test", "common": "true", "sites": "site-sno-du-1"},
+			ExtraLabels:            map[string]map[string]string{"ManagedCluster": {"group-du-sno": "test", "common": "true", "sites": "site-sno-du-1"}},
 			InstallConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}",
 			IgnitionConfigOverride: "igen",
 			DiskEncryption: &v1alpha1.DiskEncryption{

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -160,8 +160,6 @@ const ManagedCluster = `apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   name: "{{ .Spec.ClusterName }}"
-  labels:
-{{ .Spec.ClusterLabels | toYaml | indent 4 }}
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -116,8 +116,6 @@ const ManagedCluster = `apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   name: "{{ .Spec.ClusterName }}"
-  labels:
-{{ .Spec.ClusterLabels | toYaml | indent 4 }}
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
 spec:


### PR DESCRIPTION
This PR removes the `ClusterLabels` field from the `ClusterInstance` API. This field is no longer required since cluster labels should be specified through the recently introduced `ExtraLabels` field (https://github.com/stolostron/siteconfig/pull/75) with the key `ManagedCluster` as shown in the example below.

```yaml
apiVersion: siteconfig.open-cluster-management.io/v1alpha1
kind: ClusterInstance
metadata:
  name: "cnfdg6"
  namespace: "cnfdg6"
spec:
  ...
  clusterName: "cnfdg6"
  extraLabels:
    ManagedCluster:
      common: "true"
      group-du-48core: ""
      sites : "cnfdg6"
      vendor: "auto-detect"
```