### PR TITLE
ACM-15118: Cleanup BMH template for IBI

### DIFF
--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -136,19 +136,6 @@ metadata:
   annotations:
     siteconfig.open-cluster-management.io/sync-wave: "1"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
-{{ if .SpecialVars.CurrentNode.NodeLabels }}
-{{ range $key, $value := .SpecialVars.CurrentNode.NodeLabels }}
-    bmac.agent-install.openshift.io.node-label.{{ $key }}: {{ $value | quote}}
-{{ end }}
-{{ end }}
-    bmac.agent-install.openshift.io/hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
-{{ if .SpecialVars.CurrentNode.InstallerArgs  }}
-    bmac.agent-install.openshift.io/installer-args: '{{ .SpecialVars.CurrentNode.InstallerArgs  }}'
-{{ end }}
-{{ if .SpecialVars.CurrentNode.IgnitionConfigOverride }}
-    bmac.agent-install.openshift.io/ignition-config-overrides: '{{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}'
-{{ end }}
-    bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
 spec:
   bootMode: "{{ .SpecialVars.CurrentNode.BootMode }}"
   bmc:


### PR DESCRIPTION
# Summary
This PR cleans-up unused and not relevant annotations pertaining to the default IBI/BMH template.

Resolves: [ACM-15118](https://issues.redhat.com/browse/ACM-15118)