### PR TITLE
ACM-13268: Apply ACM disaster recovery backup label to custom install templates

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,20 +50,13 @@ import (
 
 	"github.com/stolostron/siteconfig/api/v1alpha1"
 	"github.com/stolostron/siteconfig/internal/controller"
-	assistedinstaller "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
-	imagebasedinstall "github.com/stolostron/siteconfig/internal/templates/image-based-install"
+	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
+	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
 	//+kubebuilder:scaffold:imports
 )
 
 var (
 	scheme = runtime.NewScheme()
-)
-
-const (
-	AssistedInstallerClusterTemplates = "ai-cluster-templates-v1"
-	AssistedInstallerNodeTemplates    = "ai-node-templates-v1"
-	ImageBasedInstallClusterTemplates = "ibi-cluster-templates-v1"
-	ImageBasedInstallNodeTemplates    = "ibi-node-templates-v1"
 )
 
 func init() {
@@ -196,10 +189,10 @@ func getSiteConfigNamespace(log *zap.Logger) string {
 
 func initConfigMapTemplates(ctx context.Context, c client.Client, log *zap.Logger) error {
 	templates := make(map[string]map[string]string, 4)
-	templates[AssistedInstallerClusterTemplates] = assistedinstaller.GetClusterTemplates()
-	templates[AssistedInstallerNodeTemplates] = assistedinstaller.GetNodeTemplates()
-	templates[ImageBasedInstallClusterTemplates] = imagebasedinstall.GetClusterTemplates()
-	templates[ImageBasedInstallNodeTemplates] = imagebasedinstall.GetNodeTemplates()
+	templates[ai_templates.ClusterLevelInstallTemplates] = ai_templates.GetClusterTemplates()
+	templates[ai_templates.NodeLevelInstallTemplates] = ai_templates.GetNodeTemplates()
+	templates[ibi_templates.ClusterLevelInstallTemplates] = ibi_templates.GetClusterTemplates()
+	templates[ibi_templates.NodeLevelInstallTemplates] = ibi_templates.GetNodeTemplates()
 
 	siteConfigNamespace := getSiteConfigNamespace(log)
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -29,6 +29,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
+	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
 )
 
 func TestMain(t *testing.T) {
@@ -64,14 +66,14 @@ var _ = Describe("initConfigMapTemplates", func() {
 
 		cm := &corev1.ConfigMap{}
 		key := types.NamespacedName{
-			Name:      AssistedInstallerClusterTemplates,
+			Name:      ai_templates.ClusterLevelInstallTemplates,
 			Namespace: SiteConfigNamespace,
 		}
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
 
 		cm = &corev1.ConfigMap{}
 		key = types.NamespacedName{
-			Name:      ImageBasedInstallClusterTemplates,
+			Name:      ibi_templates.ClusterLevelInstallTemplates,
 			Namespace: SiteConfigNamespace,
 		}
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
@@ -83,14 +85,14 @@ var _ = Describe("initConfigMapTemplates", func() {
 
 		cm := &corev1.ConfigMap{}
 		key := types.NamespacedName{
-			Name:      AssistedInstallerNodeTemplates,
+			Name:      ai_templates.NodeLevelInstallTemplates,
 			Namespace: SiteConfigNamespace,
 		}
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
 
 		cm = &corev1.ConfigMap{}
 		key = types.NamespacedName{
-			Name:      ImageBasedInstallNodeTemplates,
+			Name:      ibi_templates.NodeLevelInstallTemplates,
 			Namespace: SiteConfigNamespace,
 		}
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
@@ -100,7 +102,7 @@ var _ = Describe("initConfigMapTemplates", func() {
 		data := map[string]string{"test": "foobar"}
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      AssistedInstallerNodeTemplates,
+				Name:      ai_templates.NodeLevelInstallTemplates,
 				Namespace: SiteConfigNamespace,
 			},
 			Data: data,
@@ -108,7 +110,7 @@ var _ = Describe("initConfigMapTemplates", func() {
 		Expect(c.Create(ctx, cm)).To(Succeed())
 
 		key := types.NamespacedName{
-			Name:      AssistedInstallerNodeTemplates,
+			Name:      ai_templates.NodeLevelInstallTemplates,
 			Namespace: SiteConfigNamespace,
 		}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,18 +29,18 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
-	siteconfigv1alpha1 "github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-
+	t.Setenv("POD_NAMESPACE", "siteconfig-operator")
 	RunSpecs(t, "ControllerSuite")
 }
 
 var _ = BeforeSuite(func() {
-	Expect(siteconfigv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(hivev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(v1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -15,6 +15,12 @@ See the License for the specific language governing permissions and
 
 package assistedinstaller
 
+// Default assisted installer install template names
+const (
+	ClusterLevelInstallTemplates = "ai-cluster-templates-v1"
+	NodeLevelInstallTemplates    = "ai-node-templates-v1"
+)
+
 const AgentClusterInstall = `apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
 metadata:

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -13,7 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 */
 
-package imagebasedinstall
+package imagebasedinstaller
+
+// Default image-based installer install template names
+const (
+	ClusterLevelInstallTemplates = "ibi-cluster-templates-v1"
+	NodeLevelInstallTemplates    = "ibi-node-templates-v1"
+)
 
 const ImageClusterInstall = `apiVersion: extensions.hive.openshift.io/v1alpha1
 kind: ImageClusterInstall


### PR DESCRIPTION
# Summary

This PR applies the ACM disaster recovery backup label (`cluster.open-cluster-management.io/backup: ""`) to custom install template ConfigMaps. The default Assisted Installer (AI) and Image Based Installer (IBI) templates are not included in the content to be backed up as these are automatically created when the SiteConfig Operattor manager pod starts.

Note that the following content, required by the SiteConfig Operator and ClusterInstance controller, should already be backed up by the underlying installers (i.e. AI or IBI) and are thus excluded from the SiteConfig Operator:
- pull secret
- BMC secrets
- extra-manifests ConfigMaps

Furthermore,  the ClusterInstance CRs (`clusterinstances.siteconfig.open-cluster-management.io`) should automatically be backed up by ACM as per [resources-that-are-backed-up](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/business_continuity/business-cont-overview#resources-that-are-backed-up)
> Back up all resources with an API version suffixed by .[open-cluster-management.io](http://open-cluster-management.io/) and .[hive.openshift.io](http://hive.openshift.io/). These suffixes indicate that all Red Hat Advanced Cluster Management resources are backed up.

It is also worthwhile noting that the rendered install manifests can also be labelled for backup through the ClusterInstance CR via the `ExtraLabels` field (see https://github.com/stolostron/siteconfig/pull/75)

Resolves: [ACM-13268](https://issues.redhat.com/browse/ACM-13268)