### PR TITLE
ACM-14493: Expose the ClusterInstance ConditionType and ConditionReason

### DIFF
--- a/api/v1alpha1/clusterinstance_conditions.go
+++ b/api/v1alpha1/clusterinstance_conditions.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// ClusterInstanceConditionType is a string representing the condition's type
+type ClusterInstanceConditionType string
+
+// String satisfies the conditions.ConditionType interface
+func (t ClusterInstanceConditionType) String() string {
+	return string(t)
+}
+
+// ClusterInstanceConditionReason is a string representing the ClusterInstanceConditionType's reason
+type ClusterInstanceConditionReason string
+
+// String returns the ClusterInstanceConditionReason as a string
+func (r ClusterInstanceConditionReason) String() string {
+	return string(r)
+}
+
+// The following constants define the different types of conditions that will be set
+const (
+	ClusterInstanceValidated   ClusterInstanceConditionType = "ClusterInstanceValidated"
+	RenderedTemplates          ClusterInstanceConditionType = "RenderedTemplates"
+	RenderedTemplatesValidated ClusterInstanceConditionType = "RenderedTemplatesValidated"
+	RenderedTemplatesApplied   ClusterInstanceConditionType = "RenderedTemplatesApplied"
+	ClusterProvisioned         ClusterInstanceConditionType = "Provisioned"
+)
+
+// The following constants define the different reasons that conditions will be set for
+const (
+	Completed       ClusterInstanceConditionReason = "Completed"
+	Failed          ClusterInstanceConditionReason = "Failed"
+	TimedOut        ClusterInstanceConditionReason = "TimedOut"
+	InProgress      ClusterInstanceConditionReason = "InProgress"
+	Unknown         ClusterInstanceConditionReason = "Unknown"
+	StaleConditions ClusterInstanceConditionReason = "StaleConditions"
+)

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -81,12 +81,12 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Initialize ClusterInstance Provisioned status if not found
 	if provisionedStatus := meta.FindStatusCondition(
 		clusterInstance.Status.Conditions,
-		string(conditions.Provisioned),
+		string(v1alpha1.ClusterProvisioned),
 	); provisionedStatus == nil {
 		r.Log.Info("Initializing Provisioned condition", "ClusterInstance", clusterInstance.Name)
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.Provisioned,
-			conditions.Unknown,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Unknown,
 			metav1.ConditionUnknown,
 			"Waiting for provisioning to start")
 	}
@@ -130,8 +130,8 @@ func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.Cluste
 		// Check for successful provisioning
 		if installStopped.Status == corev1.ConditionTrue && installCompleted.Status == corev1.ConditionTrue {
 			conditions.SetStatusCondition(&ci.Status.Conditions,
-				conditions.Provisioned,
-				conditions.Completed,
+				v1alpha1.ClusterProvisioned,
+				v1alpha1.Completed,
 				metav1.ConditionTrue,
 				"Provisioning completed")
 			return
@@ -140,8 +140,8 @@ func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.Cluste
 		//  - either Stopped OR Completed deployment conditions are reflecting a `ConditionFalse` status
 		if installStopped.Status == corev1.ConditionFalse || installCompleted.Status == corev1.ConditionFalse {
 			conditions.SetStatusCondition(&ci.Status.Conditions,
-				conditions.Provisioned,
-				conditions.StaleConditions,
+				v1alpha1.ClusterProvisioned,
+				v1alpha1.StaleConditions,
 				metav1.ConditionUnknown,
 				"ClusterDeployment Spec.Installed=true, but Status.Conditions are not updated")
 			return
@@ -151,8 +151,8 @@ func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.Cluste
 	// Check whether cluster has failed provisioning
 	if installStopped.Status == corev1.ConditionTrue && installFailed.Status == corev1.ConditionTrue {
 		conditions.SetStatusCondition(&ci.Status.Conditions,
-			conditions.Provisioned,
-			conditions.Failed,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Failed,
 			metav1.ConditionFalse,
 			"Provisioning failed")
 		return
@@ -161,8 +161,8 @@ func updateCIProvisionedStatus(cd *hivev1.ClusterDeployment, ci *v1alpha1.Cluste
 	// Check whether provisioning is in-progress
 	if installStopped.Status == corev1.ConditionFalse {
 		conditions.SetStatusCondition(&ci.Status.Conditions,
-			conditions.Provisioned,
-			conditions.InProgress,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.InProgress,
 			metav1.ConditionFalse,
 			"Provisioning cluster")
 	}

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -215,8 +215,8 @@ var _ = Describe("Reconcile", func() {
 
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.Provisioned,
-			conditions.InProgress,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.InProgress,
 			metav1.ConditionTrue,
 			"Provisioning cluster")
 		err := conditions.UpdateCIStatus(ctx, c, clusterInstance)
@@ -359,9 +359,9 @@ var _ = Describe("Reconcile", func() {
 		Expect(c.Get(ctx, key, ci)).To(Succeed())
 
 		expectedCondition := &metav1.Condition{
-			Type:   string(conditions.Provisioned),
+			Type:   string(v1alpha1.ClusterProvisioned),
 			Status: metav1.ConditionTrue,
-			Reason: string(conditions.Completed),
+			Reason: string(v1alpha1.Completed),
 		}
 
 		found := conditions.FindStatusCondition(ci.Status.Conditions, expectedCondition.Type)
@@ -425,9 +425,9 @@ var _ = Describe("Reconcile", func() {
 		Expect(c.Get(ctx, key, ci)).To(Succeed())
 
 		expectedCondition := &metav1.Condition{
-			Type:   string(conditions.Provisioned),
+			Type:   string(v1alpha1.ClusterProvisioned),
 			Status: metav1.ConditionFalse,
-			Reason: string(conditions.Failed),
+			Reason: string(v1alpha1.Failed),
 		}
 
 		found := conditions.FindStatusCondition(ci.Status.Conditions, expectedCondition.Type)
@@ -499,9 +499,9 @@ var _ = Describe("Reconcile", func() {
 		Expect(c.Get(ctx, key, ci)).To(Succeed())
 
 		expectedCondition := &metav1.Condition{
-			Type:   string(conditions.Provisioned),
+			Type:   string(v1alpha1.ClusterProvisioned),
 			Status: metav1.ConditionUnknown,
-			Reason: string(conditions.StaleConditions),
+			Reason: string(v1alpha1.StaleConditions),
 		}
 
 		found := conditions.FindStatusCondition(ci.Status.Conditions, expectedCondition.Type)

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -267,27 +267,27 @@ func (r *ClusterInstanceReconciler) handleValidate(
 
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
 
-	newCond := metav1.Condition{Type: string(conditions.ClusterInstanceValidated)}
+	newCond := metav1.Condition{Type: string(v1alpha1.ClusterInstanceValidated)}
 	r.Log.Info("Starting validation", "ClusterInstance", clusterInstance.Name)
 	err := ci.Validate(ctx, r.Client, clusterInstance)
 	if err != nil {
 		r.Log.Error(err, "ClusterInstance validation failed due to error", "ClusterInstance", clusterInstance.Name)
 
-		newCond.Reason = string(conditions.Failed)
+		newCond.Reason = string(v1alpha1.Failed)
 		newCond.Status = metav1.ConditionFalse
 		newCond.Message = fmt.Sprintf("Validation failed: %s", err.Error())
 
 	} else {
 		r.Log.Info("Validation succeeded", "ClusterInstance", clusterInstance.Name)
 
-		newCond.Reason = string(conditions.Completed)
+		newCond.Reason = string(v1alpha1.Completed)
 		newCond.Status = metav1.ConditionTrue
 		newCond.Message = "Validation succeeded"
 	}
 	r.Log.Info("Finished validation", "ClusterInstance", clusterInstance.Name)
 
-	conditions.SetStatusCondition(&clusterInstance.Status.Conditions, conditions.ConditionType(newCond.Type),
-		conditions.ConditionReason(newCond.Reason), newCond.Status, newCond.Message)
+	conditions.SetStatusCondition(&clusterInstance.Status.Conditions, v1alpha1.ClusterInstanceConditionType(newCond.Type),
+		v1alpha1.ClusterInstanceConditionReason(newCond.Reason), newCond.Status, newCond.Message)
 
 	if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
 		if err == nil {
@@ -312,14 +312,14 @@ func (r *ClusterInstanceReconciler) renderManifests(
 	if err != nil {
 		r.Log.Error(err, "Failed to render manifests", "ClusterInstance", clusterInstance.Name)
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplates,
-			conditions.Failed,
+			v1alpha1.RenderedTemplates,
+			v1alpha1.Failed,
 			metav1.ConditionFalse,
 			fmt.Sprintf("Failed to render templates, err= %s", err))
 	} else {
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplates,
-			conditions.Completed,
+			v1alpha1.RenderedTemplates,
+			v1alpha1.Completed,
 			metav1.ConditionTrue,
 			"Rendered templates successfully")
 	}
@@ -485,14 +485,14 @@ func (r *ClusterInstanceReconciler) validateRenderedManifests(
 		r.Log.Info(msg)
 
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplatesValidated,
-			conditions.Failed,
+			v1alpha1.RenderedTemplatesValidated,
+			v1alpha1.Failed,
 			metav1.ConditionFalse,
 			"Rendered manifests failed dry-run validation")
 	} else {
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplatesValidated,
-			conditions.Completed,
+			v1alpha1.RenderedTemplatesValidated,
+			v1alpha1.Completed,
 			metav1.ConditionTrue,
 			"Rendered templates validation succeeded")
 	}
@@ -530,14 +530,14 @@ func (r *ClusterInstanceReconciler) applyRenderedManifests(
 		r.Log.Info(msg)
 
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplatesApplied,
-			conditions.Failed,
+			v1alpha1.RenderedTemplatesApplied,
+			v1alpha1.Failed,
 			metav1.ConditionFalse,
 			"Failed to apply site config manifests")
 	} else {
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
-			conditions.RenderedTemplatesApplied,
-			conditions.Completed,
+			v1alpha1.RenderedTemplatesApplied,
+			v1alpha1.Completed,
 			metav1.ConditionTrue,
 			"Applied site config manifests")
 	}

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -26,7 +26,6 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stolostron/siteconfig/api/v1alpha1"
 	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
-	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -862,7 +861,7 @@ var _ = Describe("handleValidate", func() {
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		matched := false
 		for _, cond := range clusterInstance.Status.Conditions {
-			if cond.Type == string(conditions.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
+			if cond.Type == string(v1alpha1.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
 				matched = true
 			}
 		}
@@ -883,7 +882,7 @@ var _ = Describe("handleValidate", func() {
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		matched := false
 		for _, cond := range clusterInstance.Status.Conditions {
-			if cond.Type == string(conditions.ClusterInstanceValidated) && cond.Status == metav1.ConditionFalse {
+			if cond.Type == string(v1alpha1.ClusterInstanceValidated) && cond.Status == metav1.ConditionFalse {
 				matched = true
 			}
 		}
@@ -893,8 +892,8 @@ var _ = Describe("handleValidate", func() {
 	It("does not require a reconcile when the ClusterInstanceValidated condition remains unchanged", func() {
 		clusterInstance.Status.Conditions = []metav1.Condition{
 			{
-				Type:    string(conditions.ClusterInstanceValidated),
-				Reason:  string(conditions.Completed),
+				Type:    string(v1alpha1.ClusterInstanceValidated),
+				Reason:  string(v1alpha1.Completed),
 				Status:  metav1.ConditionTrue,
 				Message: "Validation succeeded",
 			},
@@ -911,7 +910,7 @@ var _ = Describe("handleValidate", func() {
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		matched := false
 		for _, cond := range clusterInstance.Status.Conditions {
-			if cond.Type == string(conditions.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
+			if cond.Type == string(v1alpha1.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
 				matched = true
 			}
 		}
@@ -921,8 +920,8 @@ var _ = Describe("handleValidate", func() {
 	It("requires a reconcile when the ClusterInstanceValidated condition has changed", func() {
 		clusterInstance.Status.Conditions = []metav1.Condition{
 			{
-				Type:    string(conditions.ClusterInstanceValidated),
-				Reason:  string(conditions.Failed),
+				Type:    string(v1alpha1.ClusterInstanceValidated),
+				Reason:  string(v1alpha1.Failed),
 				Status:  metav1.ConditionFalse,
 				Message: "Validation failed",
 			},
@@ -939,7 +938,7 @@ var _ = Describe("handleValidate", func() {
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		matched := false
 		for _, cond := range clusterInstance.Status.Conditions {
-			if cond.Type == string(conditions.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
+			if cond.Type == string(v1alpha1.ClusterInstanceValidated) && cond.Status == metav1.ConditionTrue {
 				matched = true
 			}
 		}
@@ -1039,11 +1038,11 @@ spec:
 
 		matched := false
 		for _, cond := range clusterInstance.Status.Conditions {
-			if cond.Type == string(conditions.RenderedTemplates) && cond.Status == metav1.ConditionFalse {
+			if cond.Type == string(v1alpha1.RenderedTemplates) && cond.Status == metav1.ConditionFalse {
 				matched = true
 			}
 		}
-		Expect(matched).To(Equal(true), "Condition %s was not found", conditions.RenderedTemplates)
+		Expect(matched).To(Equal(true), "Condition %s was not found", v1alpha1.RenderedTemplates)
 	})
 
 	It("successfully renders templates and updates the status correctly", func() {
@@ -1097,23 +1096,23 @@ spec:
 
 		expectedConditions := []metav1.Condition{
 			{
-				Type:   string(conditions.ClusterInstanceValidated),
-				Reason: string(conditions.Completed),
+				Type:   string(v1alpha1.ClusterInstanceValidated),
+				Reason: string(v1alpha1.Completed),
 				Status: metav1.ConditionTrue,
 			},
 			{
-				Type:   string(conditions.RenderedTemplates),
-				Reason: string(conditions.Completed),
+				Type:   string(v1alpha1.RenderedTemplates),
+				Reason: string(v1alpha1.Completed),
 				Status: metav1.ConditionTrue,
 			},
 			{
-				Type:   string(conditions.RenderedTemplatesValidated),
-				Reason: string(conditions.Completed),
+				Type:   string(v1alpha1.RenderedTemplatesValidated),
+				Reason: string(v1alpha1.Completed),
 				Status: metav1.ConditionTrue,
 			},
 			{
-				Type:   string(conditions.RenderedTemplatesApplied),
-				Reason: string(conditions.Completed),
+				Type:   string(v1alpha1.RenderedTemplatesApplied),
+				Reason: string(v1alpha1.Completed),
 				Status: metav1.ConditionTrue,
 			},
 		}

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -12,37 +12,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ConditionType is a string representing the condition's type
-type ConditionType string
-
-// The following constants define the different types of conditions that will be set
-const (
-	ClusterInstanceValidated   ConditionType = "ClusterInstanceValidated"
-	RenderedTemplates          ConditionType = "RenderedTemplates"
-	RenderedTemplatesValidated ConditionType = "RenderedTemplatesValidated"
-	RenderedTemplatesApplied   ConditionType = "RenderedTemplatesApplied"
-	Provisioned                ConditionType = "Provisioned"
-)
-
-// ConditionReason is a string representing the condition's reason
-type ConditionReason string
-
-// The following constants define the different reasons that conditions will be set for
-const (
-	Completed       ConditionReason = "Completed"
-	Failed          ConditionReason = "Failed"
-	TimedOut        ConditionReason = "TimedOut"
-	InProgress      ConditionReason = "InProgress"
-	Unknown         ConditionReason = "Unknown"
-	StaleConditions ConditionReason = "StaleConditions"
-)
-
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and
 // converts them to strings
 func SetStatusCondition(
 	existingConditions *[]metav1.Condition,
-	conditionType ConditionType,
-	conditionReason ConditionReason,
+	conditionType v1alpha1.ClusterInstanceConditionType,
+	conditionReason v1alpha1.ClusterInstanceConditionReason,
 	conditionStatus metav1.ConditionStatus,
 	message string,
 ) {

--- a/internal/controller/conditions/conditions_test.go
+++ b/internal/controller/conditions/conditions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -72,7 +73,7 @@ func TestFindCDConditionType(t *testing.T) {
 
 func TestFindStatusCondition(t *testing.T) {
 	condition := metav1.Condition{
-		Type:   string(ClusterInstanceValidated),
+		Type:   string(v1alpha1.ClusterInstanceValidated),
 		Status: metav1.ConditionTrue,
 	}
 	type args struct {
@@ -89,14 +90,14 @@ func TestFindStatusCondition(t *testing.T) {
 			args: args{
 				conditions: []metav1.Condition{
 					{
-						Type: string(RenderedTemplates),
+						Type: string(v1alpha1.RenderedTemplates),
 					},
 					{
-						Type: string(RenderedTemplatesValidated),
+						Type: string(v1alpha1.RenderedTemplatesValidated),
 					},
 					condition,
 					{
-						Type: string(RenderedTemplatesApplied),
+						Type: string(v1alpha1.RenderedTemplatesApplied),
 					},
 				},
 				conditionType: condition.Type,
@@ -108,13 +109,13 @@ func TestFindStatusCondition(t *testing.T) {
 			args: args{
 				conditions: []metav1.Condition{
 					{
-						Type: string(RenderedTemplates),
+						Type: string(v1alpha1.RenderedTemplates),
 					},
 					{
-						Type: string(RenderedTemplatesValidated),
+						Type: string(v1alpha1.RenderedTemplatesValidated),
 					},
 					{
-						Type: string(RenderedTemplatesApplied),
+						Type: string(v1alpha1.RenderedTemplatesApplied),
 					},
 				},
 				conditionType: condition.Type,


### PR DESCRIPTION
# Summary

This PR exposes the `ClusterInstance` `ConditionType` and `ConditionReason` so that it may be consumed by other operators.