### PR TITLE
CNF-14561: Expose platform field for AgentClusterInstall in the ClusterInstance API

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -60,8 +60,14 @@ type BmcCredentialsName struct {
 	Name string `json:"name"`
 }
 
-// IronicInspect
+// IronicInspect is used to specify if automatic introspection carried out during registration
+// of BMH is enabled or disabled.
+// +kubebuilder:validation:Enum="";disabled
 type IronicInspect string
+
+// PlatformType is a specific supported infrastructure provider.
+// +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
+type PlatformType string
 
 type TangConfig struct {
 	URL        string `json:"url,omitempty"`
@@ -282,6 +288,10 @@ type ClusterInstanceSpec struct {
 	// +kubebuilder:default:=OVNKubernetes
 	// +optional
 	NetworkType string `json:"networkType,omitempty"`
+
+	// PlatformType is the name for the specific platform upon which to perform the installation.
+	// +optional
+	PlatformType PlatformType `json:"platformType,omitempty"`
 
 	// Additional cluster-wide annotations to be applied to the rendered templates
 	// +optional

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -303,6 +303,9 @@ spec:
                       description: |-
                         IronicInspect is used to specify if automatic introspection carried out during registration of BMH is enabled or
                         disabled
+                      enum:
+                      - ""
+                      - disabled
                       type: string
                     nodeLabels:
                       additionalProperties:
@@ -469,6 +472,17 @@ spec:
                   - templateRefs
                   type: object
                 type: array
+              platformType:
+                description: PlatformType is the name for the specific platform upon
+                  which to perform the installation.
+                enum:
+                - ""
+                - BareMetal
+                - None
+                - VSphere
+                - Nutanix
+                - External
+                type: string
               proxy:
                 description: Proxy defines the proxy settings used for the install
                   config

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -303,6 +303,9 @@ spec:
                       description: |-
                         IronicInspect is used to specify if automatic introspection carried out during registration of BMH is enabled or
                         disabled
+                      enum:
+                      - ""
+                      - disabled
                       type: string
                     nodeLabels:
                       additionalProperties:
@@ -469,6 +472,17 @@ spec:
                   - templateRefs
                   type: object
                 type: array
+              platformType:
+                description: PlatformType is the name for the specific platform upon
+                  which to perform the installation.
+                enum:
+                - ""
+                - BareMetal
+                - None
+                - VSphere
+                - Nutanix
+                - External
+                type: string
               proxy:
                 description: Proxy defines the proxy settings used for the install
                   config

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -63,6 +63,9 @@ spec:
   proxy:
 {{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
+{{ if .Spec.PlatformType }}
+  platformType: "{{ .Spec.PlatformType }}"
+{{ end }}
   sshPublicKey: "{{ .Spec.SSHPublicKey }}"
 {{ if gt (len .Spec.ExtraManifestsRefs) 0 }}
   manifestsConfigMapRefs:


### PR DESCRIPTION
This PR exposes the `platformType` field in the `ClusterInstance` API. This field is consumed by the `AgentClusterInstall` manifest. 

The corresponding ACI template is updated to include the `platformType` field if specified in the `ClusterInstance` CR.