### PR TITLE
CNF-14190: Add support for pruning manifests owned by ClusterInstance

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -354,6 +354,7 @@ const (
 	ManifestRenderedFailure   = "failed"
 	ManifestRenderedValidated = "validated"
 	ManifestSuppressed        = "suppressed"
+	ManifestPruneFailure      = "pruning-attempt-failed"
 )
 
 // ManifestReference contains enough information to let you locate the

--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -162,13 +162,27 @@ func buildClusterData(clusterInstance *v1alpha1.ClusterInstance, node *v1alpha1.
 	return
 }
 
-// suppressManifest function returns true if the manifest-rendering should be suppressed
-func suppressManifest(kind string, suppressedManifests []string) bool {
-	if kind == "" || len(suppressedManifests) == 0 {
+// pruneManifest function returns true if the manifest should be pruned (i.e. not rendered)
+func pruneManifest(resource v1alpha1.ResourceRef, pruneList []v1alpha1.ResourceRef) bool {
+	if resource.APIVersion == "" || resource.Kind == "" || len(pruneList) == 0 {
 		return false
 	}
 
-	for _, manifest := range suppressedManifests {
+	for _, p := range pruneList {
+		if resource.APIVersion == p.APIVersion && resource.Kind == p.Kind {
+			return true
+		}
+	}
+	return false
+}
+
+// suppressManifest function returns true if the manifest should be suppressed (i.e. not rendered)
+func suppressManifest(kind string, supressManifestsList []string) bool {
+	if kind == "" || len(supressManifestsList) == 0 {
+		return false
+	}
+
+	for _, manifest := range supressManifestsList {
 		if manifest == kind {
 			return true
 		}
@@ -292,4 +306,11 @@ func GetNamespacedNameFromOwnedByLabel(ownedByLabel string) (types.NamespacedNam
 	}
 
 	return types.NamespacedName{Namespace: res[0], Name: res[1]}, nil
+}
+
+func GetResourceId(name, namespace, kind string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s:%s/%s", kind, namespace, name)
+	}
+	return fmt.Sprintf("%s:%s", kind, name)
 }

--- a/internal/controller/clusterinstance/rendered_object.go
+++ b/internal/controller/clusterinstance/rendered_object.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterinstance
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type action string
+
+const (
+	actionRender   action = "render"
+	actionSuppress action = "suppress"
+	actionPrune    action = "prune"
+)
+
+type RenderedObject struct {
+	object unstructured.Unstructured
+	action action
+}
+
+type syncWaveMap struct {
+	data map[int][]RenderedObject
+}
+
+type RenderedObjectCollection struct {
+	prune, suppress, render syncWaveMap
+}
+
+func (r *RenderedObject) SetObject(manifest map[string]interface{}) error {
+	// Marshal the input manifest to JSON
+	content, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, &r.object)
+}
+
+func (r *RenderedObject) GetObject() unstructured.Unstructured {
+	return r.object
+}
+
+func (r *RenderedObject) GetAPIVersion() string {
+	return r.object.GetAPIVersion()
+}
+
+func (r *RenderedObject) GetKind() string {
+	return r.object.GetKind()
+}
+
+func (r *RenderedObject) GetNamespace() string {
+	return r.object.GetNamespace()
+}
+
+func (r *RenderedObject) GetName() string {
+	return r.object.GetName()
+}
+
+func (r *RenderedObject) GetAnnotations() map[string]string {
+	return r.object.GetAnnotations()
+}
+
+func (r *RenderedObject) GetLabels() map[string]string {
+	return r.object.GetLabels()
+}
+
+func (r *RenderedObject) GetSyncWave() (int, error) {
+	syncWaveStr, ok := r.GetAnnotations()[WaveAnnotation]
+	if !ok {
+		syncWaveStr = DefaultWaveAnnotation
+	}
+
+	return strconv.Atoi(syncWaveStr)
+}
+
+func (r *RenderedObject) GetResourceId() string {
+	return GetResourceId(r.GetName(), r.GetNamespace(), r.GetKind())
+}
+
+func (s *syncWaveMap) getAscendingSyncWaves() []int {
+	syncWaves := maps.Keys(s.data)
+	sort.Ints(syncWaves)
+	return syncWaves
+}
+
+func (s *syncWaveMap) getDescendingSyncWaves() []int {
+	syncWaves := maps.Keys(s.data)
+	sort.Sort(sort.Reverse(sort.IntSlice(syncWaves)))
+	return syncWaves
+}
+
+func (s *syncWaveMap) getSlice(syncWave int) []RenderedObject {
+	if res, ok := s.data[syncWave]; ok {
+		// sort manifests alphabetically (by "kind") to yield more deterministic results
+		sort.Slice(res, func(x, y int) bool {
+			return res[x].GetKind() < res[y].GetKind()
+		})
+		return res
+	}
+	return []RenderedObject{}
+}
+
+func (s *syncWaveMap) add(obj RenderedObject) error {
+	if obj.GetObject().Object == nil {
+		return nil
+	}
+
+	syncWave, err := obj.GetSyncWave()
+	if err != nil {
+		return err
+	}
+
+	if s.data == nil {
+		s.data = make(map[int][]RenderedObject)
+	}
+
+	// check if the key exists in the data
+	if _, ok := s.data[syncWave]; !ok {
+		// if key doesn't exist, initialize the slice
+		s.data[syncWave] = make([]RenderedObject, 0)
+	}
+	// append the object to the collection associated with the syncWave key
+	s.data[syncWave] = append(s.data[syncWave], obj)
+	return nil
+}
+
+func (r *RenderedObjectCollection) AddObject(object RenderedObject) error {
+	var err error
+	switch object.action {
+	case actionRender:
+		err = r.render.add(object)
+	case actionPrune:
+		err = r.prune.add(object)
+	case actionSuppress:
+		err = r.suppress.add(object)
+	}
+
+	return err
+}
+
+func (r *RenderedObjectCollection) AddObjects(objects []RenderedObject) error {
+	for _, object := range objects {
+		if err := r.AddObject(object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *RenderedObjectCollection) GetRenderObjects() []RenderedObject {
+	renderList := make([]RenderedObject, 0)
+	for _, syncWave := range r.render.getAscendingSyncWaves() {
+		renderList = append(renderList, r.render.getSlice(syncWave)...)
+	}
+	return renderList
+}
+
+func (r *RenderedObjectCollection) GetPruneObjects() []RenderedObject {
+	pruneList := make([]RenderedObject, 0)
+	for _, syncWave := range r.prune.getDescendingSyncWaves() {
+		pruneList = append(pruneList, r.prune.getSlice(syncWave)...)
+	}
+	return pruneList
+}
+
+func (r *RenderedObjectCollection) GetSuppressObjects() []RenderedObject {
+	suppressList := make([]RenderedObject, 0)
+	for _, syncWave := range r.suppress.getAscendingSyncWaves() {
+		suppressList = append(suppressList, r.suppress.getSlice(syncWave)...)
+	}
+	return suppressList
+}

--- a/internal/controller/clusterinstance/rendered_object_test.go
+++ b/internal/controller/clusterinstance/rendered_object_test.go
@@ -1,0 +1,508 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterinstance
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRenderedObjectGetAPIVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		input RenderedObject
+		want  string
+	}{
+		{
+			name: "apiVersion is not specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"foo": "bar"}},
+				action: actionRender,
+			},
+			want: "",
+		},
+		{
+			name: "apiVersion is specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "v1"}},
+				action: actionRender,
+			},
+			want: "v1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.GetAPIVersion(); got != tt.want {
+				t.Errorf("RenderedObject.GetAPIVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetKind(t *testing.T) {
+	tests := []struct {
+		name  string
+		input RenderedObject
+		want  string
+	}{
+		{
+			name: "kind is not specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"foo": "bar"}},
+				action: actionRender,
+			},
+			want: "",
+		},
+		{
+			name: "kind is specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"kind": "ConfigMap"}},
+				action: actionRender,
+			},
+			want: "ConfigMap",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.GetKind(); got != tt.want {
+				t.Errorf("RenderedObject.GetKind() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetNamespace(t *testing.T) {
+	tests := []struct {
+		name  string
+		input RenderedObject
+		want  string
+	}{
+		{
+			name: "namespace is not specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"foo": "bar"}},
+				action: actionRender,
+			},
+			want: "",
+		},
+		{
+			name: "namespace is specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"namespace": "default"}}},
+				action: actionRender,
+			},
+			want: "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.GetNamespace(); got != tt.want {
+				t.Errorf("RenderedObject.GetNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input RenderedObject
+		want  string
+	}{
+		{
+			name: "name is not specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"foo": "bar", "metadata": map[string]interface{}{"notName": "test"}}},
+				action: actionRender,
+			},
+			want: "",
+		},
+		{
+			name: "name is specified",
+			input: RenderedObject{
+				object: unstructured.Unstructured{Object: map[string]interface{}{"kind": "ConfigMap", "metadata": map[string]interface{}{"name": "test"}}},
+				action: actionRender,
+			},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.GetName(); got != tt.want {
+				t.Errorf("RenderedObject.GetName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetAnnotations(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]string
+	}{
+		{
+			name:  "metadata is not specified",
+			input: map[string]interface{}{"annotations": "bar", "metadata": map[string]interface{}{"noAnnotations": "test"}},
+			want:  nil,
+		},
+		{
+			name:  "metadata-annotation is specified",
+			input: map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]string{"test": "data"}}},
+			want:  map[string]string{"test": "data"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := RenderedObject{}
+			_ = object.SetObject(tt.input)
+			if got := object.GetAnnotations(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderedObject.GetAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetLabels(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]string
+	}{
+		{
+			name:  "metadata is not specified",
+			input: map[string]interface{}{"labels": "bar", "metadata": map[string]interface{}{"nolabels": "test"}},
+			want:  nil,
+		},
+		{
+			name:  "metadata-labels is specified",
+			input: map[string]interface{}{"metadata": map[string]interface{}{"labels": map[string]string{"test": "data"}}},
+			want:  map[string]string{"test": "data"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := RenderedObject{}
+			_ = object.SetObject(tt.input)
+			if got := object.GetLabels(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderedObject.GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectGetSyncWave(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]interface{}
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "syncWave is not specified",
+			input:   map[string]interface{}{"annotations": "bar", "metadata": map[string]interface{}{"noAnnotations": "test"}},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "syncWave is specified",
+			input:   map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]string{WaveAnnotation: "1"}}},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "non-integer syncWave is specified",
+			input:   map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]string{WaveAnnotation: "one"}}},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := RenderedObject{}
+			_ = object.SetObject(tt.input)
+			got, err := object.GetSyncWave()
+			if tt.wantErr && err == nil {
+				t.Error("RenderedObject.GetSyncWave(), expected err")
+			} else {
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("RenderedObject.GetSyncWave() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
+	render := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v1"}},
+				},
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v2"}},
+				},
+			},
+		},
+	}
+	prune := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v1"}},
+				},
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v2"}},
+				},
+			},
+		},
+	}
+	suppress := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v1"}},
+				},
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v2"}},
+				},
+			},
+		},
+	}
+	type fields struct {
+		prune    syncWaveMap
+		suppress syncWaveMap
+		render   syncWaveMap
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []RenderedObject
+	}{
+		{
+			name: "render objects is empty",
+			fields: fields{
+				prune:    syncWaveMap{},
+				suppress: syncWaveMap{},
+				render:   syncWaveMap{},
+			},
+			want: []RenderedObject{},
+		},
+		{
+			name: "render objects is correctly returned",
+			fields: fields{
+				prune:    prune,
+				suppress: suppress,
+				render:   render,
+			},
+			want: render.getSlice(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RenderedObjectCollection{
+				prune:    tt.fields.prune,
+				suppress: tt.fields.suppress,
+				render:   tt.fields.render,
+			}
+			if got := r.GetRenderObjects(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderedObjectCollection.GetRenderObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
+	render := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v1"}},
+				},
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v2"}},
+				},
+			},
+		},
+	}
+	prune := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v1"}},
+				},
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v2"}},
+				},
+			},
+		},
+	}
+	suppress := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v1"}},
+				},
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v2"}},
+				},
+			},
+		},
+	}
+	type fields struct {
+		prune    syncWaveMap
+		suppress syncWaveMap
+		render   syncWaveMap
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []RenderedObject
+	}{
+		{
+			name: "prune objects is empty",
+			fields: fields{
+				prune:    syncWaveMap{},
+				suppress: syncWaveMap{},
+				render:   syncWaveMap{},
+			},
+			want: []RenderedObject{},
+		},
+		{
+			name: "prune objects is correctly returned",
+			fields: fields{
+				prune:    prune,
+				suppress: suppress,
+				render:   render,
+			},
+			want: prune.getSlice(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RenderedObjectCollection{
+				prune:    tt.fields.prune,
+				suppress: tt.fields.suppress,
+				render:   tt.fields.render,
+			}
+			if got := r.GetPruneObjects(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderedObjectCollection.GetPruneObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
+	render := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v1"}},
+				},
+				{
+					action: actionRender,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "render/v2"}},
+				},
+			},
+		},
+	}
+	prune := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v1"}},
+				},
+				{
+					action: actionPrune,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "prune/v2"}},
+				},
+			},
+		},
+	}
+	suppress := syncWaveMap{
+		data: map[int][]RenderedObject{
+			0: {
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v1"}},
+				},
+				{
+					action: actionSuppress,
+					object: unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "suppress/v2"}},
+				},
+			},
+		},
+	}
+	type fields struct {
+		prune    syncWaveMap
+		suppress syncWaveMap
+		render   syncWaveMap
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []RenderedObject
+	}{
+		{
+			name: "suppress objects is empty",
+			fields: fields{
+				prune:    syncWaveMap{},
+				suppress: syncWaveMap{},
+				render:   syncWaveMap{},
+			},
+			want: []RenderedObject{},
+		},
+		{
+			name: "suppress objects is correctly returned",
+			fields: fields{
+				prune:    prune,
+				suppress: suppress,
+				render:   render,
+			},
+			want: suppress.getSlice(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RenderedObjectCollection{
+				prune:    tt.fields.prune,
+				suppress: tt.fields.suppress,
+				render:   tt.fields.render,
+			}
+			if got := r.GetSuppressObjects(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderedObjectCollection.GetSuppressObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/clusterinstance/test_utils.go
+++ b/internal/controller/clusterinstance/test_utils.go
@@ -334,6 +334,9 @@ func GetMockNetConfig() *NetConfigData {
 func GetMockBasicClusterTemplate(kind string) string {
 	return fmt.Sprintf(`apiVersion: test.io/v1
 kind: %s
+metadata:
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 spec:
   name: "{{ .Spec.ClusterName }}"`, kind)
 }
@@ -341,6 +344,9 @@ spec:
 func GetMockBasicNodeTemplate(kind string) string {
 	return fmt.Sprintf(`apiVersion: test.io/v1
 kind: %s
+metadata:
+  name: "{{ .SpecialVars.CurrentNode.HostName }}"
+  namespace: "{{ .Spec.ClusterName }}"
 spec:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"`, kind)
 }


### PR DESCRIPTION
# Summary

This PR introduces the ability to prune manifests created and owned by the `ClusterInstance`. To implement this, new data structures: `RenderedObject` and `RenderedObjectCollection` have been added. The `RenderedObject` consists of an `object` (as `unstructured.Unstructured`) and an `action` field that defines whether the manifest should be rendered, suppressed, or pruned.

These new structures are used to refactor key logic in both the `template_engine` and `clusterinstance_controller` components.

## Changes:
- Added the `RenderedObject` and `RenderedObjectCollection` types to handle template rendering / suppression / pruning functionality.
- Refactored the `template_engine` and `clusterinstance_controller` files to use the new data structures.
- Updated existing unit tests to cover these changes.
- Added new unit tests to validate the pruning and suppression of manifests.

## Testing:
- Manual end-to-end tests were performed to validate the functionality.
