### PR TITLE
CNF-15745: Add data preservation functionality to the SiteConfig Operator

### DIFF
--- a/docs/preservation.md
+++ b/docs/preservation.md
@@ -1,0 +1,191 @@
+# Safeguarding ConfigMaps and Secrets During Cluster Reinstalls with SiteConfig Operator
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Key Features](#key-features)
+   - [Backup](#backup)
+   - [Restore](#restore)
+   - [Selective Resource Management](#selective-resource-management)
+3. [Preservation Modes](#preservation-modes)
+   - [None](#none)
+   - [All](#all)
+   - [ClusterIdentity](#clusteridentity)
+4. [Backup Workflow](#backup-workflow)
+   - [Backup ConfigMaps and Secrets](#backup-configmaps-and-secrets)
+5. [Restoration Workflow](#restoration-workflow)
+   - [Restore ConfigMaps and Secrets](#restore-configmaps-and-secrets)
+     - [ConfigMaps](#configmaps)
+     - [Secrets](#secrets)
+6. [Example Usage](#example-usage)
+   - [Preserving a ConfigMap](#preserving-a-configmap)
+
+---
+
+## Introduction
+
+The **preservation** feature within the **SiteConfig Operator** provides a mechanism to back up and restore important
+Kubernetes resources such as **ConfigMaps** and **Secrets** that reside in the same namespace as the
+**ClusterInstance** Custom Resource (CR). This functionality ensures cluster data integrity during reinstallations.
+
+---
+
+## Key Features
+
+1. **Backup**: Creates preserved copies of ConfigMaps and Secrets, including their metadata.
+2. **Restore**: Restores the preserved ConfigMaps and Secrets.
+3. **Selective Resource Management**: Employs **Preservation Modes** to determine which resources are backed up and
+   restored.
+
+---
+
+## Preservation Modes
+
+The SiteConfig Operator allows users to control data preservation through three distinct modes:
+
+### 1. **None**
+- **Behavior**: No ConfigMaps or Secrets are preserved.
+- **Usage**: Select this mode if data preservation is unnecessary for the cluster during reinstallation.
+
+---
+
+### 2. **All**
+- **Behavior**:
+  - All ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve` (any value) in the same
+    namespace as the ClusterInstance CR are backed up.
+  - The original CRs of these resources are stored as immutable Kubernetes secrets.
+
+**Label Requirement**: Add the label `siteconfig.open-cluster-management.io/preserve` with any value.
+
+**Example Label**:
+```yaml
+siteconfig.open-cluster-management.io/preserve: ""
+```
+
+---
+
+### 3. **ClusterIdentity**
+- **Behavior**:
+  - Only ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve: "cluster-identity"` in
+    the same namespace as the ClusterInstance CR are backed up.
+  - The original CRs of these resources are stored as immutable Kubernetes secrets.
+
+**Label Requirement**: Add the label `siteconfig.open-cluster-management.io/preserve` with the value `cluster-identity`.
+
+**Example Label**:
+```yaml
+siteconfig.open-cluster-management.io/preserve: "cluster-identity"
+```
+
+---
+
+## Backup Workflow
+
+### Backup ConfigMaps and Secrets
+
+The SiteConfig Operator ensures the preservation of ConfigMaps and Secrets by performing the following steps:
+- **Sanitizing Metadata**: Information (such as creation timestamp, UID, and owner references) is removed from
+  the resource metadata.
+- **Serialization**: The resource's data is serialized into YAML format, ensuring that all relevant configuration
+  information is captured.
+- **Storage**: The serialized YAML data is stored in a newly created, immutable Kubernetes Secret, with appropriate labels
+  and annotations for identification as a backup.
+
+The backup data is encoded in base64 within the Secret, preserving both the original resource data and metadata in a
+format that can be easily restored later.
+
+---
+
+## Restoration Workflow
+
+### Restore ConfigMaps and Secrets
+
+Restoring a previously backed-up resource involves the following steps:
+- **Fetching the Backup**: The preserved resource(s) (stored via Kubernetes Secret) is retrieved and validated.
+- **Deserialization**: The YAML data is deserialized into the corresponding resource type (ConfigMap or Secret).
+- **Sanitizing Metadata**: As with backups, metadata such as UID and resource version is sanitized to ensure consistency.
+- **Restoration**: The resource is either created or updated within the cluster to match the original state, with a
+  `restoredAt` timestamp added for reference.
+
+---
+
+## Example Usage
+
+### Preserving a ConfigMap
+
+Given the following ClusterInstance definition:
+
+```yaml
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1
+kind: ClusterInstance
+metadata:
+  name: sample-ci
+  namespace: default
+spec:
+  reinstall:
+    generation: "1234"
+    preservationMode: "All"
+```
+
+#### Original ConfigMap Resource
+
+This is the original resource that will be preserved:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-1
+  namespace: default
+  labels:
+    siteconfig.open-cluster-management.io/preserve: ""
+  annotations:
+    example-annotation: "original-configmap"
+data:
+  key1: "value1"
+  key2: "value2"
+```
+
+
+#### Example Preserved ConfigMap Resource
+
+The preserved resource, stored as an immutable Kubernetes Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ConfigMap-example-1-1234
+  namespace: default
+  labels:
+    siteconfig.open-cluster-management.io/owned-by: "default-sample-ci"
+    siteconfig.open-cluster-management.io/preserved-data: "2025-01-01T10:00:00Z"
+  annotations:
+    siteconfig.open-cluster-management.io/reinstall.generation: "1234"
+    siteconfig.open-cluster-management.io/preservedResourceType: "ConfigMap"
+    siteconfig.open-cluster-management.io/preserve: "All"
+type: Opaque
+immutable: true
+data:
+  original-resource: YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGV4YW1wbGUtMQogIG5hbWVzcGFjZTogZGVmYXVsdAogIGxhYmVsczoKICAgIHNpdGVjb25maWcub3Blbi1jbHVzdGVyLW1hbmFnZW1lbnQuaW8vcHJlc2VydmU6ICIiCiAgYW5ub3RhdGlvbnM6CiAgICBleGFtcGxlLWFubm90YXRpb246ICJvcmlnaW5hbC1jb25maWdtYXAiCmRhdGE6CiAga2V5MTogInZhbHVlMSIKICBrZXkyOiAidmFsdWUyIg==
+```
+
+#### Example Restored ConfigMap Resource
+
+Once the resource is restored, it will appear as follows, with a new annotation indicating the restoration time:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-1
+  namespace: default
+  labels:
+    siteconfig.open-cluster-management.io/preserve: ""
+  annotations:
+    example-annotation: "original-configmap"
+    siteconfig.open-cluster-management.io/preserve.restoredAt: "2025-01-01T11:00:00Z"
+data:
+  key1: "value1"
+  key2: "value2"
+```

--- a/internal/controller/preservation/helper.go
+++ b/internal/controller/preservation/helper.go
@@ -1,0 +1,496 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preservation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/utils/ptr"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+)
+
+const (
+	// preservedDataLabelKey marks resources (ConfigMaps and Secrets) backed up by SiteConfig for restoration.
+	// It enables identification of preserved resources during a restore operation.
+	preservedDataLabelKey = v1alpha1.Group + "/preserved-data"
+
+	// restoredAtAnnotationKey indicates when a resource was restored.
+	restoredAtAnnotationKey = v1alpha1.PreservationLabelKey + ".restoredAt"
+
+	// reinstallGenerationAnnotationKey indicates the generation of resources requiring reinstallation.
+	reinstallGenerationAnnotationKey = v1alpha1.Group + "/reinstall.generation"
+
+	// resourceTypeAnnotationKey specifies the resource type (ConfigMap/Secret) being backed up.
+	resourceTypeAnnotationKey = v1alpha1.Group + "/preservedResourceType"
+
+	// preservedDataKey is the key used to store the original ConfigMap/Secret data in the Data field of the
+	// corresponding preserved ConfigMap / Secret during backup.
+	preservedDataKey = "original-resource"
+)
+
+type resourceType string
+
+const (
+	configMapResourceType resourceType = "ConfigMap"
+	secretResourceType    resourceType = "Secret"
+)
+
+// resources encapsulates the names of ConfigMaps and Secrets that are part of preservation operations.
+type resources struct {
+	configMaps []string
+	secrets    []string
+}
+
+type config struct {
+	resourceKey         types.NamespacedName
+	resourceType        resourceType
+	ownerRef            string
+	reinstallGeneration string
+	preservationMode    v1alpha1.PreservationMode
+}
+
+// buildLabelSelector constructs a label selector based on the provided parameters.
+func buildLabelSelector(labelKey string, operator selection.Operator, values []string) (labels.Selector, error) {
+	requirement, err := labels.NewRequirement(labelKey, operator, values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label selector: %w", err)
+	}
+
+	// Create and return the label selector with the constructed requirement.
+	return labels.NewSelector().Add(*requirement), nil
+}
+
+// buildBackupLabelSelector constructs a label selector for backup operations based on the PreservationMode.
+func buildBackupLabelSelector(mode v1alpha1.PreservationMode) (labels.Selector, error) {
+	if mode == v1alpha1.PreservationModeNone {
+		// No preservation required.
+		return nil, nil
+	}
+
+	switch mode {
+	case v1alpha1.PreservationModeAll:
+		// Select all resources with the PreservationLabelKey.
+		return buildLabelSelector(v1alpha1.PreservationLabelKey, selection.Exists, nil)
+	case v1alpha1.PreservationModeClusterIdentity:
+		// Select resources with PreservationLabelKey set to ClusterIdentityLabelValue.
+		return buildLabelSelector(v1alpha1.PreservationLabelKey, selection.Equals,
+			[]string{v1alpha1.ClusterIdentityLabelValue})
+	}
+	// Handle unknown or unsupported PreservationMode.
+	return nil, fmt.Errorf("unknown PreservationMode for backup: %v", mode)
+}
+
+// buildRestoreLabelSelector constructs a label selector for restore operations based on the PreservationMode.
+func buildRestoreLabelSelector(mode v1alpha1.PreservationMode) (labels.Selector, error) {
+	if mode == v1alpha1.PreservationModeNone {
+		// No restoration required.
+		return nil, nil
+	}
+
+	// Use the preservedLabel for restoration (applies to both PreservationModeAll and PreservationModeClusterIdentity).
+	if mode == v1alpha1.PreservationModeAll || mode == v1alpha1.PreservationModeClusterIdentity {
+		return buildLabelSelector(preservedDataLabelKey, selection.Exists, nil)
+	}
+
+	// Handle unknown or unsupported PreservationMode.
+	return nil, fmt.Errorf("unknown PreservationMode for restore: %v", mode)
+}
+
+// generateBackupName returns a backup name by appending the resource type and reinstall generation to the base name.
+func generateBackupName(rType resourceType, name, generation string) string {
+	return fmt.Sprintf("%s-%s-%s", rType, name, generation)
+}
+
+// sanitizeResourceMetadata removes specific metadata fields from the given Kubernetes object.
+func sanitizeResourceMetadata(obj client.Object) {
+	obj.SetCreationTimestamp(metav1.Time{})
+	obj.SetOwnerReferences(nil)
+	obj.SetResourceVersion("")
+	obj.SetUID("")
+}
+
+// backupResource backs up a Kubernetes resource (ConfigMap or Secret) by preserving its metadata and data.
+// The backup resource includes a preservation label and is created with the specified backup name.
+func backupResource(
+	ctx context.Context, c client.Client, log *zap.Logger,
+	backupName string,
+	config config,
+) error {
+
+	var resource client.Object
+	switch config.resourceType {
+	case configMapResourceType:
+		resource = &corev1.ConfigMap{}
+	case secretResourceType:
+		resource = &corev1.Secret{}
+	default:
+		err := fmt.Errorf("unsupported resource type for backup: %T", resource)
+		log.Error("Unsupported resource type", zap.Error(err))
+		return err
+	}
+
+	// Fetch the original resource.
+	if err := c.Get(ctx, config.resourceKey, resource); err != nil {
+		log.Error("Failed to retrieve resource for backup",
+			zap.String("namespace", config.resourceKey.Namespace),
+			zap.String("name", config.resourceKey.Name),
+			zap.Error(err))
+		return fmt.Errorf("failed to retrieve %s (%s/%s) for preservation: %w",
+			config.resourceType, config.resourceKey.Namespace, config.resourceKey.Name, err)
+	}
+
+	// Update logger with object context.
+	log = log.With(
+		zap.String("kind", string(config.resourceType)),
+		zap.String("name", resource.GetName()),
+		zap.String("namespace", resource.GetNamespace()),
+	)
+
+	log.Debug("Starting resource backup")
+
+	// Sanitize the resource metadata.
+	sanitizeResourceMetadata(resource)
+
+	// Marshal the resource data into YAML.
+	data, err := yaml.Marshal(resource)
+	if err != nil {
+		log.Error("Failed to marshal resource", zap.Error(err))
+		return fmt.Errorf("failed to marshal resource %s (%s/%s) for preservation: %w",
+			config.resourceType, config.resourceKey.Namespace, config.resourceKey.Name, err)
+	}
+
+	// Determine the resource type and construct the preserved resource.
+	objectMeta := metav1.ObjectMeta{
+		Name:      backupName,
+		Namespace: config.resourceKey.Namespace,
+	}
+
+	preservedResource := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: objectMeta,
+		Immutable:  ptr.To(true),
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			preservedDataKey: data,
+		},
+	}
+
+	if err := createResource(ctx, c, preservedResource, config); err != nil {
+		log.Error("Failed to create preserved resource", zap.Error(err))
+		return err
+	}
+
+	log.Debug("Successfully backed-up resource")
+	return nil
+}
+
+func createResource(ctx context.Context, c client.Client, object client.Object, config config) error {
+	// Add labels to the preserved object.
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[preservedDataLabelKey] = metav1.Now().Format(time.RFC3339)
+
+	if config.ownerRef != "" {
+		labels[ci.OwnedByLabel] = config.ownerRef
+	}
+
+	// Add annotations to the preserved object.
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[v1alpha1.PreservationLabelKey] = string(config.preservationMode)
+	annotations[resourceTypeAnnotationKey] = string(config.resourceType)
+
+	if config.reinstallGeneration != "" {
+		annotations[reinstallGenerationAnnotationKey] = config.reinstallGeneration
+	}
+
+	object.SetLabels(labels)
+	object.SetAnnotations(annotations)
+
+	// Create the backup resource.
+	if err := c.Create(ctx, object); err != nil {
+		return fmt.Errorf("failed to create preserved %s (%s/%s): %w",
+			object.GetObjectKind().GroupVersionKind().Kind,
+			object.GetNamespace(), object.GetName(),
+			err,
+		)
+	}
+
+	return nil
+}
+
+func fetchAndValidateObjectToRestore(
+	ctx context.Context, c client.Client, log *zap.Logger, object client.Object, config config,
+) (bool, error) {
+
+	// Fetch the object from the cluster.
+	if err := c.Get(ctx, config.resourceKey, object); err != nil {
+		return true, fmt.Errorf("failed to retrieve resource (%s/%s) for restoration: %w",
+			config.resourceKey.Namespace, config.resourceKey.Name, err)
+	}
+
+	// Update logger with object context.
+	log = log.With(
+		zap.String("kind", string(config.resourceType)),
+		zap.String("name", object.GetName()),
+		zap.String("namespace", object.GetNamespace()),
+	)
+
+	// Check preservation mode.
+	preservationMode, hasAnnotation := object.GetAnnotations()[v1alpha1.PreservationLabelKey]
+	if !hasAnnotation && config.preservationMode != v1alpha1.PreservationModeNone {
+		log.Warn("Missing preservation mode annotation", zap.String("annotation", v1alpha1.PreservationLabelKey))
+		return true, fmt.Errorf("preserved resource (%s/%s) is missing the '%s' annotation",
+			config.resourceKey.Namespace, config.resourceKey.Name, v1alpha1.PreservationLabelKey)
+	}
+
+	if hasAnnotation && config.preservationMode == v1alpha1.PreservationModeNone {
+		log.Warn("Preservation mode mismatch",
+			zap.String("annotation", v1alpha1.PreservationLabelKey),
+			zap.String("expected", string(v1alpha1.PreservationModeNone)),
+		)
+		return true, nil // Skip restore as preservation mode is None.
+	}
+
+	// Strict check for ClusterIdentity preservation mode.
+	if config.preservationMode == v1alpha1.PreservationModeClusterIdentity &&
+		preservationMode != string(config.preservationMode) {
+		log.Warn("Cluster identity preservation mode mismatch",
+			zap.String("expected", string(config.preservationMode)),
+			zap.String("found", preservationMode),
+		)
+		return true, nil // Skip restore due to mismatched preservation mode.
+	}
+
+	// Verify ownership if specified.
+	if config.ownerRef != "" {
+		if err := ci.VerifyOwnership(object, config.ownerRef); err != nil {
+			log.Warn("Ownership verification failed",
+				zap.String("label", ci.OwnedByLabel),
+				zap.String("expected", config.ownerRef),
+				zap.String("found", object.GetLabels()[ci.OwnedByLabel]),
+			)
+			return true, err
+		}
+	}
+
+	// Validate reinstall generation if specified.
+	if config.reinstallGeneration != "" {
+		value, ok := object.GetAnnotations()[reinstallGenerationAnnotationKey]
+		if !ok {
+			log.Warn("Missing reinstall generation annotation", zap.String("annotation", reinstallGenerationAnnotationKey))
+			return true, fmt.Errorf("preserved resource (%s/%s) is missing the '%s' annotation",
+				config.resourceKey.Namespace, config.resourceKey.Name, reinstallGenerationAnnotationKey)
+		}
+		if value != config.reinstallGeneration {
+			log.Warn("Mismatched reinstall generation annotation",
+				zap.String("annotation", reinstallGenerationAnnotationKey),
+				zap.String("expected", config.reinstallGeneration),
+				zap.String("found", value),
+			)
+			return true, fmt.Errorf("preserved resource's (%s/%s) '%s' annotation (%s) does not match (%s)",
+				config.resourceKey.Namespace, config.resourceKey.Name, reinstallGenerationAnnotationKey, value,
+				config.reinstallGeneration)
+		}
+	}
+
+	return false, nil // Proceed with restore.
+}
+
+// restoreResource restores a preserved ConfigMap or Secret by fetching it, validating the resource type,
+// unmarshaling the preserved data, and applying necessary metadata updates.
+func restoreResource(ctx context.Context, c client.Client, log *zap.Logger, conf config) error {
+	// Update logger with object context.
+	log = log.With(
+		zap.String("name", conf.resourceKey.Name),
+		zap.String("namespace", conf.resourceKey.Namespace),
+	)
+
+	log.Debug("Starting resource restoration")
+
+	// Fetch the preserved resource (always a Secret storing the backup)
+	preservedResource := &corev1.Secret{}
+	skip, err := fetchAndValidateObjectToRestore(ctx, c, log, preservedResource, conf)
+	if err != nil {
+		log.Error("Failed to fetch or validate preserved resource", zap.Error(err))
+		return err
+	}
+	if skip {
+		log.Debug("Skipping restoration of resource")
+		return nil
+	}
+
+	// Determine the resource type from annotations
+	resourceTypeValue, ok := preservedResource.GetAnnotations()[resourceTypeAnnotationKey]
+	if !ok {
+		return fmt.Errorf("missing '%s' annotation in preserved resource (%s/%s)",
+			resourceTypeAnnotationKey, conf.resourceKey.Namespace, conf.resourceKey.Name)
+	}
+
+	data, ok := preservedResource.Data[preservedDataKey]
+	if !ok {
+		return fmt.Errorf("missing '%s' key in Secret.Data (%s/%s)",
+			preservedDataKey, conf.resourceKey.Namespace, conf.resourceKey.Name)
+	}
+
+	var (
+		restoredResource    client.Object
+		preservedData       interface{}
+		originalAnnotations map[string]string
+		originalLabels      map[string]string
+	)
+
+	// Initialize the restored resource object based on the type
+	switch resourceType(resourceTypeValue) {
+	case secretResourceType:
+		restoredResource = &corev1.Secret{}
+	case configMapResourceType:
+		restoredResource = &corev1.ConfigMap{}
+	default:
+		return fmt.Errorf("unknown resource type: %s", resourceTypeValue)
+	}
+
+	// Unmarshal the preserved data into the target object
+	if err := yaml.Unmarshal(data, restoredResource); err != nil {
+		return fmt.Errorf("failed to unmarshal preserved resource (%s/%s): %v",
+			conf.resourceKey.Namespace, conf.resourceKey.Name, err)
+	}
+
+	// Capture annotations, labels, and data for later restoration
+	originalAnnotations = restoredResource.GetAnnotations()
+	originalLabels = restoredResource.GetLabels()
+
+	switch v := restoredResource.(type) {
+	case *corev1.ConfigMap:
+		preservedData = v.Data
+	case *corev1.Secret:
+		preservedData = v.Data
+	default:
+		return fmt.Errorf("unsupported resource type: %T", restoredResource)
+	}
+
+	// Generate the mutate function to restore the resource
+	mutateFn := func() error {
+		switch v := restoredResource.(type) {
+		case *corev1.ConfigMap:
+			v.Data = preservedData.(map[string]string)
+		case *corev1.Secret:
+			v.Data = preservedData.(map[string][]byte)
+		}
+
+		// Apply the "restoredAt" annotation to indicate the time of restoration
+		if originalAnnotations == nil {
+			originalAnnotations = make(map[string]string)
+		}
+		originalAnnotations[restoredAtAnnotationKey] = metav1.Now().Format(time.RFC3339)
+
+		// Set the restored annotations and labels
+		restoredResource.SetAnnotations(originalAnnotations)
+		restoredResource.SetLabels(originalLabels)
+
+		// Sanitize metadata by removing fields like UID, ResourceVersion, and OwnerReferences
+		sanitizeResourceMetadata(restoredResource)
+
+		return nil
+	}
+
+	// Attempt to create or update the restored resource
+	result, err := controllerutil.CreateOrUpdate(ctx, c, restoredResource, mutateFn)
+	if err != nil {
+		log.Error("Failed to restore preserved resource", zap.String("kind", resourceTypeValue), zap.Error(err))
+		return fmt.Errorf("failed to restore preserved %s (%s/%s): %w",
+			resourceTypeValue, restoredResource.GetNamespace(), restoredResource.GetName(), err)
+	}
+
+	log.Info("Resource restoration completed successfully",
+		zap.String("kind", resourceTypeValue),
+		zap.String("namespace", restoredResource.GetNamespace()),
+		zap.String("name", restoredResource.GetName()),
+		zap.String("result", string(result)),
+	)
+
+	return nil
+}
+
+// resourcesForPreservation fetches the names of ConfigMaps and Secrets based on the provided ListOptions.
+// Logs the count of retrieved resources and aggregates errors if any occur during the listing process.
+func resourcesForPreservation(
+	ctx context.Context,
+	c client.Client,
+	log *zap.Logger,
+	listOptions *client.ListOptions,
+) (*resources, error) {
+	var (
+		errs       []error
+		cmList     corev1.ConfigMapList
+		secretList corev1.SecretList
+	)
+
+	// Fetch ConfigMaps matching the label selector.
+	if err := c.List(ctx, &cmList, listOptions); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list ConfigMaps: %w", err))
+	}
+
+	// Fetch Secrets matching the label selector.
+	if err := c.List(ctx, &secretList, listOptions); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list Secrets: %w", err))
+	}
+
+	// Aggregate and return any errors encountered during the listing process.
+	if len(errs) > 0 {
+		return nil, errors.NewAggregate(errs)
+	}
+
+	// Collect the names of the retrieved ConfigMaps and Secrets.
+	var configMaps, secrets []string
+	for _, cm := range cmList.Items {
+		configMaps = append(configMaps, cm.Name)
+	}
+	for _, s := range secretList.Items {
+		secrets = append(secrets, s.Name)
+	}
+	log.Sugar().Infof("Retrieved %d ConfigMaps, %d Secrets for preservation", len(configMaps), len(secrets))
+
+	// Return the collected resource names as a Data object.
+	return &resources{
+		configMaps: configMaps,
+		secrets:    secrets,
+	}, nil
+}

--- a/internal/controller/preservation/helper_test.go
+++ b/internal/controller/preservation/helper_test.go
@@ -1,0 +1,756 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preservation
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func ensureEquality(actual, expected client.Object) {
+	// Check for equality
+	sanitizeResourceMetadata(actual)
+	sanitizeResourceMetadata(expected)
+	Expect(equality.Semantic.DeepEqual(actual, expected)).To(BeTrue())
+}
+
+var _ = Describe("Test LabelSelector builders", func() {
+	commonTests := func(labelSelectorBuilderFn func(v1alpha1.PreservationMode) (labels.Selector, error),
+		validPreservationLabelKey string,
+		expectedLabelValues []string) {
+
+		Context("preservationMode is valid", func() {
+
+			verifyLabelSelectorFn := func(mode v1alpha1.PreservationMode, expectedOutcome OmegaMatcher) {
+				lSelector, err := labelSelectorBuilderFn(mode)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lSelector).To(expectedOutcome)
+			}
+
+			It("does not error and returns a nil label.selector when preservationMode is None", func() {
+				verifyLabelSelectorFn(v1alpha1.PreservationModeNone, BeNil())
+			})
+
+			It("returns a label.selector for retrieving all preservation resources when preservationMode is All", func() {
+				expected, err := labels.NewRequirement(validPreservationLabelKey, selection.Exists, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				verifyLabelSelectorFn(v1alpha1.PreservationModeAll, Equal(labels.NewSelector().Add(*expected)))
+			})
+
+			It("returns a label.selector for retrieving cluster identity preservation resources when preservationMode is ClusterIdentity", func() {
+				var (
+					expected *labels.Requirement
+					err      error
+				)
+				if expectedLabelValues == nil {
+					expected, err = labels.NewRequirement(validPreservationLabelKey, selection.Exists, nil)
+				} else {
+					expected, err = labels.NewRequirement(validPreservationLabelKey, selection.Equals, expectedLabelValues)
+				}
+
+				Expect(err).NotTo(HaveOccurred())
+				verifyLabelSelectorFn(v1alpha1.PreservationModeClusterIdentity, Equal(labels.NewSelector().Add(*expected)))
+			})
+
+		})
+
+		Context("preservationMode is invalid", func() {
+			It("errors and returns a nil label.selector", func() {
+				var mode v1alpha1.PreservationMode = "foobar"
+				lSelector, err := labelSelectorBuilderFn(mode)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unknown PreservationMode"))
+				Expect(lSelector).To(BeNil())
+			})
+		})
+	}
+
+	Describe("buildBackupLabelSelector", func() {
+		commonTests(buildBackupLabelSelector, v1alpha1.PreservationLabelKey, []string{v1alpha1.ClusterIdentityLabelValue})
+	})
+
+	Describe("buildRestoreLabelSelector", func() {
+		commonTests(buildRestoreLabelSelector, preservedDataLabelKey, nil)
+	})
+
+})
+
+var _ = Describe("generateName", func() {
+	It("should generate a name by appending the resourceType and generation to the base name", func() {
+		Expect(generateBackupName(configMapResourceType, "foobar", "12345")).To(Equal("ConfigMap-foobar-12345"))
+		Expect(generateBackupName(secretResourceType, "foobar", "12345")).To(Equal("Secret-foobar-12345"))
+	})
+})
+
+var _ = Describe("resourcesForPreservation", func() {
+	var (
+		c   client.Client
+		ctx context.Context
+
+		cm1, cm2, cm3             *corev1.ConfigMap
+		secret1, secret2, secret3 *corev1.Secret
+
+		testLogger = zap.NewNop().Named("Test")
+
+		namespaceUnderTest string
+	)
+
+	BeforeEach(func() {
+		cm1 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm1",
+				Namespace: testNamespace1,
+				Labels:    map[string]string{"foo": "bar"},
+			},
+		}
+		cm2 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm2",
+				Namespace: testNamespace1,
+				Labels:    map[string]string{"bar": "foo"},
+			},
+		}
+		cm3 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm3",
+				Namespace: testNamespace2,
+				Labels:    map[string]string{"foo": "bar"},
+			},
+		}
+
+		secret1 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: testNamespace1,
+				Labels:    map[string]string{"bar": "foobar"},
+			},
+		}
+
+		secret2 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: testNamespace1,
+				Labels:    map[string]string{"foo": "bar"},
+			},
+		}
+
+		secret3 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret3",
+				Namespace: testNamespace2,
+				Labels:    map[string]string{"foo": "bar1"},
+			},
+		}
+
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(cm1, cm2, cm3, secret1, secret2, secret3).
+			Build()
+		ctx = context.Background()
+	})
+
+	retrieveDataAndEnsureEquality := func(namespace string, requirement *labels.Requirement, expectedResult *resources) {
+		listOptions := &client.ListOptions{
+			Namespace:     namespace,
+			LabelSelector: labels.NewSelector().Add(*requirement),
+		}
+		// Retrieve data for restoration
+		actual, err := resourcesForPreservation(ctx, c, testLogger, listOptions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expectedResult))
+	}
+
+	Context("ConfigMaps and Secrets exist in the given namespace and match the label.selector", func() {
+
+		When("using testNamespace1", func() {
+
+			BeforeEach(func() {
+				namespaceUnderTest = testNamespace1
+			})
+
+			It("retrieves data with label.selector={foo:bar}", func() {
+				requirement, err := labels.NewRequirement("foo", selection.Equals, []string{"bar"})
+				Expect(err).NotTo(HaveOccurred())
+				expected := &resources{
+					configMaps: []string{"cm1"},
+					secrets:    []string{"secret2"},
+				}
+				retrieveDataAndEnsureEquality(namespaceUnderTest, requirement, expected)
+			})
+
+			It("retrieves data with label.selector={bar:*}", func() {
+				requirement, err := labels.NewRequirement("bar", selection.Exists, nil)
+				Expect(err).NotTo(HaveOccurred())
+				expected := &resources{
+					configMaps: []string{"cm2"},
+					secrets:    []string{"secret1"},
+				}
+				retrieveDataAndEnsureEquality(namespaceUnderTest, requirement, expected)
+			})
+
+		})
+
+		When("using testNamespace2", func() {
+
+			BeforeEach(func() {
+				namespaceUnderTest = testNamespace2
+			})
+
+			It("retrieves data with label.selector={foo:*}", func() {
+				requirement, err := labels.NewRequirement("foo", selection.Exists, nil)
+				Expect(err).NotTo(HaveOccurred())
+				expected := &resources{
+					configMaps: []string{"cm3"},
+					secrets:    []string{"secret3"},
+				}
+				retrieveDataAndEnsureEquality(namespaceUnderTest, requirement, expected)
+			})
+		})
+	})
+
+	Context("ConfigMaps and Secrets do not exist in the given namespace or do not match the label.selector", func() {
+
+		When("using a namespace with no ConfigMaps or Secrets but matching label.selector", func() {
+
+			BeforeEach(func() {
+				namespaceUnderTest = "non-existent"
+			})
+
+			It("returns an empty Data object", func() {
+				requirement, err := labels.NewRequirement("foo", selection.Equals, []string{"bar"})
+				Expect(err).NotTo(HaveOccurred())
+				expected := &resources{
+					configMaps: nil,
+					secrets:    nil,
+				}
+				retrieveDataAndEnsureEquality(namespaceUnderTest, requirement, expected)
+			})
+		})
+
+		When("using a namespace with ConfigMaps and Secrets but no matching label.selector", func() {
+
+			BeforeEach(func() {
+				namespaceUnderTest = testNamespace1
+			})
+
+			It("returns an empty Data object", func() {
+				requirement, err := labels.NewRequirement("foo", selection.Equals, []string{"do-not-match"})
+				Expect(err).NotTo(HaveOccurred())
+				expected := &resources{
+					configMaps: nil,
+					secrets:    nil,
+				}
+				retrieveDataAndEnsureEquality(namespaceUnderTest, requirement, expected)
+			})
+		})
+	})
+
+})
+
+var _ = Describe("fetchAndValidateObjectToRestore", func() {
+	var (
+		ctx        context.Context
+		c          client.Client
+		testLogger *zap.Logger
+		testConfig config
+		object     *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testLogger = zap.NewNop().Named("Test")
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			Build()
+
+		testConfig = config{
+			resourceKey:         types.NamespacedName{Namespace: testNamespace1, Name: "test-configmap"},
+			ownerRef:            "test-owner",
+			reinstallGeneration: testReinstallGeneration,
+			preservationMode:    v1alpha1.PreservationModeClusterIdentity,
+		}
+
+		object = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: testNamespace1,
+				Labels: map[string]string{
+					ci.OwnedByLabel: "test-owner",
+				},
+				Annotations: map[string]string{
+					reinstallGenerationAnnotationKey: testReinstallGeneration,
+					v1alpha1.PreservationLabelKey:    "ClusterIdentity",
+				},
+			},
+		}
+	})
+
+	It("should return an error when the object is not found", func() {
+		skipRestore, err := fetchAndValidateObjectToRestore(ctx, c, testLogger, object, testConfig)
+		Expect(skipRestore).To(BeTrue())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to retrieve resource"))
+	})
+
+	It("should return an error when ownership verification fails", func() {
+		// Create a ConfigMap with a different owner label
+		object.Labels = map[string]string{
+			ci.OwnedByLabel: "different-owner",
+		}
+		Expect(c.Create(ctx, object)).To(Succeed())
+
+		skipRestore, err := fetchAndValidateObjectToRestore(ctx, c, testLogger, object, testConfig)
+		Expect(skipRestore).To(BeTrue())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("is not the owner of object"))
+	})
+
+	It("should return an error when the reinstall generation annotation is missing", func() {
+		// Create a ConfigMap without the reinstall generation annotation
+		object.Annotations = map[string]string{v1alpha1.PreservationLabelKey: "ClusterIdentity"}
+		Expect(c.Create(ctx, object)).To(Succeed())
+
+		skipRestore, err := fetchAndValidateObjectToRestore(ctx, c, testLogger, object, testConfig)
+		Expect(skipRestore).To(BeTrue())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("missing the '%s' annotation", reinstallGenerationAnnotationKey)))
+	})
+
+	It("should skip restore when the preservation mode is None", func() {
+		// Create a ConfigMap with a preservation mode but set config to None
+		testConfig.preservationMode = v1alpha1.PreservationModeNone
+		Expect(c.Create(ctx, object)).To(Succeed())
+
+		skipRestore, err := fetchAndValidateObjectToRestore(ctx, c, testLogger, object, testConfig)
+		Expect(skipRestore).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return nil error and skipRestore=false when validation succeeds", func() {
+		// Create a valid ConfigMap that matches the config
+		Expect(c.Create(ctx, object)).To(Succeed())
+
+		skipRestore, err := fetchAndValidateObjectToRestore(ctx, c, testLogger, object, testConfig)
+		Expect(skipRestore).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("sanitizeResourceMetadata", func() {
+	It("should remove CreationTimestamp, OwnerReferences, ResourceVersion, and UID", func() {
+
+		// Create a sample ConfigMap with metadata
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "cm1",
+				Namespace:         testNamespace1,
+				CreationTimestamp: metav1.Now(),
+				ResourceVersion:   "1",
+				UID:               "abc-123",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Foobar",
+						Name:       "foobar",
+					},
+				},
+			},
+		}
+		sanitizeResourceMetadata(obj)
+
+		Expect(obj.GetCreationTimestamp().Time.IsZero()).To(BeTrue(), "CreationTimestamp should be zero")
+		Expect(obj.GetOwnerReferences()).To(BeNil(), "OwnerReferences should be nil")
+		Expect(obj.GetResourceVersion()).To(BeEmpty(), "ResourceVersion should be empty")
+		Expect(obj.GetUID()).To(BeEmpty(), "UID should be empty")
+	})
+})
+
+var _ = Describe("createResource", func() {
+	var (
+		ctx        context.Context
+		c          client.Client // Assuming a mock client is used
+		testConfig config
+		obj        *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		testConfig = config{
+			resourceKey:         types.NamespacedName{Name: "cm1", Namespace: testNamespace1},
+			resourceType:        configMapResourceType,
+			ownerRef:            "test-owner",
+			reinstallGeneration: testReinstallGeneration,
+			preservationMode:    v1alpha1.PreservationModeAll,
+		}
+
+		obj = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm1",
+				Namespace: testNamespace1,
+			},
+		}
+	})
+
+	It("should add labels and annotations to the resource and create it", func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			Build()
+
+		err := createResource(ctx, c, obj, testConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		labels := obj.GetLabels()
+		annotations := obj.GetAnnotations()
+
+		Expect(labels).To(HaveKey(preservedDataLabelKey), "preservedDataLabelKey should be set")
+		Expect(labels[ci.OwnedByLabel]).To(Equal(testConfig.ownerRef), "OwnedByLabel should match ownerRef")
+
+		Expect(annotations).To(HaveKey(v1alpha1.PreservationLabelKey), "PreservationLabelKey should be set")
+		Expect(annotations[v1alpha1.PreservationLabelKey]).To(Equal(string(testConfig.preservationMode)))
+		Expect(annotations).To(HaveKey(resourceTypeAnnotationKey), "resourceTypeAnnotationKey should be set")
+		Expect(annotations[resourceTypeAnnotationKey]).To(Equal(string(configMapResourceType)))
+		Expect(annotations).To(HaveKey(reinstallGenerationAnnotationKey), "reinstallGenerationAnnotationKey should be set")
+		Expect(annotations[reinstallGenerationAnnotationKey]).To(Equal(testConfig.reinstallGeneration))
+	})
+
+	It("should return an error if the client fails to create the resource", func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return fmt.Errorf("inject error")
+				},
+			}).
+			Build()
+
+		err := createResource(ctx, c, obj, testConfig)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to create"))
+	})
+})
+
+var _ = Describe("Backup Restore Functionality", func() {
+
+	var (
+		ctx        context.Context
+		c          client.Client
+		testLogger *zap.Logger
+
+		namespace           = testNamespace1
+		originalName        = "original-resource"
+		ownerRef            = "foobar"
+		reinstallGeneration = testReinstallGeneration
+		mode                = v1alpha1.PreservationModeAll
+
+		nonExistentKey = types.NamespacedName{Namespace: namespace, Name: "non-existent"}
+
+		secretType = corev1.SecretTypeOpaque
+
+		originalConfigMap  *corev1.ConfigMap
+		preservedConfigMap *corev1.Secret
+
+		originalSecret, preservedSecret *corev1.Secret
+
+		testConfig config
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testLogger = zap.NewNop().Named("Test")
+
+		originalConfigMap, preservedConfigMap = generateConfigMap(originalName, namespace, ownerRef, mode)
+		originalSecret, preservedSecret = generateSecret(originalName, namespace, ownerRef, mode)
+
+	})
+
+	Describe("backupResource", func() {
+		BeforeEach(func() {
+			c = fakeclient.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(originalConfigMap, originalSecret).
+				Build()
+		})
+
+		Context("Test backing-up ConfigMap", func() {
+
+			BeforeEach(func() {
+				testConfig = config{
+					resourceType:        configMapResourceType,
+					ownerRef:            ownerRef,
+					reinstallGeneration: reinstallGeneration,
+					preservationMode:    mode,
+				}
+			})
+
+			It("should successfully create a backup ConfigMap", func() {
+				testConfig.resourceKey = client.ObjectKeyFromObject(originalConfigMap)
+
+				err := backupResource(ctx, c, testLogger, preservedConfigMap.Name, testConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				backedupConfigMap := &corev1.Secret{}
+				err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: preservedConfigMap.Name}, backedupConfigMap)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(backedupConfigMap.GetAnnotations()).To(HaveKeyWithValue(reinstallGenerationAnnotationKey, reinstallGeneration))
+				Expect(backedupConfigMap.GetLabels()).To(HaveKeyWithValue(ci.OwnedByLabel, ownerRef))
+				Expect(backedupConfigMap.GetLabels()).To(HaveKey(preservedDataLabelKey))
+				// Set the preservedLabel value to match the preservedConfigMap value to test for equality
+				backedupConfigMap.Labels[preservedDataLabelKey] = testTimestamp
+				ensureEquality(backedupConfigMap, preservedConfigMap)
+			})
+
+			It("should return an error if the original ConfigMap is not found", func() {
+				testConfig.resourceKey = nonExistentKey
+
+				err := backupResource(ctx, c, testLogger, preservedConfigMap.Name, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to retrieve ConfigMap"))
+			})
+		})
+
+		Context("Test backing-up Secret", func() {
+
+			BeforeEach(func() {
+				testConfig = config{
+					resourceType:        secretResourceType,
+					ownerRef:            ownerRef,
+					reinstallGeneration: reinstallGeneration,
+					preservationMode:    mode,
+				}
+			})
+
+			It("should successfully create a backup Secret", func() {
+				testConfig.resourceKey = client.ObjectKeyFromObject(originalSecret)
+
+				err := backupResource(ctx, c, testLogger, preservedSecret.Name, testConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				backedUpSecret := &corev1.Secret{}
+				err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: preservedSecret.Name}, backedUpSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(backedUpSecret.GetAnnotations()).To(HaveKeyWithValue(reinstallGenerationAnnotationKey, reinstallGeneration))
+				Expect(backedUpSecret.GetLabels()).To(HaveKeyWithValue(ci.OwnedByLabel, ownerRef))
+				Expect(backedUpSecret.GetLabels()).To(HaveKey(preservedDataLabelKey))
+
+				// Set the preservedLabel value to match the preservedSecret value to test for equality
+				backedUpSecret.Labels[preservedDataLabelKey] = testTimestamp
+				ensureEquality(backedUpSecret, preservedSecret)
+			})
+
+			It("should return an error if the original Secret is not found", func() {
+				testConfig.resourceKey = nonExistentKey
+
+				err := backupResource(ctx, c, testLogger, preservedSecret.Name, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to retrieve Secret"))
+			})
+
+		})
+	})
+
+	Describe("restoreResource", func() {
+
+		BeforeEach(func() {
+			c = fakeclient.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(preservedConfigMap, preservedSecret).
+				Build()
+		})
+
+		Context("Test restoring ConfigMap", func() {
+
+			BeforeEach(func() {
+				testConfig = config{
+					resourceKey:         client.ObjectKeyFromObject(preservedConfigMap),
+					ownerRef:            ownerRef,
+					reinstallGeneration: reinstallGeneration,
+					preservationMode:    mode,
+				}
+			})
+
+			It("should successfully restore a ConfigMap", func() {
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				restoredConfigMap := &corev1.ConfigMap{}
+				err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: originalName}, restoredConfigMap)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(restoredConfigMap.Annotations).To(HaveKey(restoredAtAnnotationKey))
+				delete(restoredConfigMap.Annotations, restoredAtAnnotationKey)
+				ensureEquality(restoredConfigMap, originalConfigMap)
+			})
+
+			It("should not return an error if the ConfigMap to be restored exists, but instead update it", func() {
+				// Create an existing "restored" ConfigMap.
+				existingConfigMap := &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: corev1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            originalName,
+						Namespace:       namespace,
+						Annotations:     map[string]string{"test": "value"},
+						Labels:          map[string]string{"abc": "def"},
+						ResourceVersion: "1",
+					},
+					Data: map[string]string{"random": "foobar"},
+				}
+
+				c = fakeclient.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(preservedConfigMap, existingConfigMap).
+					Build()
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+
+				// Validate that no error is returned.
+				Expect(err).NotTo(HaveOccurred())
+
+				actual := &corev1.ConfigMap{}
+				err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: originalName}, actual)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actual.Annotations).To(HaveKey(restoredAtAnnotationKey))
+				delete(actual.Annotations, restoredAtAnnotationKey)
+				ensureEquality(actual, originalConfigMap)
+			})
+
+			It("should return an error if the preserved ConfigMap is not found", func() {
+				testConfig.resourceKey = nonExistentKey
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to retrieve resource"))
+			})
+
+			It("should return an error if the preserved ConfigMap contains invalid data", func() {
+				preservedConfigMap.Data[preservedDataKey] = []byte("invalid-yaml:")
+				c = fakeclient.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(preservedConfigMap).
+					Build()
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to restore preserved ConfigMap"))
+			})
+		})
+
+		Context("Test restoring Secret", func() {
+
+			BeforeEach(func() {
+				testConfig = config{
+					resourceKey:         client.ObjectKeyFromObject(preservedSecret),
+					ownerRef:            ownerRef,
+					reinstallGeneration: reinstallGeneration,
+					preservationMode:    mode,
+				}
+			})
+
+			It("should successfully restore a Secret", func() {
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				restoredSecret := &corev1.Secret{}
+				err = c.Get(ctx, client.ObjectKeyFromObject(originalSecret), restoredSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(restoredSecret.Annotations).To(HaveKey(restoredAtAnnotationKey))
+				delete(restoredSecret.Annotations, restoredAtAnnotationKey)
+				ensureEquality(restoredSecret, originalSecret)
+			})
+
+			It("should not return an error if the Secret to be restored exists, but instead update it", func() {
+				// Create an existing "restored" Secret.
+				existingSecret := &corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: corev1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            originalName,
+						Namespace:       namespace,
+						Annotations:     map[string]string{"test": "value"},
+						Labels:          map[string]string{"abc": "def"},
+						ResourceVersion: "1",
+					},
+					Type: secretType,
+					Data: map[string][]byte{},
+				}
+
+				c = fakeclient.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(preservedSecret, existingSecret).
+					Build()
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				// Validate that no error is returned.
+				Expect(err).NotTo(HaveOccurred())
+
+				actual := &corev1.Secret{}
+				err = c.Get(ctx, client.ObjectKeyFromObject(originalSecret), actual)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actual.Annotations).To(HaveKey(restoredAtAnnotationKey))
+				delete(actual.Annotations, restoredAtAnnotationKey)
+				ensureEquality(actual, originalSecret)
+			})
+
+			It("should return an error if the preserved Secret is not found", func() {
+				testConfig.resourceKey = nonExistentKey
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to retrieve resource"))
+			})
+
+			It("should return an error if the preserved Secret contains invalid data", func() {
+				preservedSecret.Data[preservedDataKey] = []byte("invalid-yaml")
+				c = fakeclient.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(preservedSecret).Build()
+
+				err := restoreResource(ctx, c, testLogger, testConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to unmarshal"))
+			})
+
+		})
+
+	})
+
+})

--- a/internal/controller/preservation/preservation.go
+++ b/internal/controller/preservation/preservation.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preservation
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/deletion"
+)
+
+// Backup preserves ConfigMaps and Secrets based on the specified preservation mode.
+// The outcome of each backup is logged and any errors encountered are aggregated.
+func Backup(
+	ctx context.Context,
+	c client.Client,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (err error) {
+
+	log = log.Named("Backup")
+
+	namespace := clusterInstance.Namespace
+	ownerRef := ci.GenerateOwnedByLabelValue(namespace, clusterInstance.Name)
+	reinstallGeneration := clusterInstance.Spec.Reinstall.Generation
+	mode := clusterInstance.Spec.Reinstall.PreservationMode
+
+	// Define the label selector for filtering ConfigMaps and Secrets.
+	labelSelector, err := buildBackupLabelSelector(mode)
+	if err != nil {
+		return err
+	}
+	if labelSelector == nil {
+		log.Info("Nothing to backup")
+		return nil
+	}
+
+	listOptions := &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	}
+
+	// Retrieve data for backup
+	data, err := resourcesForPreservation(ctx, c, log, listOptions)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	backupFn := func(rType resourceType, resourceNames []string) {
+		for _, name := range resourceNames {
+			preservedName := generateBackupName(rType, name, reinstallGeneration)
+			config := config{
+				resourceKey:         types.NamespacedName{Namespace: namespace, Name: name},
+				resourceType:        rType,
+				ownerRef:            ownerRef,
+				reinstallGeneration: reinstallGeneration,
+				preservationMode:    mode,
+			}
+
+			if err := backupResource(ctx, c, log, preservedName, config); err != nil {
+				log.Error("Failed to backup resource",
+					zap.String("kind", string(rType)),
+					zap.String("namespace", namespace),
+					zap.String("name", name),
+					zap.Error(err))
+				errs = append(errs, err)
+			} else {
+				log.Debug("Successfully backed-up resource",
+					zap.String("kind", string(rType)),
+					zap.String("namespace", namespace),
+					zap.String("name", name))
+			}
+		}
+	}
+
+	// Backup each ConfigMap.
+	backupFn(configMapResourceType, data.configMaps)
+
+	// Backup each Secret.
+	backupFn(secretResourceType, data.secrets)
+
+	return errors.NewAggregate(errs)
+}
+
+// Restore restores ConfigMaps and Secrets from preserved data.
+// The outcome of each restore is logged and any errors encountered are aggregated.
+func Restore(
+	ctx context.Context,
+	c client.Client,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (err error) {
+
+	log = log.Named("Restore")
+
+	namespace := clusterInstance.Namespace
+	ownerRef := ci.GenerateOwnedByLabelValue(namespace, clusterInstance.Name)
+	reinstallGeneration := clusterInstance.Spec.Reinstall.Generation
+	mode := clusterInstance.Spec.Reinstall.PreservationMode
+
+	// Define the label selector for filtering ConfigMaps and Secrets.
+	labelSelector, err := buildRestoreLabelSelector(mode)
+	if err != nil {
+		return err
+	}
+	if labelSelector == nil {
+		log.Info("Nothing to restore")
+		return nil
+	}
+
+	listOptions := &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	}
+
+	// Retrieve data for restoration
+	data, err := resourcesForPreservation(ctx, c, log, listOptions)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	restoreFn := func(resourceNames []string) {
+		for _, name := range resourceNames {
+			config := config{
+				resourceKey:         types.NamespacedName{Namespace: namespace, Name: name},
+				ownerRef:            ownerRef,
+				reinstallGeneration: reinstallGeneration,
+				preservationMode:    mode,
+			}
+			if err := restoreResource(ctx, c, log, config); err != nil {
+				log.Error("Failed to restore resource",
+					zap.String("namespace", namespace),
+					zap.String("name", name),
+					zap.Error(err))
+				errs = append(errs, err)
+			} else {
+				log.Debug("Successfully restored resource",
+					zap.String("namespace", namespace),
+					zap.String("name", name))
+			}
+		}
+	}
+
+	// Restore ConfigMaps.
+	restoreFn(data.configMaps)
+
+	// Restore Secrets.
+	restoreFn(data.secrets)
+
+	return errors.NewAggregate(errs)
+}
+
+// Cleanup deletes preserved ConfigMaps and Secrets.
+// The outcome of each deletion is logged and any errors encountered are aggregated.
+func Cleanup(
+	ctx context.Context,
+	c client.Client,
+	deletionHandler *deletion.DeletionHandler,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (completedCleanup bool, err error) {
+	completedCleanup = true
+
+	// Define the label selector for filtering ConfigMaps and Secrets.
+	labelSelector, err := buildRestoreLabelSelector(clusterInstance.Spec.Reinstall.PreservationMode)
+	if err != nil {
+		return false, err
+	}
+
+	if labelSelector == nil {
+		return true, nil
+	}
+
+	listOptions := &client.ListOptions{
+		Namespace:     clusterInstance.Namespace,
+		LabelSelector: labelSelector,
+	}
+
+	// Retrieve data for restoration
+	data, err := resourcesForPreservation(ctx, c, log, listOptions)
+	if err != nil {
+		return false, err
+	}
+
+	deleteFn := func(rType resourceType, name string) error {
+
+		rawObject := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       string(rType),
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": clusterInstance.Namespace,
+			},
+		}
+
+		object := ci.RenderedObject{}
+		err := object.SetObject(rawObject)
+		if err != nil {
+			return err
+		}
+
+		deleted, err := deletionHandler.DeleteObject(ctx, clusterInstance, object, nil)
+		if client.IgnoreNotFound(err) != nil {
+			log.Warn("Failed to delete", zap.String("object", object.GetResourceId()), zap.Error(err))
+			return err
+		}
+		if !deleted {
+			completedCleanup = false
+		} else {
+			log.Info("Successfully deleted", zap.String("object", object.GetResourceId()))
+		}
+		return nil
+	}
+
+	var errs []error
+
+	// Delete ConfigMaps
+	for _, name := range data.configMaps {
+		if err := deleteFn(configMapResourceType, name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Delete Secrets
+	for _, name := range data.secrets {
+		if err := deleteFn(secretResourceType, name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return completedCleanup, errors.NewAggregate(errs)
+}

--- a/internal/controller/preservation/preservation_test.go
+++ b/internal/controller/preservation/preservation_test.go
@@ -1,0 +1,570 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preservation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/yaml"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/deletion"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Constants for unit-tests
+const (
+	testReinstallGeneration = "123"
+	testNamespace1          = "test-cluster-1"
+	testNamespace2          = "test-cluster-2"
+	testTimestamp           = "some-timestamp"
+)
+
+func verifyFn(targetObject types.NamespacedName, expectedObjects []client.Object, err error) bool {
+	for _, expectedObject := range expectedObjects {
+		if targetObject == client.ObjectKeyFromObject(expectedObject) {
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expected resource %s/%s to exist", expectedObject.GetNamespace(), expectedObject.GetName()))
+			return true
+		}
+	}
+	Expect(err).To(HaveOccurred(), fmt.Sprintf("Expected error since resource %s/%s should not exist", targetObject.Namespace, targetObject.Name))
+	return true
+}
+
+func verifyBackupFunctionality(ctx context.Context, c client.Client,
+	preservedConfigMapList, preservedSecretList []*corev1.Secret,
+	expectedPreservedConfigMaps, expectedPreservedSecrets []client.Object,
+) {
+	for _, obj := range preservedConfigMapList {
+		key := client.ObjectKeyFromObject(obj)
+		targetObject := &corev1.Secret{}
+		Expect(c.Get(ctx, key, targetObject)).
+			To(Satisfy(func(err error) bool {
+				return verifyFn(key, expectedPreservedConfigMaps, err)
+			}))
+	}
+
+	for _, obj := range preservedSecretList {
+		key := client.ObjectKeyFromObject(obj)
+		targetObject := &corev1.Secret{}
+		Expect(c.Get(ctx, key, targetObject)).
+			To(Satisfy(func(err error) bool {
+				return verifyFn(key, expectedPreservedSecrets, err)
+			}))
+	}
+}
+
+func verifyRestoreFunctionality(ctx context.Context, c client.Client,
+	configMapList []*corev1.ConfigMap,
+	secretList []*corev1.Secret,
+	expectedRestoredConfigMaps, expectedRestoredSecrets []client.Object,
+) {
+	for _, obj := range configMapList {
+		key := client.ObjectKeyFromObject(obj)
+		targetObject := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, key, targetObject)).
+			To(Satisfy(func(err error) bool {
+				return verifyFn(key, expectedRestoredConfigMaps, err)
+			}))
+	}
+
+	for _, obj := range secretList {
+		key := client.ObjectKeyFromObject(obj)
+		targetObject := &corev1.Secret{}
+		Expect(c.Get(ctx, key, targetObject)).
+			To(Satisfy(func(err error) bool {
+				return verifyFn(key, expectedRestoredSecrets, err)
+			}))
+	}
+}
+
+// generateConfigMap function generates and returns originalConfigMap, preservedConfigMap
+func generateConfigMap(name, namespace, ownerRef string, mode v1alpha1.PreservationMode) (*corev1.ConfigMap, *corev1.Secret) {
+
+	labels := map[string]string{
+		ci.OwnedByLabel: ownerRef,
+	}
+	switch mode {
+	case v1alpha1.PreservationModeAll:
+		labels[v1alpha1.PreservationLabelKey] = ""
+	case v1alpha1.PreservationModeClusterIdentity:
+		labels[v1alpha1.PreservationLabelKey] = v1alpha1.ClusterIdentityLabelValue
+	}
+
+	// ConfigMaps for testing.
+	originalConfigMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Data: map[string]string{"foo": "bar"},
+	}
+
+	originalConfigMapCopied := originalConfigMap.DeepCopy()
+	sanitizeResourceMetadata(originalConfigMapCopied)
+	dAtA, err := yaml.Marshal(originalConfigMapCopied)
+	Expect(err).ToNot(HaveOccurred())
+
+	annotations := map[string]string{
+		reinstallGenerationAnnotationKey: testReinstallGeneration,
+		resourceTypeAnnotationKey:        string(configMapResourceType),
+	}
+
+	if mode != v1alpha1.PreservationModeNone {
+		annotations[v1alpha1.PreservationLabelKey] = string(mode)
+	}
+
+	preservedConfigMap := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        generateBackupName(configMapResourceType, name, testReinstallGeneration),
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				ci.OwnedByLabel:       ownerRef,
+				preservedDataLabelKey: testTimestamp,
+			},
+		},
+		Type:      corev1.SecretTypeOpaque,
+		Immutable: ptr.To(true),
+		Data:      map[string][]byte{preservedDataKey: dAtA},
+	}
+
+	return originalConfigMap, preservedConfigMap
+}
+
+// generateSecret function generates and returns originalSecret, preservedSecret
+func generateSecret(name, namespace, ownerRef string, mode v1alpha1.PreservationMode) (*corev1.Secret, *corev1.Secret) {
+	labels := map[string]string{
+		ci.OwnedByLabel: ownerRef,
+	}
+	switch mode {
+	case v1alpha1.PreservationModeAll:
+		labels[v1alpha1.PreservationLabelKey] = ""
+	case v1alpha1.PreservationModeClusterIdentity:
+		labels[v1alpha1.PreservationLabelKey] = v1alpha1.ClusterIdentityLabelValue
+	}
+
+	// ConfigMaps for testing.
+	originalSecret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"username": []byte("admin"), "password": []byte("password")},
+	}
+
+	originalSecretCopied := originalSecret.DeepCopy()
+	sanitizeResourceMetadata(originalSecretCopied)
+	dAtA, err := yaml.Marshal(originalSecretCopied)
+	Expect(err).ToNot(HaveOccurred())
+
+	annotations := map[string]string{
+		reinstallGenerationAnnotationKey: testReinstallGeneration,
+		resourceTypeAnnotationKey:        string(secretResourceType),
+	}
+
+	if mode != v1alpha1.PreservationModeNone {
+		annotations[v1alpha1.PreservationLabelKey] = string(mode)
+	}
+
+	preservedSecret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        generateBackupName(secretResourceType, name, testReinstallGeneration),
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				ci.OwnedByLabel:       ownerRef,
+				preservedDataLabelKey: testTimestamp,
+			},
+		},
+		Type:      corev1.SecretTypeOpaque,
+		Immutable: ptr.To(true),
+		Data:      map[string][]byte{preservedDataKey: dAtA},
+	}
+
+	return originalSecret, preservedSecret
+}
+
+var _ = Describe("Test Backup and Restore functionality", func() {
+
+	var (
+		c   client.Client
+		ctx context.Context
+
+		testLogger = zap.NewNop().Named("Test")
+
+		ownerRef1 = ci.GenerateOwnedByLabelValue(testNamespace1, testNamespace1)
+		ownerRef2 = ci.GenerateOwnedByLabelValue(testNamespace2, testNamespace2)
+
+		// ConfigMap test data
+		originalCM1, originalCM2, originalCM3, originalCM4     *corev1.ConfigMap
+		preservedCM1, preservedCM2, preservedCM3, preservedCM4 *corev1.Secret
+
+		// Secret test data
+		originalSecret1, originalSecret2, originalSecret3, originalSecret4     *corev1.Secret
+		preservedSecret1, preservedSecret2, preservedSecret3, preservedSecret4 *corev1.Secret
+
+		// Collection of original ConfigMaps and Secrets
+		originalConfigMaps []*corev1.ConfigMap
+		originalSecrets    []*corev1.Secret
+
+		// Collection of preserved ConfigMaps and Secrets
+		preservedConfigMaps []*corev1.Secret
+		preservedSecrets    []*corev1.Secret
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			Build()
+		ctx = context.Background()
+
+		// Generate test data consisting of ConfigMaps and Secrets
+
+		// ConfigMaps for testing.
+		originalCM1, preservedCM1 = generateConfigMap("cm1", testNamespace2, ownerRef2, v1alpha1.PreservationModeAll)
+		originalCM2, preservedCM2 = generateConfigMap("cm2", testNamespace1, ownerRef1, v1alpha1.PreservationModeAll)
+		originalCM3, preservedCM3 = generateConfigMap("cm3", testNamespace2, ownerRef2, v1alpha1.PreservationModeClusterIdentity)
+		originalCM4, preservedCM4 = generateConfigMap("cm4", testNamespace1, ownerRef1, v1alpha1.PreservationModeClusterIdentity)
+
+		// Secrets for testing.
+		originalSecret1, preservedSecret1 = generateSecret("secret1", testNamespace2, ownerRef2, v1alpha1.PreservationModeAll)
+		originalSecret2, preservedSecret2 = generateSecret("secret2", testNamespace1, ownerRef1, v1alpha1.PreservationModeAll)
+		originalSecret3, preservedSecret3 = generateSecret("secret3", testNamespace2, ownerRef2, v1alpha1.PreservationModeClusterIdentity)
+		originalSecret4, preservedSecret4 = generateSecret("secret4", testNamespace1, ownerRef1, v1alpha1.PreservationModeClusterIdentity)
+
+		// Collect ConfigMaps and Secrets
+		originalConfigMaps = append([]*corev1.ConfigMap(nil), originalCM1, originalCM2, originalCM3, originalCM4)
+		preservedConfigMaps = append([]*corev1.Secret(nil), preservedCM1, preservedCM2, preservedCM3, preservedCM4)
+		originalSecrets = append([]*corev1.Secret(nil), originalSecret1, originalSecret2, originalSecret3, originalSecret4)
+		preservedSecrets = append([]*corev1.Secret(nil), preservedSecret1, preservedSecret2, preservedSecret3, preservedSecret4)
+	})
+
+	Describe("Backup", func() {
+
+		BeforeEach(func() {
+			// Create the original ConfigMaps and Secrets
+			for _, cm := range originalConfigMaps {
+				Expect(c.Create(ctx, cm)).To(Succeed())
+			}
+			for _, secret := range originalSecrets {
+				Expect(c.Create(ctx, secret)).To(Succeed())
+			}
+		})
+
+		It("successfully backups all labeled ConfigMaps and Secrets when preservationMode is All", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace1,
+					Namespace: testNamespace1,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeAll,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Backup(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedBackupCMs := []client.Object{preservedCM2, preservedCM4}
+			expectedBackupSecrets := []client.Object{preservedSecret2, preservedSecret4}
+			verifyBackupFunctionality(ctx, c, preservedConfigMaps, preservedSecrets, expectedBackupCMs, expectedBackupSecrets)
+		})
+
+		It("successfully backups only cluster identity ConfigMaps and Secrets when preservationMode is ClusterIdentity", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace1,
+					Namespace: testNamespace1,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeClusterIdentity,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Backup(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedBackupCMs := []client.Object{preservedCM4}
+			expectedBackupSecrets := []client.Object{preservedSecret4}
+			verifyBackupFunctionality(ctx, c, preservedConfigMaps, preservedSecrets, expectedBackupCMs, expectedBackupSecrets)
+		})
+
+		It("does not backup any data when preservationMode is None", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace1,
+					Namespace: testNamespace1,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeNone,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Backup(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedBackupCMs := []client.Object(nil)
+			expectedBackupSecrets := []client.Object(nil)
+			verifyBackupFunctionality(ctx, c, preservedConfigMaps, preservedSecrets, expectedBackupCMs, expectedBackupSecrets)
+		})
+
+	})
+
+	Describe("Restore", func() {
+
+		BeforeEach(func() {
+			// Create the preserved ConfigMaps and Secrets
+			for _, cm := range preservedConfigMaps {
+				Expect(c.Create(ctx, cm)).To(Succeed())
+			}
+			for _, secret := range preservedSecrets {
+				Expect(c.Create(ctx, secret)).To(Succeed())
+			}
+		})
+
+		It("successfully restore all labeled ConfigMaps and Secrets when preservationMode is All", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace2,
+					Namespace: testNamespace2,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeAll,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Restore(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedRestoredCMs := []client.Object{originalCM1, originalCM3}
+			expectedRestoredSecrets := []client.Object{originalSecret1, originalSecret3}
+			verifyRestoreFunctionality(ctx, c, originalConfigMaps, originalSecrets, expectedRestoredCMs, expectedRestoredSecrets)
+		})
+
+		It("successfully restore only cluster identity ConfigMaps and Secrets when preservationMode is ClusterIdentity", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace1,
+					Namespace: testNamespace1,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeClusterIdentity,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Restore(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedRestoredCMs := []client.Object{originalCM4}
+			expectedRestoredSecrets := []client.Object{originalSecret4}
+			verifyRestoreFunctionality(ctx, c, originalConfigMaps, originalSecrets, expectedRestoredCMs, expectedRestoredSecrets)
+		})
+
+		It("does not restore any data when preservationMode is None", func() {
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNamespace1,
+					Namespace: testNamespace1,
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					Reinstall: &v1alpha1.ReinstallSpec{
+						PreservationMode: v1alpha1.PreservationModeNone,
+						Generation:       testReinstallGeneration,
+					},
+				},
+			}
+
+			err := Restore(ctx, c, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedRestoredCMs := []client.Object(nil)
+			expectedRestoredSecrets := []client.Object(nil)
+			verifyRestoreFunctionality(ctx, c, originalConfigMaps, originalSecrets, expectedRestoredCMs, expectedRestoredSecrets)
+		})
+
+	})
+})
+
+var _ = Describe("Cleanup", func() {
+	var (
+		ctx             context.Context
+		c               client.Client
+		testLogger      *zap.Logger
+		deletionHandler *deletion.DeletionHandler
+
+		// ConfigMap resources
+		cm1, cm2, cm3, cm4 *corev1.ConfigMap
+		// Secret resources
+		secret1, secret2, secret3, secret4 *corev1.Secret
+		// Objects
+		objects []client.Object
+
+		clusterInstance *v1alpha1.ClusterInstance
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		testLogger = zap.NewNop().Named("Test")
+
+		clusterInstance = &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testNamespace1,
+			},
+			Spec: v1alpha1.ClusterInstanceSpec{
+				Reinstall: &v1alpha1.ReinstallSpec{
+					Generation:       "1",
+					PreservationMode: v1alpha1.PreservationModeAll,
+				},
+			},
+		}
+
+		pLabel := map[string]string{
+			preservedDataLabelKey: testTimestamp,
+			ci.OwnedByLabel:       ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
+		}
+		otherLabel := map[string]string{
+			"foo": "bar",
+		}
+
+		cm1 = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: testNamespace1, Labels: pLabel}}
+		cm2 = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: testNamespace1, Labels: otherLabel}}
+		cm3 = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm3", Namespace: testNamespace2, Labels: pLabel}}
+		cm4 = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm4", Namespace: testNamespace2, Labels: otherLabel}}
+
+		secret1 = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: testNamespace1, Labels: pLabel}}
+		secret2 = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret2", Namespace: testNamespace1, Labels: otherLabel}}
+		secret3 = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret3", Namespace: testNamespace2, Labels: pLabel}}
+		secret4 = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret4", Namespace: testNamespace2, Labels: otherLabel}}
+
+		objects = []client.Object{cm1, cm2, cm3, cm4, secret1, secret2, secret3, secret4}
+	})
+
+	It("successfully deletes all preserved ConfigMaps and Secrets in a given namespace", func() {
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithObjects(objects...).
+			Build()
+
+		deletionHandler = &deletion.DeletionHandler{
+			Client: c,
+			Logger: testLogger,
+		}
+
+		// Ensure resources exist before attempting Cleanup
+		for _, obj := range objects {
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		}
+
+		// First call to cleanup should return no errors with cleanup waiting for resources to be deleted
+		cleanupCompleted, err := Cleanup(ctx, c, deletionHandler, testLogger, clusterInstance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleanupCompleted).To(BeFalse())
+
+		// Second call to cleanuo should result in confirmation of the deletion of preservation resources
+		cleanupCompleted, err = Cleanup(ctx, c, deletionHandler, testLogger, clusterInstance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleanupCompleted).To(BeTrue())
+
+		// Verify correct resources are deleted
+		for _, obj := range []client.Object{cm1, secret1} {
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).ToNot(Succeed())
+		}
+		for _, obj := range []client.Object{cm2, cm3, cm4, secret2, secret3, secret4} {
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		}
+	})
+
+	It("returns an error when Cleanup fails for one or more preserved ConfigMaps and Secrets", func() {
+		fakeErrorMsg := "induced fake error"
+		deleteCalled := false
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithObjects(objects...).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					// trigger a deletion failure on secret1
+					if obj.GetName() == secret1.Name && obj.GetNamespace() == secret1.Namespace {
+						deleteCalled = true
+						return errors.New(fakeErrorMsg)
+					}
+					return nil
+				},
+			}).
+			Build()
+
+		deletionHandler = &deletion.DeletionHandler{
+			Client: c,
+			Logger: testLogger,
+		}
+
+		completedDeletion, err := Cleanup(ctx, c, deletionHandler, testLogger, clusterInstance)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(fakeErrorMsg))
+		Expect(deleteCalled).To(BeTrue())
+		Expect(completedDeletion).To(BeFalse())
+	})
+
+})

--- a/internal/controller/preservation/suite_test.go
+++ b/internal/controller/preservation/suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preservation
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+func TestPreservation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PreservationSuite")
+}


### PR DESCRIPTION
# Summary

This PR introduces a data preservation mechanism for backing up and restoring ConfigMaps and Secrets associated with the SiteConfig Operator. It ensures the protection of cluster data during reinstallations by preserving relevant Kubernetes resources in the same namespace as the ClusterInstance CR.

**Key Features:**

- **Preservation Modes**:
  - **None**: No preservation.
  - **All**: Backs up all ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve`.
  - **ClusterIdentity**: Backs up ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve: "cluster-identity"`.

- **Backup Workflow**:
  - Preserves Kubernetes resources by sanitizing metadata, removing information (e.g., creation timestamp, owner references), and serializing the resource data into YAML format.
  - The serialized data is stored in a new, immutable Kubernetes Secret, encoded in base64, and labeled as a backup.

- **Restore Workflow**:
  - Retrieves and validates backed-up Secret(s), deserializes the YAML data into the corresponding resource type (ConfigMap or Secret), and reapplies original annotations and labels.
  - Metadata is sanitized, a `restoredAt` timestamp is added, and the resource is created or updated in the cluster to restore its original state.

**Documentation:**
- Detailed usage instructions and YAML examples to help users effectively utilize the preservation feature.

**Tests:**
- Unit tests added to validate functionality.


## **References:**
- Resolves: [CNF-15745](https://issues.redhat.com/browse/CNF-15745)
- Related to IBBF - SNO H/W replacement epic: [CNF-14103](https://issues.redhat.com/browse/CNF-14103)