### PR TITLE
ACM-14649: Pluralize the extra manifests field name in the IBI templates

### DIFF
--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -34,7 +34,7 @@ spec:
 {{ .Spec.CaBundleRef | toYaml | indent 4 }}
 {{ end }}
 {{ if gt (len .Spec.ExtraManifestsRefs) 0 }}
-  extraManifestsRef:
+  extraManifestsRefs:
 {{ .Spec.ExtraManifestsRefs | toYaml | indent 4 }}
 {{ end }}
   bareMetalHostRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-14649

Merge after https://github.com/openshift/image-based-install-operator/pull/125