### PR TITLE
ACM-14672: Set externallyProvisioned in IBI BMH template

### DIFF
--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -153,6 +153,7 @@ spec:
   bootMACAddress: "{{ .SpecialVars.CurrentNode.BootMACAddress }}"
   automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
   online: true
+  externallyProvisioned: true
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:
 {{ .SpecialVars.CurrentNode.RootDeviceHints | toYaml | indent 4 }}


### PR DESCRIPTION
# Summary

This PR sets the `externallyProvisioned: true` BMH spec field for the IBI template.

Resolves: https://issues.redhat.com/browse/ACM-14672