### PR TITLE
ACM-13620: Add FIPS readiness support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY internal/ internal/
 
 # Build the binaries
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/manager cmd/main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o build/manager cmd/main.go
 
 #####################################################################################################
 # Build the controller image


### PR DESCRIPTION
# Summary

This PR updates the Dockerfile to add FIPS readiness support. Specifically, the `CGO_ENABLED` flag is enabled.

## Container FIPS readiness check
A custom image was built with the above changes resulting in the following scan using the [check-payload](https://github.com/openshift/check-payload) tool.

```sh
$ sudo ./check-payload scan operator --spec quay.io/sakhoury/siteconfig-operator:2.12.0
I0930 14:51:57.195002       1 main.go:315] using embedded config
I0930 14:51:57.195584       1 types_config.go:12] using config &{Components:[] FailOnWarnings:false FilterFile: FromFile: FromURL: InsecurePull:true Limit:-1 ContainerImageComponent: ContainerImage: OutputFile: OutputFormat:table Parallelism:5 Java:false PrintExceptions:false PullSecret: TimeLimit:1h0m0s Verbose:false UseRPMScan:false ConfigFile:{FilterFiles:[] FilterDirs:[/lib/firmware /lib/modules /usr/lib/.build-id /usr/lib/firmware /usr/lib/grub /usr/lib/modules /usr/share/app-info /usr/share/doc /usr/share/fonts /usr/share/icons /usr/share/openshift /usr/src/plugins /rootfs /sysroot] FilterImages:[] JavaDisabledAlgorithms:[DH keySize < 2048 TLSv1.1 TLSv1 SSLv3 SSLv2 TLS_RSA_WITH_AES_256_CBC_SHA256 TLS_RSA_WITH_AES_256_CBC_SHA TLS_RSA_WITH_AES_128_CBC_SHA256 TLS_RSA_WITH_AES_128_CBC_SHA TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_128_GCM_SHA256 DHE_DSS RSA_EXPORT DHE_DSS_EXPORT DHE_RSA_EXPORT DH_DSS_EXPORT DH_RSA_EXPORT DH_anon ECDH_anon DH_RSA DH_DSS ECDH 3DES_EDE_CBC DES_CBC RC4_40 RC4_128 DES40_CBC RC2 HmacMD5] CertifiedDistributions:[] PayloadIgnores:map[openshift-enterprise-pod-container:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/bin/pod] Dirs:[] Tags:[]}]} openshift-istio-cni-rhel8-container:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrLibcryptoSoMissing Files:[/opt/cni/bin/istio-cni-rhel9] Dirs:[] Tags:[]}]} openshift-virtualization-cdi-container:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoNotCgoEnabled Files:[/usr/bin/cdi-containerimage-server] Dirs:[] Tags:[]}]} openshift-virtualization-virt-container:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/bin/container-disk] Dirs:[] Tags:[]}]}] TagIgnores:map[] RPMIgnores:map[containernetworking-plugins:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[] Dirs:[/usr/libexec/cni] Tags:[]}]} cri-o:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/bin/crio /usr/bin/crio-status] Dirs:[] Tags:[]} {Error:ErrNotDynLinked Files:[/usr/bin/pinns] Dirs:[] Tags:[]}]} cri-tools:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/bin/crictl] Dirs:[] Tags:[]}]} glibc:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/sbin/ldconfig /sbin/ldconfig] Dirs:[] Tags:[]}]} glibc-common:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/sbin/build-locale-archive] Dirs:[] Tags:[]}]} ignition:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/lib/dracut/modules.d/30ignition/ignition] Dirs:[] Tags:[]}]} podman:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/bin/podman /usr/libexec/podman/quadlet /usr/libexec/podman/rootlessport] Dirs:[] Tags:[]} {Error:ErrNotDynLinked Files:[/usr/libexec/podman/catatonit] Dirs:[] Tags:[]}]} podman-catatonit:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/libexec/catatonit/catatonit] Dirs:[] Tags:[]}]} runc:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/bin/runc] Dirs:[] Tags:[]} {Error:ErrGoInvalidTag Files:[/usr/bin/runc] Dirs:[] Tags:[]} {Error:ErrGoMissingSymbols Files:[/usr/bin/runc] Dirs:[] Tags:[]} {Error:ErrLibcryptoMissing Files:[/usr/bin/runc] Dirs:[] Tags:[]}]} skopeo:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrGoMissingTag Files:[/usr/bin/skopeo] Dirs:[] Tags:[]}]} tini:{FilterFiles:[] FilterDirs:[] ErrIgnores:[{Error:ErrNotDynLinked Files:[/usr/bin/tini-static] Dirs:[] Tags:[]}]}] ErrIgnores:[]}}
I0930 14:51:57.195682       1 main.go:103] "scan" version="0.3.1-183-g0032898c-dirty"
I0930 14:52:00.705351       1 scan.go:460] "scanning warning" image="quay.io/sakhoury/siteconfig-operator:2.12.0" path="/usr/local/bin/manager" error="go binary has no build tags set (should have strictfipsruntime)" component="ubi9-minimal-container" tag="" rpm="" status="warning"
---- Warning Report
+------------------------+------------------------+-----------------------------------------------------------------+---------------------------------------------+
| OPERATOR NAME          | EXECUTABLE NAME        | STATUS                                                          | IMAGE                                       |
+------------------------+------------------------+-----------------------------------------------------------------+---------------------------------------------+
| ubi9-minimal-container | /usr/local/bin/manager | go binary has no build tags set (should have strictfipsruntime) | quay.io/sakhoury/siteconfig-operator:2.12.0 |
+------------------------+------------------------+-----------------------------------------------------------------+---------------------------------------------+
---- Successful run with warnings
```