### PR TITLE
Remove logger object from TemplateEngine

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -149,7 +149,7 @@ func main() {
 		Scheme:     mgr.GetScheme(),
 		Recorder:   mgr.GetEventRecorderFor("ClusterInstanceController"),
 		Log:        clusterInstanceLogger,
-		TmplEngine: ci.NewTemplateEngine(clusterInstanceLogger.Named("TemplateEngine")),
+		TmplEngine: ci.NewTemplateEngine(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error("Unable to create controller",
 			zap.String("controller", "ClusterInstance"),

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -315,8 +315,7 @@ func (r *ClusterInstanceReconciler) renderManifests(
 	log.Info("Starting to render templates")
 
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
-	r.TmplEngine.SetLogger(log.Named("TemplateEngine"))
-	renderedObjects, err := r.TmplEngine.ProcessTemplates(ctx, r.Client, *clusterInstance)
+	renderedObjects, err := r.TmplEngine.ProcessTemplates(ctx, r.Client, log.Named("TemplateEngine"), *clusterInstance)
 	if err != nil {
 		log.Error("Failed to render templates", zap.Error(err))
 		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -99,12 +99,12 @@ var _ = Describe("Reconcile", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		Expect(c.Create(ctx, testParams.GeneratePullSecret())).To(Succeed())
@@ -212,12 +212,11 @@ var _ = Describe("handleFinalizer", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			Client: c,
+			Scheme: scheme.Scheme,
+			Log:    testLogger,
 		}
 	})
 
@@ -544,12 +543,12 @@ var _ = Describe("pruneManifests", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		annotations := map[string]string{
@@ -834,12 +833,12 @@ var _ = Describe("handleValidate", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		ci.SetupTestResources(ctx, c, testParams)
@@ -973,12 +972,12 @@ var _ = Describe("handleRenderTemplates", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		ci.SetupTestResources(ctx, c, testParams)
@@ -1152,12 +1151,12 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
 		testLogger := zap.NewNop().Named("Test")
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r := &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		clusterInstance := &v1alpha1.ClusterInstance{
@@ -1531,12 +1530,12 @@ var _ = Describe("executeRenderedManifests", func() {
 			WithScheme(scheme.Scheme).
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
-		tmplEngine := ci.NewTemplateEngine(testLogger)
+
 		r = &ClusterInstanceReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			TmplEngine: ci.NewTemplateEngine(),
 		}
 
 		clusterInstance = &v1alpha1.ClusterInstance{


### PR DESCRIPTION
# Summary

This PR removes the logger object from the TemplateEngine struct and passes it instead as a function argument. This is done to make the TemplateEngine thread-safe and to support handling multiple concurrent reconciles.
