### PR TITLE
ACM-14519: Apply nodeLabel to default BareMetalHost templates

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -179,8 +179,9 @@ metadata:
     siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
 {{ if .SpecialVars.CurrentNode.NodeLabels }}
-    bmac.agent-install.openshift.io.node-label:
-{{ .SpecialVars.CurrentNode.NodeLabels | toYaml | indent 6 }}
+{{ range $key, $value := .SpecialVars.CurrentNode.NodeLabels }}
+    bmac.agent-install.openshift.io.node-label.{{ $key }}: {{ $value | quote}}
+{{ end }}
 {{ end }}
     bmac.agent-install.openshift.io/hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
 {{ if .SpecialVars.CurrentNode.InstallerArgs  }}

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -132,8 +132,9 @@ metadata:
     siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
 {{ if .SpecialVars.CurrentNode.NodeLabels }}
-    bmac.agent-install.openshift.io.node-label:
-{{ .SpecialVars.CurrentNode.NodeLabels | toYaml | indent 6 }}
+{{ range $key, $value := .SpecialVars.CurrentNode.NodeLabels }}
+    bmac.agent-install.openshift.io.node-label.{{ $key }}: {{ $value | quote}}
+{{ end }}
 {{ end }}
     bmac.agent-install.openshift.io/hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
 {{ if .SpecialVars.CurrentNode.InstallerArgs  }}


### PR DESCRIPTION
# Summary
This PR updates the default `BareMetalHost` install templates for Assisted Installer and Image Based Installer to handle the `NodeSpec.NodeLabels` in the same way as the old SiteConfig implementation (https://github.com/openshift-kni/cnf-features-deploy/pull/1485/commits/77cc48c625b786046be6554364cf3eb5b08e729e)

Specifically, the `NodeLabels` are appended to the `BareMetalHost` annotations with the `bmac.agent-install.openshift.io` prefix. 



