### PR TITLE
ACM-14164: Add preprovisioningNetworkDataName guard to IBI BMH template

### DIFF
--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -158,7 +158,9 @@ spec:
   rootDeviceHints:
 {{ .SpecialVars.CurrentNode.RootDeviceHints | toYaml | indent 4 }}
 {{ end }}
-  preprovisioningNetworkDataName: {{ .SpecialVars.CurrentNode.HostName }}`
+{{ if .SpecialVars.CurrentNode.NodeNetwork }}
+  preprovisioningNetworkDataName: {{ .SpecialVars.CurrentNode.HostName }}
+{{ end }}`
 
 func GetClusterTemplates() map[string]string {
 	data := make(map[string]string)


### PR DESCRIPTION
# Summary

This PR introduces a `preprovisioningNetworkDataName` guard in the IBI-BMH template to support deploying a DHCP spoke cluster.

Resolves [ACM-14164](https://issues.redhat.com/browse/ACM-14164)