### PR TITLE
ACM-14955: Extract machineNetwork for IBI template

### DIFF
--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -186,6 +186,42 @@ func TestTemplateEngineRender(t *testing.T) {
 		},
 
 		{
+			name: "Test with a valid ImageClusterInstall-like template",
+			args: args{
+				templateType: "ImageClusterInstall",
+				templateStr:  GetMockImageClusterInstallTemplate(),
+				data:         TestData,
+			},
+			want: map[string]interface{}{
+				"apiVersion": "extensions.hive.openshift.io/v1alpha1",
+				"kind":       "ImageClusterInstall",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"siteconfig.open-cluster-management.io/sync-wave": "1"},
+					"name":      "site-sno-du-1",
+					"namespace": "site-sno-du-1",
+				},
+				"spec": map[string]interface{}{
+					"hostname":             "node1",
+					"clusterDeploymentRef": map[string]interface{}{"name": "site-sno-du-1"},
+					"imageSetRef":          map[string]interface{}{"name": "openshift-test"},
+					"proxy":                map[string]interface{}{"noProxy": "foobar"},
+					"extraManifestsRefs": []interface{}{
+						map[string]interface{}{
+							"name": "foobar1",
+						},
+						map[string]interface{}{
+							"name": "foobar2",
+						},
+					},
+					"machineNetwork":   "203.0.113.0/24",
+					"bareMetalHostRef": map[string]interface{}{"name": "node1", "namespace": "site-sno-du-1"},
+					"sshKey":           "ssh-rsa",
+				}},
+			wantErr: false,
+		},
+
+		{
 			name: "Test with valid BMH-like template",
 			args: args{
 				templateType: "BareMetalHost",

--- a/internal/controller/clusterinstance/test_utils.go
+++ b/internal/controller/clusterinstance/test_utils.go
@@ -243,6 +243,42 @@ spec:
     name: "{{ .Spec.ClusterName }}"`
 }
 
+func GetMockImageClusterInstallTemplate() string {
+	return `apiVersion: extensions.hive.openshift.io/v1alpha1
+kind: ImageClusterInstall
+metadata:
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
+  annotations:
+    siteconfig.open-cluster-management.io/sync-wave: "1"
+spec:
+  clusterDeploymentRef:
+    name: "{{ .Spec.ClusterName }}"
+  imageSetRef:
+    name: "{{ .Spec.ClusterImageSetNameRef }}"
+  hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
+  sshKey: "{{ .Spec.SSHPublicKey }}"
+{{ if .Spec.CaBundleRef }}
+  caBundleRef:
+{{ .Spec.CaBundleRef | toYaml | indent 4 }}
+{{ end }}
+{{ if .Spec.ExtraManifestsRefs }}
+  extraManifestsRefs:
+{{ .Spec.ExtraManifestsRefs | toYaml | indent 4 }}
+{{ end }}
+  bareMetalHostRef:
+    name: "{{ .SpecialVars.CurrentNode.HostName }}"
+    namespace: "{{ .Spec.ClusterName }}"
+{{ if .Spec.MachineNetwork }}
+  machineNetwork: "{{ (index .Spec.MachineNetwork 0).CIDR }}"
+{{ end }}
+{{ if .Spec.Proxy }}
+  proxy:
+{{ .Spec.Proxy | toYaml | indent 4 }}
+{{ end }}
+`
+}
+
 func GetMockNMStateConfigTemplate() string {
 	return `apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -39,7 +39,7 @@ spec:
   caBundleRef:
 {{ .Spec.CaBundleRef | toYaml | indent 4 }}
 {{ end }}
-{{ if gt (len .Spec.ExtraManifestsRefs) 0 }}
+{{ if .Spec.ExtraManifestsRefs }}
   extraManifestsRefs:
 {{ .Spec.ExtraManifestsRefs | toYaml | indent 4 }}
 {{ end }}
@@ -47,8 +47,7 @@ spec:
     name: "{{ .SpecialVars.CurrentNode.HostName }}"
     namespace: "{{ .Spec.ClusterName }}"
 {{ if .Spec.MachineNetwork }}
-machineNetwork:
-{{ .Spec.MachineNetwork | toYaml | indent 4 }}
+  machineNetwork: "{{ (index .Spec.MachineNetwork 0).CIDR }}"
 {{ end }}
 {{ if .Spec.Proxy }}
   proxy:


### PR DESCRIPTION
# Summary
This PR updates the ImageClusterInstall IBI template to make use of the first `machineNetwork` value defined in the ClusterInstance.spec to align with the Image Based Install Operator's API specification of MachineNetwork as a [string](https://github.com/openshift/image-based-install-operator/blob/main/api/v1alpha1/imageclusterinstall_types.go#L98) value.

Resolves: [ACM-14955](https://issues.redhat.com/browse/ACM-14955)