### PR TITLE
Remove deprecated sbom-json-check task from konflux pipelines

### DIFF
--- a/.tekton/siteconfig-main-pull-request.yaml
+++ b/.tekton/siteconfig-main-pull-request.yaml
@@ -384,28 +384,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:f3f441de3002c5654acdff0553fd54cb1409e6bef6ff68e514d1731c9688b5cc
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: rpms-signature-scan
       params:
       - name: image-digest

--- a/.tekton/siteconfig-main-push.yaml
+++ b/.tekton/siteconfig-main-push.yaml
@@ -381,28 +381,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:f3f441de3002c5654acdff0553fd54cb1409e6bef6ff68e514d1731c9688b5cc
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: rpms-signature-scan
       params:
       - name: image-digest


### PR DESCRIPTION
This PR removes the deprecated `sbom-json-check` task from the konflux pipeline. Reference: https://github.com/konflux-ci/build-definitions/commit/76a2742f82f377441da39636b3b7ed10a8e62d2f.