### PR TITLE
CNF-15718: Add Configuration Support for the SiteConfig Operator

### DIFF
--- a/docs/configure_siteconfig.md
+++ b/docs/configure_siteconfig.md
@@ -1,0 +1,104 @@
+# Configure SiteConfig Operator
+
+This guide provides instructions for configuring the SiteConfig Operator.
+The SiteConfig Operator relies on a ConfigMap to define key parameters that influence its behavior,
+such as whether reinstallation operations are allowed and the the maximum number of ClusterInstance resources
+that can be reconciled concurrently.
+
+## Configuration overview
+
+The SiteConfig Operator configuration is stored in a ConfigMap named **`siteconfig-operator-configuration`**.
+This ConfigMap must reside in the same namespace where the SiteConfig Operator is running.
+
+Key configuration options include:
+- **`allowReinstalls`**: Specifies whether reinstallation operations are permitted.
+- **`maxConcurrentReconciles`**: Determines the maximum number of concurrent reconcile operations.
+**Note**: Changing this value requires restarting the SiteConfig manager pod.
+
+---
+
+## Creating the configuration ConfigMap
+
+If the configuration ConfigMap does not already exist, follow these steps to create it:
+
+1. **Ensure you are targeting the correct namespace:**
+   ```sh
+   NAMESPACE=<siteconfig-operator-namespace>
+   ```
+
+2. **Create the ConfigMap with desired values:**
+   ```sh
+   cat <<EOF | oc apply -f -
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: siteconfig-operator-configuration
+     namespace: $NAMESPACE
+   data:
+     allowReinstalls: "false"
+     maxConcurrentReconciles: "1"
+   EOF
+   ```
+
+This will create the ConfigMap with reinstall disabled.
+
+---
+
+## Updating the configuration
+
+To modify the configuration, use the `oc patch` command to update the ConfigMap:
+
+1. **Update the `allowReinstalls` setting:**
+   ```sh
+   oc patch configmap siteconfig-operator-configuration \
+     -n $NAMESPACE \
+     --type=json \
+     -p '[{"op": "replace", "path": "/data/allowReinstalls", "value": "true"}]'
+   ```
+
+2. **Update the `maxConcurrentReconciles` setting:**
+   ```sh
+   oc patch configmap siteconfig-operator-configuration \
+     -n $NAMESPACE \
+     --type=json \
+     -p '[{"op": "replace", "path": "/data/maxConcurrentReconciles", "value": "10"}]'
+   ```
+
+   **Important**: If you modify `maxConcurrentReconciles`, you must restart the SiteConfig manager pod for the
+   changes to take effect.
+
+---
+
+## Restarting the SiteConfig manager pod
+
+To apply changes to `maxConcurrentReconciles`, restart the SiteConfig Operator pod:
+
+   ```sh
+   oc rollout restart deployment -n $NAMESPACE siteconfig-controller-manager
+   ```
+
+   The Operator's deployment will automatically recreate the pod.
+
+---
+
+## Verifying the Configuration
+
+After updating the ConfigMap or restarting the pod:
+1. **Check the ConfigMap data:**
+   ```sh
+   oc get configmap siteconfig-operator-configuration -n $NAMESPACE -o yaml
+   ```
+
+2. **Ensure the Operator is using the new configuration:**
+   Review the Operator logs to confirm the updated configuration:
+   ```sh
+   oc logs -n $NAMESPACE --selector app.kubernetes.io/name=siteconfig-controller -c manager --follow
+   ```
+
+---
+
+## Troubleshooting
+
+- If the ConfigMap is missing, the SiteConfig Operator will recreate it with default values.
+Check the Operator logs for relevant messages.
+- Ensure the ConfigMap name is **`siteconfig-operator-configuration`** and is located in the correct namespace.

--- a/internal/controller/clusterinstance/suite_test.go
+++ b/internal/controller/clusterinstance/suite_test.go
@@ -33,7 +33,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-func TestControllers(t *testing.T) {
+func TestClusterInstance(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "ClusterInstanceSuite")

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -27,6 +27,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stolostron/siteconfig/api/v1alpha1"
 	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/configuration"
 	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
 	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
 	"go.uber.org/zap"
@@ -103,11 +104,15 @@ var _ = Describe("Reconcile", func() {
 			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
 			Build()
 
+		configStore, err := configuration.NewConfigurationStore(configuration.NewDefaultConfiguration())
+		Expect(err).ToNot(HaveOccurred())
+
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:      c,
+			Scheme:      scheme.Scheme,
+			Log:         testLogger,
+			TmplEngine:  ci.NewTemplateEngine(),
+			ConfigStore: configStore,
 		}
 
 		Expect(c.Create(ctx, testParams.GeneratePullSecret())).To(Succeed())

--- a/internal/controller/configuration/configuration.go
+++ b/internal/controller/configuration/configuration.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Default configuration values for ClusterInstance.
+const (
+	// DefaultAllowReinstalls specifies whether reinstallation is allowed by default.
+	DefaultAllowReinstalls = false
+
+	// DefaultMaxConcurrentReconciles defines the default maximum number of concurrent reconciles.
+	DefaultMaxConcurrentReconciles = 1
+)
+
+// Configuration defines the runtime settings for the ClusterInstance controller.
+// These settings can be customized to control specific behaviors.
+type Configuration struct {
+	// allowReinstalls specifies whether the controller permits reinstallation operations.
+	// This setting determines if reinstallation requests are processed.
+	allowReinstalls bool
+
+	// maxConcurrentReconciles specifies the maximum number of ClusterInstance resources
+	// that can be reconciled concurrently by the controller.
+	// To apply changes to this value after the controller has started, the siteconfig-manager
+	// pod must be restarted.
+	maxConcurrentReconciles int
+}
+
+// NewDefaultConfiguration creates a new Configuration instance with default settings.
+func NewDefaultConfiguration() *Configuration {
+	return &Configuration{
+		allowReinstalls:         DefaultAllowReinstalls,
+		maxConcurrentReconciles: DefaultMaxConcurrentReconciles,
+	}
+}
+
+// ToMap converts the Configuration object into a map of string keys and values.
+func (c *Configuration) ToMap() map[string]string {
+	return map[string]string{
+		"allowReinstalls":         strconv.FormatBool(c.allowReinstalls),
+		"maxConcurrentReconciles": strconv.Itoa(c.maxConcurrentReconciles),
+	}
+}
+
+// FromMap updates the Configuration object based on values from a provided map.
+// An error if any input key is unsupported or if value conversion fails.
+func (c *Configuration) FromMap(input map[string]string) error {
+	for key, value := range input {
+		switch key {
+		case "allowReinstalls":
+			boolValue, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			c.allowReinstalls = boolValue
+
+		case "maxConcurrentReconciles":
+			intValue, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			c.maxConcurrentReconciles = intValue
+
+		default:
+			return fmt.Errorf("unsupported key in input map: %q", key)
+		}
+	}
+	return nil
+}

--- a/internal/controller/configuration/configuration_store.go
+++ b/internal/controller/configuration/configuration_store.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// ConfigurationStore provides thread-safe access to the runtime configuration for the
+// ClusterInstance controller. It allows dynamic updates to configuration fields, such
+// as reinstallation permissions and the number of concurrent reconciles.
+type ConfigurationStore struct {
+	// configuration holds the current runtime configuration settings.
+	configuration *Configuration
+
+	// mu is a read-write mutex to ensure synchronized access to the configuration.
+	mu sync.RWMutex
+}
+
+// NewConfigurationStore initializes a new ConfigurationStore with the given initial configuration.
+func NewConfigurationStore(initialConfig *Configuration) (*ConfigurationStore, error) {
+	if initialConfig == nil {
+		return nil, fmt.Errorf("configuration cannot be nil")
+	}
+
+	return &ConfigurationStore{
+		configuration: initialConfig,
+	}, nil
+}
+
+// SetAllowReinstalls updates the allowReinstalls field in the configuration.
+func (s *ConfigurationStore) SetAllowReinstalls(allowReinstalls bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configuration.allowReinstalls = allowReinstalls
+}
+
+// GetAllowReinstalls retrieves the current value of the allowReinstalls field.
+func (s *ConfigurationStore) GetAllowReinstalls() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.configuration.allowReinstalls
+}
+
+// SetMaxConcurrentReconciles updates the maxConcurrentReconciles field in the configuration.
+func (s *ConfigurationStore) SetMaxConcurrentReconciles(maxConcurrentReconciles int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configuration.maxConcurrentReconciles = maxConcurrentReconciles
+}
+
+// GetMaxConcurrentReconciles retrieves the current value of the maxConcurrentReconciles field.
+func (s *ConfigurationStore) GetMaxConcurrentReconciles() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.configuration.maxConcurrentReconciles
+}
+
+// UpdateConfiguration applies a set of configuration changes provided as key-value pairs.
+// Supported keys are:
+// - "allowReinstalls": A boolean string value (true/false) indicating whether reinstallation operations are allowed.
+// - "maxConcurrentReconciles": An integer string value specifying the maximum number of concurrent reconciles.
+//
+// Returns an error if any value cannot be parsed or if an unsupported key is provided.
+func (s *ConfigurationStore) UpdateConfiguration(data map[string]string) error {
+	for key, value := range data {
+		switch key {
+		case "allowReinstalls":
+			allowReinstalls, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			if s.GetAllowReinstalls() != allowReinstalls {
+				s.SetAllowReinstalls(allowReinstalls)
+			}
+
+		case "maxConcurrentReconciles":
+			maxConcurrentReconciles, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			if s.GetMaxConcurrentReconciles() != maxConcurrentReconciles {
+				s.SetMaxConcurrentReconciles(maxConcurrentReconciles)
+			}
+
+		default:
+			return fmt.Errorf("unsupported key in input map: %q", key)
+		}
+	}
+	return nil
+}

--- a/internal/controller/configuration/configuration_store_test.go
+++ b/internal/controller/configuration/configuration_store_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewConfigurationStore", func() {
+	It("creates a new ConfigurationStore object with the given Configuration object", func() {
+		testConfigs := []*Configuration{
+			{
+				allowReinstalls:         false,
+				maxConcurrentReconciles: 5,
+			},
+			{
+				allowReinstalls:         true,
+				maxConcurrentReconciles: 1,
+			},
+			NewDefaultConfiguration(),
+		}
+		for _, config := range testConfigs {
+			configStore, err := NewConfigurationStore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configStore.configuration).To(Equal(config))
+		}
+	})
+
+	It("returns a nil type when the given Configuration object is nil", func() {
+		configStore, err := NewConfigurationStore(nil)
+		Expect(err).To(HaveOccurred())
+		Expect(configStore).To(BeNil())
+	})
+})
+
+var _ = Describe("ConfigurationStore.UpdateConfiguration", func() {
+	It("successfully updates the Configuration object from the ConfigurationStore with the given data map", func() {
+		config := &Configuration{
+			allowReinstalls:         true,
+			maxConcurrentReconciles: 1,
+		}
+		configStore, err := NewConfigurationStore(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(configStore.GetAllowReinstalls()).To(BeTrue())
+		Expect(configStore.GetMaxConcurrentReconciles()).To(Equal(1))
+
+		data := map[string]string{
+			"allowReinstalls":         "false",
+			"maxConcurrentReconciles": "1",
+		}
+
+		err = configStore.UpdateConfiguration(data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(configStore.GetAllowReinstalls()).To(BeFalse())
+		Expect(configStore.GetMaxConcurrentReconciles()).To(Equal(1))
+
+		data["maxConcurrentReconciles"] = "10"
+		err = configStore.UpdateConfiguration(data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(configStore.GetAllowReinstalls()).To(BeFalse())
+		Expect(configStore.GetMaxConcurrentReconciles()).To(Equal(10))
+	})
+})

--- a/internal/controller/configuration/configuration_test.go
+++ b/internal/controller/configuration/configuration_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewDefaultConfiguration", func() {
+	It("creates a new Configuration object with default values for the SiteConfig Operator", func() {
+		expected := &Configuration{
+			allowReinstalls:         DefaultAllowReinstalls,
+			maxConcurrentReconciles: DefaultMaxConcurrentReconciles,
+		}
+		gotConfig := NewDefaultConfiguration()
+		Expect(gotConfig).To(Equal(expected))
+	})
+})
+
+var _ = Describe("Configuration.ToMap", func() {
+	It("correctly converts Configuration objects to maps", func() {
+
+		testConfigs := []Configuration{
+			{
+				allowReinstalls:         false,
+				maxConcurrentReconciles: 5,
+			},
+			{
+				allowReinstalls:         true,
+				maxConcurrentReconciles: 1,
+			},
+		}
+		expectedMaps := []map[string]string{
+			{
+				"allowReinstalls":         "false",
+				"maxConcurrentReconciles": "5",
+			},
+			{
+				"allowReinstalls":         "true",
+				"maxConcurrentReconciles": "1",
+			},
+		}
+
+		for index, config := range testConfigs {
+			got := config.ToMap()
+			Expect(got).To(Equal(expectedMaps[index]))
+		}
+	})
+})
+
+var _ = Describe("FromMap", func() {
+	It("correctly converts maps to Configuration objects", func() {
+		testMaps := []map[string]string{
+			{
+				"allowReinstalls":         "false",
+				"maxConcurrentReconciles": "5",
+			},
+			{
+				"allowReinstalls":         "true",
+				"maxConcurrentReconciles": "1",
+			},
+		}
+
+		expectedConfigs := []Configuration{
+			{
+				allowReinstalls:         false,
+				maxConcurrentReconciles: 5,
+			},
+			{
+				allowReinstalls:         true,
+				maxConcurrentReconciles: 1,
+			},
+		}
+
+		for index, tMap := range testMaps {
+			var config Configuration
+			err := config.FromMap(tMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(Equal(expectedConfigs[index]))
+		}
+	})
+
+	It("errors when it fails to convert maps to Configuration objects", func() {
+		testMaps := []map[string]string{
+			{
+				"allowReinstalls":         "foobar",
+				"maxConcurrentReconciles": "5",
+			},
+			{
+				"allowReinstalls":         "true",
+				"maxConcurrentReconciles": "ONE",
+			},
+		}
+
+		for _, tMap := range testMaps {
+			var config Configuration
+			err := config.FromMap(tMap)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
+	It("errors when unknown fields are found while converting maps to Configuration objects", func() {
+		testMaps := []map[string]string{
+			{
+				"allowReinstall$":         "true",
+				"maxConcurrentReconciles": "1",
+			},
+			{
+				"allowReinstalls":         "false",
+				"maxConcurrentReconciles": "10",
+				"foo":                     "bar",
+			},
+		}
+
+		for _, tMap := range testMaps {
+			var config Configuration
+			err := config.FromMap(tMap)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+})

--- a/internal/controller/configuration/suite_test.go
+++ b/internal/controller/configuration/suite_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+func TestConfiguration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	t.Setenv("POD_NAMESPACE", "siteconfig-operator")
+	RunSpecs(t, "ConfigurationSuite")
+}

--- a/internal/controller/configuration_monitor.go
+++ b/internal/controller/configuration_monitor.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/siteconfig/internal/controller/configuration"
+)
+
+const (
+	// SiteConfigOperatorConfigMap defines the name of the ConfigMap used to manage
+	// the SiteConfig Operator's runtime configuration.
+	SiteConfigOperatorConfigMap = "siteconfig-operator-configuration"
+
+	// RequeueDelay defines the default requeue delay on transient errors.
+	RequeueDelay = 30 * time.Second
+)
+
+// ConfigurationMonitor watches for changes to a specific ConfigMap and updates
+// the SiteConfig Operator's runtime configuration accordingly.
+type ConfigurationMonitor struct {
+	client.Client
+	Log    *zap.Logger
+	Scheme *runtime.Scheme
+
+	// Namespace containing the ConfigMap
+	Namespace string
+
+	// Store for runtime configuration
+	ConfigStore *configuration.ConfigurationStore
+}
+
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile processes events for the SiteConfig Configuration ConfigMap, ensuring the runtime configuration
+// remains synchronized.
+// Creates a default Configuration ConfigMap if one does not exist.
+func (r *ConfigurationMonitor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	log := r.Log.With(
+		zap.String("name", req.Name),
+		zap.String("namespace", req.Namespace),
+	)
+
+	log.Info("Start reconcile")
+	defer log.Info("Completed reconcile")
+
+	// Ignore non-SiteConfig configuration ConfigMaps
+	if req.Name != SiteConfigOperatorConfigMap {
+		log.Sugar().Infof("Ignoring unrelated ConfigMap %s", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// Retrieve the Configuration data from the ConfigMap
+	data, err := GetConfigurationData(ctx, r.Client, req.Namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create the default ConfigMap if it does not exist
+			log.Info("SiteConfig configuration ConfigMap not found, creating default configuration")
+			if err := CreateDefaultConfigurationConfigMap(ctx, r.Client, req.Namespace); err != nil {
+				log.Error("Failed to create default SiteConfig configuration ConfigMap", zap.Error(err))
+				return ctrl.Result{RequeueAfter: RequeueDelay}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		log.Error("Failed to retrieve SiteConfig configuration ConfigMap", zap.Error(err))
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
+	}
+
+	// Update the runtime configuration store
+	if err := r.ConfigStore.UpdateConfiguration(data); err != nil {
+		log.Error("Failed to update configuration store", zap.Error(err))
+		return ctrl.Result{}, err
+	}
+	log.Sugar().Infof("Successfully updated runtime configuration: %v", data)
+
+	return ctrl.Result{}, nil
+}
+
+// CreateDefaultConfigMap creates a ConfigMap with default configuration values in the given namespace.
+func CreateDefaultConfigurationConfigMap(ctx context.Context, c client.Client, namespace string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SiteConfigOperatorConfigMap,
+			Namespace: namespace,
+		},
+		Data: configuration.NewDefaultConfiguration().ToMap(),
+	}
+
+	if err := c.Create(ctx, cm); err != nil {
+		return fmt.Errorf("failed to create default ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+// GetConfigurationData retrieves the data field of the specified ConfigMap.
+func GetConfigurationData(ctx context.Context, c client.Client, namespace string) (map[string]string, error) {
+	// Fetch the ConfigMap
+	cm := &corev1.ConfigMap{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: SiteConfigOperatorConfigMap}, cm)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.Data, nil
+}
+
+// SetupWithManager configures the controller to watch the SiteConfig configuration
+// ConfigMap and process relevant events.
+func (r *ConfigurationMonitor) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Namespace == "" {
+		return fmt.Errorf("namespace not defined")
+	}
+
+	// isTargetConfigMap checks whether the given name and namespace match the expected
+	// SiteConfig configuration ConfigMap.
+	isTargetConfigMap := func(name, namespace string) bool {
+		if name != SiteConfigOperatorConfigMap || namespace != r.Namespace {
+			return false
+		}
+		return true
+	}
+
+	// Predicate to filter events for the target ConfigMap.
+	siteConfigCMPredicate := predicate.Funcs{
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isTargetConfigMap(e.Object.GetName(), e.Object.GetNamespace())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Recreate the ConfigMap if it is deleted
+			return isTargetConfigMap(e.Object.GetName(), e.Object.GetNamespace())
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isTargetConfigMap(e.ObjectNew.GetName(), e.ObjectNew.GetNamespace())
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("ConfigurationMonitor").
+		For(&corev1.ConfigMap{}).
+		WithOptions(ctrlruntime.Options{MaxConcurrentReconciles: 1}).
+		WithEventFilter(siteConfigCMPredicate).
+		Complete(r)
+}

--- a/internal/controller/configuration_monitor_test.go
+++ b/internal/controller/configuration_monitor_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/siteconfig/internal/controller/configuration"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Reconcile", func() {
+	var (
+		c             client.Client
+		r             *ConfigurationMonitor
+		ctx           = context.Background()
+		testNamespace = "siteconfig-operator"
+		testLogger    = zap.NewNop().Named("Test")
+		key           = types.NamespacedName{
+			Name:      SiteConfigOperatorConfigMap,
+			Namespace: testNamespace,
+		}
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&corev1.ConfigMap{}).
+			Build()
+
+		configStore, err := configuration.NewConfigurationStore(configuration.NewDefaultConfiguration())
+		Expect(err).ToNot(HaveOccurred())
+
+		r = &ConfigurationMonitor{
+			Client:      c,
+			Scheme:      scheme.Scheme,
+			Log:         testLogger,
+			ConfigStore: configStore,
+			Namespace:   testNamespace,
+		}
+	})
+
+	It("creates the default SiteConfig configuration ConfigMap when not found", func() {
+		cm := &corev1.ConfigMap{}
+
+		Expect(c.Get(ctx, key, cm)).ToNot(Succeed())
+
+		// Trigger the creation of the default SiteConfig configuration CM via reconcile
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		// Fetch the configmap and compare the data
+		Expect(c.Get(ctx, key, cm)).To(Succeed())
+		Expect(cm.Data).To(Equal(configuration.NewDefaultConfiguration().ToMap()))
+	})
+
+	It("updates the SiteConfig configuration when the ConfigMap changes", func() {
+		// Kick-off a reconcile that should auto-create a default SiteConfig configuration CM
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		cm := &corev1.ConfigMap{}
+		// Fetch the SiteConfig configuration ConfigMap and verify the configuration
+		Expect(c.Get(ctx, key, cm)).To(Succeed())
+		Expect(cm.Data).To(Equal(configuration.NewDefaultConfiguration().ToMap()))
+
+		// Update config and verify changes
+		cm.Data["allowReinstalls"] = "true"
+		cm.Data["maxConcurrentReconciles"] = "10"
+		Expect(c.Update(ctx, cm)).To(Succeed())
+
+		// Trigger a reconcile and verify that the configuration is udpated
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+		cm1 := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, key, cm1)).To(Succeed())
+		Expect(cm1.Data).To(Equal(cm.Data))
+	})
+
+	It("recreates the SiteConfig configuration ConfigMap with default config when deleted", func() {
+		// create the configuration CM
+		data := map[string]string{
+			"allowReinstalls":         "true",
+			"maxConcurrentReconciles": "10",
+		}
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Data: data,
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+
+		// Update the shared configuration store config
+		err := r.ConfigStore.UpdateConfiguration(data)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Kick-off a reconcile and verify the SiteConfig configuration CM
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(c.Get(ctx, key, cm)).To(Succeed())
+		Expect(cm.Data).To(Equal(data))
+
+		// Delete the CM
+		Expect(c.Delete(ctx, cm)).To(Succeed())
+		Expect(c.Get(ctx, key, cm)).ToNot(Succeed())
+
+		// Verify default config CM is recreated on reconcile
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		Expect(c.Get(ctx, key, cm)).To(Succeed())
+		Expect(cm.Data).To(Equal(configuration.NewDefaultConfiguration().ToMap()))
+	})
+})
+
+var _ = Describe("CreateDefaultConfigurationConfigMap", func() {
+	var (
+		c             client.Client
+		ctx           = context.Background()
+		testNamespace = "siteconfig-operator"
+		key           = types.NamespacedName{
+			Name:      SiteConfigOperatorConfigMap,
+			Namespace: testNamespace,
+		}
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			Build()
+	})
+
+	It("creates default configuration ConfigMap", func() {
+		err := CreateDefaultConfigurationConfigMap(ctx, c, testNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that the ConfigMap is created with correct data
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, key, cm)).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cm.Data).To(Equal(configuration.NewDefaultConfiguration().ToMap()))
+	})
+
+	It("returns an error if SiteConfig Operator configuration ConfigMap cannot be created", func() {
+		// Simulate an error by pre-creating the ConfigMap
+		// create the configuration CM
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Data: configuration.NewDefaultConfiguration().ToMap(),
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+
+		err := CreateDefaultConfigurationConfigMap(ctx, c, testNamespace)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("GetConfigurationData", func() {
+	var (
+		ctx           = context.Background()
+		c             client.Client
+		testNamespace = "siteconfig-operator"
+		key           = types.NamespacedName{
+			Name:      SiteConfigOperatorConfigMap,
+			Namespace: testNamespace,
+		}
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			Build()
+	})
+
+	It("returns the configuration data when the SiteConfig Operator Configuration ConfigMap exists", func() {
+		// create the configuration CM
+		data := map[string]string{
+			"allowReinstalls":         "true",
+			"maxConcurrentReconciles": "10",
+		}
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Data: data,
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+
+		got, err := GetConfigurationData(ctx, c, testNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(data))
+	})
+
+	It("errors when the SiteConfig Operator Configuration ConfigMap is not found", func() {
+		_, err := GetConfigurationData(ctx, c, testNamespace)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
# Summary

This PR introduces functionality to manage the SiteConfig Operator's configuration via a ConfigMap.

A new controller, `ConfigurationMonitor`, has been implemented to monitor and maintain the configuration. Key features include:
- Automatic creation of the ConfigMap with default values during manager pod initialization if it doesn't exist.
- Re-creation of the ConfigMap with default values if it is deleted.

The following configuration fields are supported:
- `AllowReinstalls`: Enables or disables the reinstall functionality.
- `MaxConcurrentReconciles`: Sets the maximum number of `ClusterInstances` that can be processed concurrently.

Unit tests have been added to validate the behavior of the new components.

**Resolves**: [CNF-15718](https://issues.redhat.com/browse/CNF-15718)
