### PR TITLE
ACM-15169: Update ClusterDeployment template for IBI

### DIFF
--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -71,10 +71,7 @@ spec:
     version: v1alpha1
   clusterName: "{{ .Spec.ClusterName }}"
   platform:
-    agentBareMetal:
-      agentSelector:
-        matchLabels:
-          cluster-name: "{{ .Spec.ClusterName }}"
+    none: {}
   pullSecretRef:
     name: "{{ .Spec.PullSecretRef.Name }}"`
 


### PR DESCRIPTION
# Summary
This PR updates the default IBI ClusterDeployment template by assigning the appropriate value to the platform field.

Resolves: [ACM-15169](https://issues.redhat.com/browse/ACM-15169)