### PR TITLE
CNF-14769: Refactor logging to use zap logger directly with contextual information

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -41,9 +40,9 @@ func TestMain(t *testing.T) {
 var _ = Describe("initConfigMapTemplates", func() {
 	var (
 		c                   client.Client
-		ctx                             = context.Background()
-		log                 logr.Logger = ctrl.Log.WithName("controllers").WithName("SiteConfig")
-		SiteConfigNamespace             = getSiteConfigNamespace(log)
+		ctx                 = context.Background()
+		testLogger          = zap.NewNop().Named("Test")
+		SiteConfigNamespace = getSiteConfigNamespace(testLogger)
 	)
 
 	BeforeEach(func() {
@@ -60,7 +59,7 @@ var _ = Describe("initConfigMapTemplates", func() {
 	})
 
 	It("should create default assisted install and image based install cluster templates on initialization", func() {
-		err := initConfigMapTemplates(ctx, c, log)
+		err := initConfigMapTemplates(ctx, c, testLogger)
 		Expect(err).ToNot(HaveOccurred())
 
 		cm := &corev1.ConfigMap{}
@@ -79,7 +78,7 @@ var _ = Describe("initConfigMapTemplates", func() {
 	})
 
 	It("should create default assisted install and image based install node templates on initialization", func() {
-		err := initConfigMapTemplates(ctx, c, log)
+		err := initConfigMapTemplates(ctx, c, testLogger)
 		Expect(err).ToNot(HaveOccurred())
 
 		cm := &corev1.ConfigMap{}
@@ -113,7 +112,7 @@ var _ = Describe("initConfigMapTemplates", func() {
 			Namespace: SiteConfigNamespace,
 		}
 
-		err := initConfigMapTemplates(ctx, c, log)
+		err := initConfigMapTemplates(ctx, c, testLogger)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify that the existing ConfigMap is not over-written

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/stolostron/siteconfig
 go 1.21
 
 require (
-	github.com/go-logr/logr v1.4.1
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
 	github.com/openshift/assisted-service/models v0.0.0 // indirect
@@ -21,6 +21,7 @@ require (
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/openshift/assisted-service/api v0.0.0-20240405132132-484ec5c683c6
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	open-cluster-management.io/api v0.13.0
 	sigs.k8s.io/yaml v1.3.0
@@ -77,7 +78,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stolostron/siteconfig/api/v1alpha1"
 	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
 	"github.com/stolostron/siteconfig/internal/controller/conditions"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,6 +50,7 @@ var _ = Describe("Reconcile", func() {
 		c                client.Client
 		r                *ClusterDeploymentReconciler
 		ctx              = context.Background()
+		testLogger       = zap.NewNop().Named("Test")
 		clusterName      = "test-cluster"
 		clusterNamespace = "test-namespace"
 		clusterInstance  *v1alpha1.ClusterInstance
@@ -58,7 +60,6 @@ var _ = Describe("Reconcile", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		testLogger := ctrl.Log.WithName("ClusterDeploymentReconciler")
 		r = &ClusterDeploymentReconciler{
 			Client: c,
 			Scheme: scheme.Scheme,


### PR DESCRIPTION
# Summary

This PR replaces the current logger `go-logr` with the zap logger with added contextual information about the `ClusterInstance` or `ClusterDeployment` objects as well as useful function names (where relevant to aid debugging). Furthermore, some of the log messages have been converted from `Info` to `Debug`.

Resolves: [CNF-14769](https://issues.redhat.com/browse/CNF-14769)