### PR TITLE
ACM-14738: Add observability labels to ManagedCluster template for AI and IBI

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -130,9 +130,6 @@ metadata:
 spec:
   clusterName: "{{ .Spec.ClusterName }}"
   clusterNamespace: "{{ .Spec.ClusterName }}"
-  clusterLabels:
-    cloud: auto-detect
-    vendor: auto-detect
   applicationManager:
     enabled: false
   certPolicyController:
@@ -167,6 +164,9 @@ metadata:
   name: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
+  labels:
+    cloud: auto-detect
+    vendor: auto-detect
 spec:
   hubAcceptsClient: true`
 

--- a/internal/templates/image-based-install/template.go
+++ b/internal/templates/image-based-install/template.go
@@ -100,9 +100,6 @@ metadata:
 spec:
   clusterName: "{{ .Spec.ClusterName }}"
   clusterNamespace: "{{ .Spec.ClusterName }}"
-  clusterLabels:
-    cloud: auto-detect
-    vendor: auto-detect
   applicationManager:
     enabled: true
   certPolicyController:
@@ -120,6 +117,9 @@ metadata:
   name: "{{ .Spec.ClusterName }}"
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "2"
+  labels:
+    cloud: auto-detect
+    vendor: auto-detect
 spec:
   hubAcceptsClient: true`
 


### PR DESCRIPTION
# Summary

This PR removes the `cloud` and `vendor` labels from the KlusterletAddonConfig template and adds them to the ManagedCluster template for both Assisted Installer and Image Based Installer to support enabling ACM observability without user intervention (reference: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#preparing-cluster-import).

Resolves: [ACM-14738](https://issues.redhat.com/browse/ACM-14738)