### PR TITLE
ACM-16142: Enhanced deletion handling for SiteConfig

### DIFF
--- a/api/v1alpha1/clusterinstance_conditions.go
+++ b/api/v1alpha1/clusterinstance_conditions.go
@@ -38,6 +38,7 @@ const (
 	RenderedTemplates          ClusterInstanceConditionType = "RenderedTemplates"
 	RenderedTemplatesValidated ClusterInstanceConditionType = "RenderedTemplatesValidated"
 	RenderedTemplatesApplied   ClusterInstanceConditionType = "RenderedTemplatesApplied"
+	RenderedTemplatesDeleted   ClusterInstanceConditionType = "RenderedTemplatesDeleted"
 	ClusterProvisioned         ClusterInstanceConditionType = "Provisioned"
 )
 

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -402,11 +402,14 @@ type ClusterInstanceSpec struct {
 }
 
 const (
-	ManifestRenderedSuccess   = "rendered"
-	ManifestRenderedFailure   = "failed"
-	ManifestRenderedValidated = "validated"
-	ManifestSuppressed        = "suppressed"
-	ManifestPruneFailure      = "pruning-attempt-failed"
+	ManifestRenderedSuccess    = "rendered"
+	ManifestRenderedFailure    = "failed"
+	ManifestRenderedValidated  = "validated"
+	ManifestSuppressed         = "suppressed"
+	ManifestDeleted            = "deleted"
+	ManifestDeletionInProgress = "deletion-in-progress"
+	ManifestDeletionFailure    = "deletion-failed"
+	ManifestDeletionTimedOut   = "deletion-attempt-timed-out"
 )
 
 // ManifestReference contains enough information to let you locate the

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	open-cluster-management.io/api v0.15.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -107,7 +108,6 @@ require (
 	gorm.io/gorm v1.24.5 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -19,13 +19,14 @@ package clusterinstance
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"strings"
+	"text/template"
 
 	sprig "github.com/go-task/slim-sprig"
-	"github.com/stolostron/siteconfig/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
+
 	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
 )
 
 const (
@@ -290,22 +291,6 @@ func funcMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	f["toYaml"] = toYaml
 	return f
-}
-
-// GenerateOwnedByLabelValue is a utility function that generates the ownedBy label value
-// using the ClusterInstance namespace and name
-func GenerateOwnedByLabelValue(namespace, name string) string {
-	return fmt.Sprintf("%s_%s", namespace, name)
-}
-
-// GetNamespacedNameFromOwnedByLabel extracts the namespace and name from the ownedBy label value
-func GetNamespacedNameFromOwnedByLabel(ownedByLabel string) (types.NamespacedName, error) {
-	res := strings.Split(ownedByLabel, "_")
-	if len(res) != 2 {
-		return types.NamespacedName{}, fmt.Errorf("expecting single underscore delimiter in %s label value", ownedByLabel)
-	}
-
-	return types.NamespacedName{Namespace: res[0], Name: res[1]}, nil
 }
 
 func GetResourceId(name, namespace, kind string) string {

--- a/internal/controller/clusterinstance/ownership.go
+++ b/internal/controller/clusterinstance/ownership.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterinstance
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	cierrors "github.com/stolostron/siteconfig/internal/controller/errors"
+)
+
+// OwnedByLabel is the key for the "owned-by" label, used to identify the owner of a resource.
+const OwnedByLabel = v1alpha1.Group + "/owned-by"
+
+// GetOwner retrieves the value of the "owned-by" label from an object.
+// If the label is not present, it returns an empty string.
+func GetOwner(obj client.Object) string {
+	return obj.GetLabels()[OwnedByLabel]
+}
+
+// VerifyOwnership checks if an object is logically owned by a specified owner reference label.
+func VerifyOwnership(obj client.Object, ownerRefLabel string) error {
+	if GetOwner(obj) != ownerRefLabel {
+		resourceId := GetResourceId(obj.GetName(), obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind().Kind)
+		return cierrors.NewNotOwnedObjectError(ownerRefLabel, resourceId)
+	}
+	return nil
+}
+
+// GenerateOwnedByLabelValue generates a consistent value for the "owned-by" label using the
+// namespace and name of a ClusterInstance.
+func GenerateOwnedByLabelValue(namespace, name string) string {
+	return fmt.Sprintf("%s_%s", namespace, name)
+}
+
+// GetNamespacedNameFromOwnedByLabel parses the value of the "owned-by" label to extract the
+// namespace and name of the owning resource.
+func GetNamespacedNameFromOwnedByLabel(ownedByLabel string) (types.NamespacedName, error) {
+	res := strings.Split(ownedByLabel, "_")
+	if len(res) != 2 {
+		return types.NamespacedName{}, fmt.Errorf("expecting single underscore delimiter in %s label value", ownedByLabel)
+	}
+
+	return types.NamespacedName{Namespace: res[0], Name: res[1]}, nil
+}
+
+// GetNameFromOwnedByLabel extracts only the name portion from the "owned-by" label value.
+func GetNameFromOwnedByLabel(ownedByLabel string) string {
+	res, err := GetNamespacedNameFromOwnedByLabel(ownedByLabel)
+	if err != nil {
+		return ""
+	}
+	return res.Name
+}

--- a/internal/controller/clusterinstance/rendered_object_test.go
+++ b/internal/controller/clusterinstance/rendered_object_test.go
@@ -250,7 +250,7 @@ func TestRenderedObjectGetSyncWave(t *testing.T) {
 }
 
 func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
-	render := syncWaveMap{
+	render := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -264,7 +264,7 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 			},
 		},
 	}
-	prune := syncWaveMap{
+	prune := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -278,7 +278,7 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 			},
 		},
 	}
-	suppress := syncWaveMap{
+	suppress := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -293,9 +293,9 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 		},
 	}
 	type fields struct {
-		prune    syncWaveMap
-		suppress syncWaveMap
-		render   syncWaveMap
+		prune    SyncWaveMap
+		suppress SyncWaveMap
+		render   SyncWaveMap
 	}
 	tests := []struct {
 		name   string
@@ -305,9 +305,9 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 		{
 			name: "render objects is empty",
 			fields: fields{
-				prune:    syncWaveMap{},
-				suppress: syncWaveMap{},
-				render:   syncWaveMap{},
+				prune:    SyncWaveMap{},
+				suppress: SyncWaveMap{},
+				render:   SyncWaveMap{},
 			},
 			want: []RenderedObject{},
 		},
@@ -318,7 +318,7 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 				suppress: suppress,
 				render:   render,
 			},
-			want: render.getSlice(0),
+			want: render.GetObjectsForSyncWave(0),
 		},
 	}
 	for _, tt := range tests {
@@ -336,7 +336,7 @@ func TestRenderedObjectCollectionGetRenderObjects(t *testing.T) {
 }
 
 func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
-	render := syncWaveMap{
+	render := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -350,7 +350,7 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 			},
 		},
 	}
-	prune := syncWaveMap{
+	prune := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -364,7 +364,7 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 			},
 		},
 	}
-	suppress := syncWaveMap{
+	suppress := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -379,9 +379,9 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 		},
 	}
 	type fields struct {
-		prune    syncWaveMap
-		suppress syncWaveMap
-		render   syncWaveMap
+		prune    SyncWaveMap
+		suppress SyncWaveMap
+		render   SyncWaveMap
 	}
 	tests := []struct {
 		name   string
@@ -391,9 +391,9 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 		{
 			name: "prune objects is empty",
 			fields: fields{
-				prune:    syncWaveMap{},
-				suppress: syncWaveMap{},
-				render:   syncWaveMap{},
+				prune:    SyncWaveMap{},
+				suppress: SyncWaveMap{},
+				render:   SyncWaveMap{},
 			},
 			want: []RenderedObject{},
 		},
@@ -404,7 +404,7 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 				suppress: suppress,
 				render:   render,
 			},
-			want: prune.getSlice(0),
+			want: prune.GetObjectsForSyncWave(0),
 		},
 	}
 	for _, tt := range tests {
@@ -422,7 +422,7 @@ func TestRenderedObjectCollectionGetPruneObjects(t *testing.T) {
 }
 
 func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
-	render := syncWaveMap{
+	render := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -436,7 +436,7 @@ func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
 			},
 		},
 	}
-	prune := syncWaveMap{
+	prune := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -450,7 +450,7 @@ func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
 			},
 		},
 	}
-	suppress := syncWaveMap{
+	suppress := SyncWaveMap{
 		data: map[int][]RenderedObject{
 			0: {
 				{
@@ -465,9 +465,9 @@ func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
 		},
 	}
 	type fields struct {
-		prune    syncWaveMap
-		suppress syncWaveMap
-		render   syncWaveMap
+		prune    SyncWaveMap
+		suppress SyncWaveMap
+		render   SyncWaveMap
 	}
 	tests := []struct {
 		name   string
@@ -477,9 +477,9 @@ func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
 		{
 			name: "suppress objects is empty",
 			fields: fields{
-				prune:    syncWaveMap{},
-				suppress: syncWaveMap{},
-				render:   syncWaveMap{},
+				prune:    SyncWaveMap{},
+				suppress: SyncWaveMap{},
+				render:   SyncWaveMap{},
 			},
 			want: []RenderedObject{},
 		},
@@ -490,7 +490,7 @@ func TestRenderedObjectCollectionGetSuppressObjects(t *testing.T) {
 				suppress: suppress,
 				render:   render,
 			},
-			want: suppress.getSlice(0),
+			want: suppress.GetObjectsForSyncWave(0),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/controller/clusterinstance/template_engine.go
+++ b/internal/controller/clusterinstance/template_engine.go
@@ -35,7 +35,6 @@ import (
 const (
 	WaveAnnotation        = v1alpha1.Group + "/sync-wave"
 	DefaultWaveAnnotation = "0"
-	OwnedByLabel          = v1alpha1.Group + "/owned-by"
 )
 
 type TemplateEngine struct{}

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -20,22 +20,23 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
-	"sort"
 	"time"
 
-	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
-	"github.com/stolostron/siteconfig/internal/controller/conditions"
-	"github.com/stolostron/siteconfig/internal/controller/configuration"
 	"go.uber.org/zap"
+
 	"golang.org/x/exp/maps"
+
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -43,6 +44,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
+	"github.com/stolostron/siteconfig/internal/controller/configuration"
+	"github.com/stolostron/siteconfig/internal/controller/deletion"
+	cierrors "github.com/stolostron/siteconfig/internal/controller/errors"
 	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
 	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
 )
@@ -55,14 +61,17 @@ const (
 	acmBackupLabelValue = ""
 )
 
+const DefaultDeletionRequeueDelay = 30 * time.Second
+
 // ClusterInstanceReconciler reconciles a ClusterInstance object
 type ClusterInstanceReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Recorder    record.EventRecorder
-	Log         *zap.Logger
-	TmplEngine  *ci.TemplateEngine
-	ConfigStore *configuration.ConfigurationStore
+	Scheme          *runtime.Scheme
+	Recorder        record.EventRecorder
+	Log             *zap.Logger
+	TmplEngine      *ci.TemplateEngine
+	ConfigStore     *configuration.ConfigurationStore
+	DeletionHandler *deletion.DeletionHandler
 }
 
 func doNotRequeue() ctrl.Result {
@@ -72,6 +81,11 @@ func doNotRequeue() ctrl.Result {
 func requeueWithError(err error) (ctrl.Result, error) {
 	// can not be fixed by user during reconcile
 	return ctrl.Result{}, err
+}
+
+func requeueForDeletion() ctrl.Result {
+	// Requeue after the default delay while waiting for resource deletion to complete
+	return ctrl.Result{Requeue: true, RequeueAfter: DefaultDeletionRequeueDelay}
 }
 
 //+kubebuilder:rbac:groups=siteconfig.open-cluster-management.io,resources=clusterinstances,verbs=get;list;watch;create;update;patch;delete
@@ -112,7 +126,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Get the ClusterInstance CR
 	clusterInstance := &v1alpha1.ClusterInstance{}
 	if err := r.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Error("ClusterInstance not found")
 			return doNotRequeue(), nil
 		}
@@ -123,7 +137,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	log.Info("Loaded ClusterInstance", zap.String("version", clusterInstance.GetResourceVersion()))
 
-	if res, stop, err := r.handleFinalizer(ctx, log, clusterInstance); !res.IsZero() || stop || err != nil {
+	if res, err := r.handleFinalizer(ctx, log, clusterInstance); !res.IsZero() || err != nil {
 		if err != nil {
 			log.Error("Encountered error while handling finalizer", zap.Error(err))
 		}
@@ -148,15 +162,15 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Render, validate and apply templates
-	ok, err := r.handleRenderTemplates(ctx, log, clusterInstance)
-	if err != nil {
+	if ok, err := r.handleRenderTemplates(ctx, log, clusterInstance); err != nil {
+		// Encountered an error, requeue the request
 		return requeueWithError(err)
+	} else if !ok {
+		// no error, however requeue required (e.g. wait for manifests to be pruned)
+		log.Info("Could not complete rendering templates, will try again")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	if ok {
-		log.Info("Finished rendering templates")
-	} else {
-		log.Info("Failed to render templates")
-	}
+	log.Info("Finished rendering templates")
 
 	// Only update the ObservedGeneration when all the above processes have been successfully executed
 	if clusterInstance.Status.ObservedGeneration != clusterInstance.ObjectMeta.Generation {
@@ -253,120 +267,84 @@ func (r *ClusterInstanceReconciler) applyACMBackupLabelToInstallTemplates(
 	return nil
 }
 
-func (r *ClusterInstanceReconciler) finalizeClusterInstance(
-	ctx context.Context,
-	log *zap.Logger,
-	clusterInstance *v1alpha1.ClusterInstance,
-) error {
-
-	// Group the manifests by the sync-wave
-	// This is so that the manifests can be deleted in descending order of sync-wave
-	manifestGroups := map[int][]v1alpha1.ManifestReference{}
-	for _, manifest := range clusterInstance.Status.ManifestsRendered {
-		// check if the key exists in the map
-		if _, ok := manifestGroups[manifest.SyncWave]; !ok {
-			// if key doesn't exist, initialize the slice
-			manifestGroups[manifest.SyncWave] = make([]v1alpha1.ManifestReference, 0)
-		}
-		// append the value to the slice associated with the key
-		manifestGroups[manifest.SyncWave] = append(manifestGroups[manifest.SyncWave], manifest)
-	}
-
-	syncWaves := maps.Keys(manifestGroups)
-	// Sort the syncWaves in descending order
-	sort.Sort(sort.Reverse(sort.IntSlice(syncWaves)))
-
-	for _, syncWave := range syncWaves {
-		for _, manifest := range manifestGroups[syncWave] {
-			obj := &unstructured.Unstructured{}
-			obj.SetName(manifest.Name)
-			obj.SetNamespace(manifest.Namespace)
-			obj.SetAPIVersion(*manifest.APIGroup)
-			obj.SetKind(manifest.Kind)
-
-			if err := r.deleteResource(
-				ctx,
-				log,
-				ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
-				obj,
-			); err != nil {
-				return err
-			}
-		}
-	}
-	log.Info("Successfully finalized ClusterInstance")
-	return nil
-}
-
-func (r *ClusterInstanceReconciler) deleteResource(
-	ctx context.Context,
-	log *zap.Logger,
-	owner string,
-	obj client.Object,
-) error {
-
-	resourceId := ci.GetResourceId(
-		obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(),
-	)
-	// Check that the manifest is logically owned-by the ClusterInstance
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-		if errors.IsNotFound(err) {
-			log.Sugar().Infof("Skipping deletion of resource %s not found", resourceId)
-			return nil
-		}
-		log.Sugar().Infof("Unable to retrieve resource %s for deletion", resourceId)
-		return err
-	}
-	labels := obj.GetLabels()
-	ownedBy, ok := labels[ci.OwnedByLabel]
-	if !ok || ownedBy != owner {
-		log.Sugar().Infof("Skipping deletion of resource %s not owned-by ClusterInstance %s", resourceId, owner)
-		return nil
-	}
-
-	// Delete resource
-	if err := r.Client.Delete(ctx, obj); err == nil {
-		log.Sugar().Infof("Successfully deleted resource %s", resourceId)
-	} else if !errors.IsNotFound(err) {
-		log.Sugar().Infof("Failed to delete resource %s", resourceId)
-		return err
-	}
-
-	return nil
-}
-
+// handleFinalizer ensures proper finalizer management for the ClusterInstance resource.
+// - Adds the finalizer if the object is not marked for deletion.
+// - Executes cleanup logic and removes the finalizer when the object is marked for deletion.
+// Returns a ctrl.Result to indicate whether the reconciler should requeue and an error if any operation fails.
 func (r *ClusterInstanceReconciler) handleFinalizer(
 	ctx context.Context,
 	log *zap.Logger,
 	clusterInstance *v1alpha1.ClusterInstance,
-) (ctrl.Result, bool, error) {
-	// Check if the ClusterInstance is marked to be deleted, which is
-	// indicated by the deletion timestamp being set.
-	if clusterInstance.DeletionTimestamp.IsZero() {
-		// Check and add finalizer for this CR.
-		if !controllerutil.ContainsFinalizer(clusterInstance, clusterInstanceFinalizer) {
-			controllerutil.AddFinalizer(clusterInstance, clusterInstanceFinalizer)
-			// update and requeue since the finalizer is added
-			return ctrl.Result{Requeue: true}, true, r.Update(ctx, clusterInstance)
-		}
-		return ctrl.Result{}, false, nil
-	} else if controllerutil.ContainsFinalizer(clusterInstance, clusterInstanceFinalizer) {
-		// Run finalization logic for clusterInstanceFinalizer. If the
-		// finalization logic fails, don't remove the finalizer so
-		// that we can retry during the next reconciliation.
-		if err := r.finalizeClusterInstance(ctx, log, clusterInstance); err != nil {
-			return ctrl.Result{}, true, err
-		}
+) (ctrl.Result, error) {
+	log = log.Named("handleFinalizer")
 
-		// Remove clusterInstanceFinalizer. Once all finalizers have been
-		// removed, the object will be deleted.
-		log.Info("Removing ClusterInstance finalizer")
-		patch := client.MergeFrom(clusterInstance.DeepCopy())
-		if controllerutil.RemoveFinalizer(clusterInstance, clusterInstanceFinalizer) {
-			return ctrl.Result{}, true, r.Patch(ctx, clusterInstance, patch)
-		}
+	// Check if ClusterInstance is not being deleted
+	if clusterInstance.DeletionTimestamp.IsZero() {
+		return r.ensureFinalizer(ctx, log, clusterInstance)
 	}
-	return ctrl.Result{}, false, nil
+
+	// ClusterInstance is being deleted
+	if !controllerutil.ContainsFinalizer(clusterInstance, clusterInstanceFinalizer) {
+		// Finalizer already removed; no action needed
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Running finalization logic for ClusterInstance")
+
+	// Perform cleanup logic
+	deletionCompleted, err := r.DeletionHandler.DeleteRenderedObjects(
+		ctx, clusterInstance, nil, ptr.To(deletion.DefaultDeletionTimeout))
+
+	if err != nil {
+		if cierrors.IsDeletionTimeoutError(err) {
+			log.Warn("Finalization timed out; deferring further attempts")
+			// Add hold annotation for manual intervention (CNF-15719)
+			return ctrl.Result{Requeue: false}, nil
+		}
+		log.Error("Finalization encountered an error", zap.Error(err))
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	if !deletionCompleted {
+		log.Info("Waiting for rendered manifests to be deleted")
+		return requeueForDeletion(), nil
+	}
+
+	// Finalization complete; remove the finalizer
+	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	controllerutil.RemoveFinalizer(clusterInstance, clusterInstanceFinalizer)
+
+	if err := r.Patch(ctx, clusterInstance, patch); err != nil {
+		log.Error("Failed to remove finalizer", zap.Error(err))
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Finalizer removed successfully")
+	return ctrl.Result{}, nil
+}
+
+// ensureFinalizer ensures the ClusterInstance has the required finalizer and requeues if it was added.
+func (r *ClusterInstanceReconciler) ensureFinalizer(
+	ctx context.Context,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (ctrl.Result, error) {
+	if controllerutil.ContainsFinalizer(clusterInstance, clusterInstanceFinalizer) {
+		// Finalizer already present; no action needed
+		return ctrl.Result{}, nil
+	}
+
+	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	controllerutil.AddFinalizer(clusterInstance, clusterInstanceFinalizer)
+
+	// Persist the finalizer addition
+	if err := r.Patch(ctx, clusterInstance, patch); err != nil {
+		log.Error("Failed to add finalizer", zap.Error(err))
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Finalizer added successfully; requeuing reconciliation")
+	return ctrl.Result{Requeue: true}, nil
 }
 
 func (r *ClusterInstanceReconciler) handleValidate(
@@ -467,10 +445,12 @@ func createOrPatch(
 	log *zap.Logger,
 	renderedObj unstructured.Unstructured,
 ) (controllerutil.OperationResult, error) {
+	log = log.Named("createOrPatch")
+
 	liveObj := &unstructured.Unstructured{}
 	liveObj.SetGroupVersionKind(renderedObj.GroupVersionKind())
 	if err := c.Get(ctx, client.ObjectKeyFromObject(&renderedObj), liveObj); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return controllerutil.OperationResultNone, err
 		}
 
@@ -524,8 +504,8 @@ func createOrPatch(
 	)
 	// Compute difference between the liveObject and updatedLiveObject without "status" fields
 	unstructured.RemoveNestedField(liveObj.Object, "status")
-	if !reflect.DeepEqual(liveObj, updatedLiveObj) {
-		log.Debug(fmt.Sprintf("Change detected in resource %s, updating it", resourceId))
+	if !equality.Semantic.DeepEqual(liveObj, updatedLiveObj) {
+		log.Sugar().Debugf("Change detected in resource %s, updating it", resourceId)
 
 		// Only issue a Patch if the before and after resources (minus status) differ
 		if err := c.Patch(ctx, updatedLiveObj, patch); err != nil {
@@ -534,26 +514,9 @@ func createOrPatch(
 		}
 		return controllerutil.OperationResultUpdated, nil
 	}
-	log.Debug(fmt.Sprintf("No change detected in resource %s, skipping update request", resourceId))
+	log.Sugar().Debugf("No change detected in resource %s, skipping update request", resourceId)
 
 	return controllerutil.OperationResultNone, nil
-}
-
-// createManifestReference creates a ManifestReference object from a manifest item
-func createManifestReference(object ci.RenderedObject) (*v1alpha1.ManifestReference, error) {
-	apiVersion := object.GetAPIVersion()
-	syncWave, err := object.GetSyncWave()
-	if err != nil {
-		return nil, err
-	}
-
-	return &v1alpha1.ManifestReference{
-		Name:            object.GetName(),
-		Namespace:       object.GetNamespace(),
-		Kind:            object.GetKind(),
-		APIGroup:        &apiVersion,
-		SyncWave:        syncWave,
-		LastAppliedTime: metav1.NewTime(time.Now())}, nil
 }
 
 func (r *ClusterInstanceReconciler) executeRenderedManifests(
@@ -565,71 +528,43 @@ func (r *ClusterInstanceReconciler) executeRenderedManifests(
 	manifestStatus string) (bool, error) {
 
 	ok := true
+
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	manifestsRendered := append([]v1alpha1.ManifestReference{}, clusterInstance.Status.ManifestsRendered...)
 
+	var errs []error
 	for _, object := range objects {
+		manifestRef := object.ManifestReference()
 
-		manifestRef, err := createManifestReference(object)
-		if err != nil {
-			return false, err
-		}
-
+		status := v1alpha1.ManifestRenderedFailure
+		message := ""
 		if result, err := createOrPatch(ctx, c, log, object.GetObject()); err != nil {
+			errs = append(errs, err)
 			ok = false
-			setManifestFailure(manifestRef, err)
+			message = err.Error()
 		} else if result != controllerutil.OperationResultNone {
-			setManifestSuccess(manifestRef, manifestStatus)
+			status = manifestStatus
 		}
+		manifestRef.UpdateStatus(status, message)
 
-		updateClusterInstanceStatus(clusterInstance, manifestRef)
-	}
-
-	return ok, conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch)
-}
-
-func setManifestFailure(manifestRef *v1alpha1.ManifestReference, err error) {
-	manifestRef.Status = v1alpha1.ManifestRenderedFailure
-	manifestRef.Message = err.Error()
-}
-
-func setManifestSuccess(manifestRef *v1alpha1.ManifestReference, manifestStatus string) {
-	manifestRef.Status = manifestStatus
-	manifestRef.Message = ""
-}
-
-func removeClusterInstanceStatus(clusterInstance *v1alpha1.ClusterInstance, manifestRef v1alpha1.ManifestReference) {
-	for index, m := range clusterInstance.Status.ManifestsRendered {
-		if *manifestRef.APIGroup == *m.APIGroup && manifestRef.Kind == m.Kind && manifestRef.Name == m.Name {
-			clusterInstance.Status.ManifestsRendered = append(
-				clusterInstance.Status.ManifestsRendered[:index],
-				clusterInstance.Status.ManifestsRendered[index+1:]...,
-			)
+		// Check if the manifestRef needs to be added to manifestsRendered
+		if index, err := v1alpha1.IndexOfManifestByIdentity(manifestRef, manifestsRendered); err != nil {
+			manifestsRendered = append(manifestsRendered, *manifestRef)
+		} else {
+			manifestsRendered[index].UpdateStatus(manifestRef.Status, manifestRef.Message)
 		}
 	}
-}
 
-func updateClusterInstanceStatus(clusterInstance *v1alpha1.ClusterInstance, manifestRef *v1alpha1.ManifestReference) {
-	if found := findManifestRendered(manifestRef, clusterInstance.Status.ManifestsRendered); found != nil {
-		if found.Status != manifestRef.Status || found.Message != manifestRef.Message {
-			found.LastAppliedTime = manifestRef.LastAppliedTime
-			found.Status = manifestRef.Status
-			found.Message = manifestRef.Message
-		}
-	} else {
-		clusterInstance.Status.ManifestsRendered = append(clusterInstance.Status.ManifestsRendered, *manifestRef)
-	}
-}
-
-func findManifestRendered(
-	manifest *v1alpha1.ManifestReference,
-	manifestList []v1alpha1.ManifestReference,
-) *v1alpha1.ManifestReference {
-	for index, m := range manifestList {
-		if *manifest.APIGroup == *m.APIGroup && manifest.Kind == m.Kind && manifest.Name == m.Name {
-			return &manifestList[index]
+	// Update ClusterInstance.Status.ManifestsRendered only if there are changes
+	if !equality.Semantic.DeepEqual(clusterInstance.Status.ManifestsRendered, manifestsRendered) {
+		clusterInstance.Status.ManifestsRendered = manifestsRendered
+		if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
+			log.Error("Failed to update ClusterInstance.Status.ManifestsRendered", zap.Error(updateErr))
+			errs = append(errs, updateErr)
 		}
 	}
-	return nil
+	return ok, utilerrors.NewAggregate(errs)
+
 }
 
 func (r *ClusterInstanceReconciler) validateRenderedManifests(
@@ -732,36 +667,34 @@ func (r *ClusterInstanceReconciler) pruneManifests(
 	clusterInstance *v1alpha1.ClusterInstance,
 	objects []ci.RenderedObject,
 ) (bool, error) {
-	ok := true
-	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	log = log.Named("pruneManifests")
 
-	for _, object := range objects {
-
-		apiGroup := object.GetAPIVersion()
-		manifestRef := v1alpha1.ManifestReference{
-			APIGroup:  &apiGroup,
-			Kind:      object.GetKind(),
-			Name:      object.GetName(),
-			Namespace: object.GetNamespace(),
-		}
-		obj := object.GetObject()
-		if err := r.deleteResource(
-			ctx,
-			log,
-			ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
-			&obj,
-		); err == nil {
-			// Remove rendered manifest information from status.RenderedManifests
-			removeClusterInstanceStatus(clusterInstance, manifestRef)
-		} else {
-			ok = false
-			manifestRef.Status = v1alpha1.ManifestPruneFailure
-			manifestRef.Message = err.Error()
-			updateClusterInstanceStatus(clusterInstance, &manifestRef)
-		}
+	if len(objects) == 0 {
+		log.Info("No objects to prune; skipping pruning operation")
+		return true, nil
 	}
 
-	return ok, conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch)
+	// Perform the deletion of objects
+	deletionCompleted, err := r.DeletionHandler.DeleteObjects(ctx, clusterInstance, objects, nil,
+		ptr.To(deletion.DefaultDeletionTimeout))
+
+	if err != nil {
+		if cierrors.IsDeletionTimeoutError(err) {
+			log.Warn("Pruning operation timed out; manual intervention may be required", zap.Error(err))
+			// Add hold annotation for manual intervention (CNF-15719)
+			return false, nil
+		}
+		log.Error("Pruning operation encountered an error", zap.Error(err))
+		return false, err
+	}
+
+	if deletionCompleted {
+		log.Info("Pruning operation completed successfully.")
+		return true, nil
+	}
+
+	log.Info("Pruning operation in progress; waiting for objects to be pruned")
+	return false, nil
 }
 
 func (r *ClusterInstanceReconciler) updateSuppressedManifestsStatus(
@@ -772,20 +705,32 @@ func (r *ClusterInstanceReconciler) updateSuppressedManifestsStatus(
 ) error {
 
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	manifestsRendered := append([]v1alpha1.ManifestReference{}, clusterInstance.Status.ManifestsRendered...)
 
 	for _, object := range objects {
-		resourceId := ci.GetResourceId(object.GetKind(), object.GetNamespace(), object.GetName())
-		manifestRef, err := createManifestReference(object)
-		if err != nil {
-			return err
-		}
+		resourceId := object.GetResourceId()
+		manifestRef := object.ManifestReference()
 		manifestRef.Status = v1alpha1.ManifestSuppressed
 		manifestRef.Message = ""
-		updateClusterInstanceStatus(clusterInstance, manifestRef)
+
+		// Check if the manifestRef needs to be added to manifestsRendered
+		if index, err := v1alpha1.IndexOfManifestByIdentity(manifestRef, manifestsRendered); err != nil {
+			manifestsRendered = append(manifestsRendered, *manifestRef)
+		} else {
+			manifestsRendered[index].UpdateStatus(manifestRef.Status, manifestRef.Message)
+		}
 		log.Sugar().Infof("Suppressed manifest %s", resourceId)
 	}
 
-	return conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch)
+	// Update ClusterInstance.Status.ManifestsRendered only if there are changes
+	if !equality.Semantic.DeepEqual(clusterInstance.Status.ManifestsRendered, manifestsRendered) {
+		clusterInstance.Status.ManifestsRendered = manifestsRendered
+		if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
+			log.Error("Failed to update ClusterInstance.Status.ManifestsRendered", zap.Error(updateErr))
+			return updateErr
+		}
+	}
+	return nil
 }
 
 func (r *ClusterInstanceReconciler) handleRenderTemplates(

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Reconcile", func() {
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
 		// Expect errors to occur in the ClusterInstance validations stage
 		Expect(err).To(HaveOccurred())
-		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(res).To(Equal(requeueWithDelay(DefaultValidationErrorDelay)))
 	})
 
 	It("pre-empts the reconcile-loop when the ObjectMeta.Generation and ObservedGeneration are the same", func() {

--- a/internal/controller/clusterinstance_controller_test.go
+++ b/internal/controller/clusterinstance_controller_test.go
@@ -21,16 +21,8 @@ import (
 	"fmt"
 	"os"
 
-	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/stolostron/siteconfig/api/v1alpha1"
-	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
-	"github.com/stolostron/siteconfig/internal/controller/configuration"
-	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
-	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,12 +30,28 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"k8s.io/utils/ptr"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/configuration"
+	"github.com/stolostron/siteconfig/internal/controller/deletion"
+	cierrors "github.com/stolostron/siteconfig/internal/controller/errors"
+	ai_templates "github.com/stolostron/siteconfig/internal/templates/assisted-installer"
+	ibi_templates "github.com/stolostron/siteconfig/internal/templates/image-based-installer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -78,11 +86,6 @@ const (
 	NMStateConfigKind       = "NMStateConfig"
 )
 
-func stringToStringPtr(s string) *string {
-	sPtr := s
-	return &sPtr
-}
-
 var _ = Describe("Reconcile", func() {
 	var (
 		c          client.Client
@@ -94,7 +97,6 @@ var _ = Describe("Reconcile", func() {
 			ClusterNamespace: TestClusterInstanceNamespace,
 			PullSecret:       TestPullSecret,
 		}
-
 		clusterInstance *v1alpha1.ClusterInstance
 	)
 
@@ -108,11 +110,12 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		r = &ClusterInstanceReconciler{
-			Client:      c,
-			Scheme:      scheme.Scheme,
-			Log:         testLogger,
-			TmplEngine:  ci.NewTemplateEngine(),
-			ConfigStore: configStore,
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			ConfigStore:     configStore,
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		Expect(c.Create(ctx, testParams.GeneratePullSecret())).To(Succeed())
@@ -215,6 +218,45 @@ var _ = Describe("handleFinalizer", func() {
 		clusterNamespace = TestClusterInstanceNamespace
 	)
 
+	ensureDeletionInProgressStatus := func(manifests []v1alpha1.ManifestReference) bool {
+		Expect(len(manifests)).To(BeNumerically(">", 0))
+		for _, m := range manifests {
+			Expect(m.Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		}
+		return true
+	}
+
+	var triggerAndVerifyFinalizerHandling = func(
+		r *ClusterInstanceReconciler,
+		clusterInstanceKey types.NamespacedName,
+		expectedNumManifestsToBeDeleted int,
+	) {
+		// Trigger deletion of ClusterInstance.
+		clusterInstance := &v1alpha1.ClusterInstance{}
+		Expect(r.Client.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+		Expect(r.Client.Delete(ctx, clusterInstance)).To(Succeed())
+
+		// Fetch the ClusterInstance to get the DeletionTimestamp.
+		Expect(r.Client.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+
+		// First call of r.handleFinalizer should trigger deletion of rendered manifests.
+		res, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(requeueForDeletion()))
+		Expect(r.Client.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+
+		Expect(len(clusterInstance.Status.ManifestsRendered)).To(Equal(expectedNumManifestsToBeDeleted))
+		Expect(clusterInstance.Status.ManifestsRendered).To(Satisfy(ensureDeletionInProgressStatus))
+
+		// Second call of r.handleFinalizer should result in the deletion of all the rendered objects.
+		res, err = r.handleFinalizer(ctx, testLogger, clusterInstance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Check that the ClusterInstance is deleted.
+		Expect(r.Client.Get(ctx, clusterInstanceKey, clusterInstance)).ToNot(Succeed())
+	}
+
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().
 			WithScheme(scheme.Scheme).
@@ -222,9 +264,10 @@ var _ = Describe("handleFinalizer", func() {
 			Build()
 
 		r = &ClusterInstanceReconciler{
-			Client: c,
-			Scheme: scheme.Scheme,
-			Log:    testLogger,
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 	})
 
@@ -237,16 +280,11 @@ var _ = Describe("handleFinalizer", func() {
 		}
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
 
-		res, stop, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
+		res, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
 		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
-		Expect(stop).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 
-		key := types.NamespacedName{
-			Name:      clusterName,
-			Namespace: clusterNamespace,
-		}
-		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
 		Expect(clusterInstance.GetFinalizers()).To(ContainElement(clusterInstanceFinalizer))
 	})
 
@@ -260,9 +298,8 @@ var _ = Describe("handleFinalizer", func() {
 		}
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
 
-		res, stop, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
+		res, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
 		Expect(res).To(Equal(ctrl.Result{}))
-		Expect(stop).To(BeFalse())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -280,7 +317,7 @@ var _ = Describe("handleFinalizer", func() {
 			Status: v1alpha1.ClusterInstanceStatus{
 				ManifestsRendered: []v1alpha1.ManifestReference{
 					{
-						APIGroup:  stringToStringPtr(ClusterDeploymentApiVersion),
+						APIGroup:  ptr.To(ClusterDeploymentApiVersion),
 						Kind:      ClusterDeploymentKind,
 						Name:      manifestName,
 						Namespace: clusterNamespace,
@@ -288,7 +325,7 @@ var _ = Describe("handleFinalizer", func() {
 						Status:    v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+						APIGroup:  ptr.To(BareMetalHostApiVersion),
 						Kind:      BareMetalHostKind,
 						Name:      manifestName,
 						Namespace: clusterNamespace,
@@ -296,14 +333,14 @@ var _ = Describe("handleFinalizer", func() {
 						Status:    v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup: stringToStringPtr(ManagedClusterApiVersion),
+						APIGroup: ptr.To(ManagedClusterApiVersion),
 						Kind:     ManagedClusterKind,
 						Name:     manifestName,
 						SyncWave: 3,
 						Status:   v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup:  stringToStringPtr(V1ApiVersion),
+						APIGroup:  ptr.To(V1ApiVersion),
 						Kind:      ConfigMapKind,
 						Name:      manifest2Name,
 						Namespace: clusterNamespace,
@@ -311,7 +348,7 @@ var _ = Describe("handleFinalizer", func() {
 						Status:    v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup:  stringToStringPtr(V1ApiVersion),
+						APIGroup:  ptr.To(V1ApiVersion),
 						Kind:      ConfigMapKind,
 						Name:      manifestName,
 						Namespace: clusterNamespace,
@@ -396,25 +433,21 @@ var _ = Describe("handleFinalizer", func() {
 		Expect(c.Get(ctx, key2, cm)).To(Succeed())
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
 
-		// Set the deletionTimestamp to force deletion of siteconfig manifests
-		deletionTimeStamp := metav1.Now()
-		clusterInstance.ObjectMeta.DeletionTimestamp = &deletionTimeStamp
+		clusterInstanceKey := client.ObjectKeyFromObject(clusterInstance)
+		expectedNumManifestsToBeDeleted := 3 // ClusterDeployment, BareMetalHost, ManagedCluster
+		triggerAndVerifyFinalizerHandling(r, clusterInstanceKey, expectedNumManifestsToBeDeleted)
 
-		// Expect the manifests previously created to be deleted after the handleFinalizer is called
-		res, stop, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
-		Expect(res).To(Equal(ctrl.Result{}))
-		Expect(stop).To(BeTrue())
-		Expect(err).ToNot(HaveOccurred())
-
+		// Verify ClusterDeployment, BareMetalHost, ManagedCluster manifests are deleted
 		Expect(c.Get(ctx, key, cd)).ToNot(Succeed())
 		Expect(c.Get(ctx, key, bmh)).ToNot(Succeed())
 		Expect(c.Get(ctx, keyMc, mc)).ToNot(Succeed())
+
+		// Verify both ConfigMap manifests are NOT deleted
 		Expect(c.Get(ctx, key2, cm)).To(Succeed())
 		Expect(c.Get(ctx, key, cm)).To(Succeed())
 	})
 
 	It("does not fail to handle the finalizer when attempting to delete a missing manifest", func() {
-
 		manifestName := TestClusterInstanceName
 		clusterInstance := &v1alpha1.ClusterInstance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -425,7 +458,7 @@ var _ = Describe("handleFinalizer", func() {
 			Status: v1alpha1.ClusterInstanceStatus{
 				ManifestsRendered: []v1alpha1.ManifestReference{
 					{
-						APIGroup:  stringToStringPtr(ClusterDeploymentApiVersion),
+						APIGroup:  ptr.To(ClusterDeploymentApiVersion),
 						Kind:      ClusterDeploymentKind,
 						Name:      manifestName,
 						Namespace: TestClusterInstanceNamespace,
@@ -433,15 +466,16 @@ var _ = Describe("handleFinalizer", func() {
 						Status:    v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+						// BMH resource will not be created
+						APIGroup:  ptr.To(BareMetalHostApiVersion),
 						Kind:      BareMetalHostKind,
 						Name:      manifestName,
-						Namespace: clusterNamespace,
+						Namespace: TestClusterInstanceNamespace,
 						SyncWave:  2,
 						Status:    v1alpha1.ManifestRenderedSuccess,
 					},
 					{
-						APIGroup: stringToStringPtr(ManagedClusterApiVersion),
+						APIGroup: ptr.To(ManagedClusterApiVersion),
 						Kind:     ManagedClusterKind,
 						Name:     manifestName,
 						SyncWave: 3,
@@ -456,7 +490,7 @@ var _ = Describe("handleFinalizer", func() {
 		cd := &hivev1.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      manifestName,
-				Namespace: clusterNamespace,
+				Namespace: TestClusterInstanceNamespace,
 				Labels: map[string]string{
 					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
 				},
@@ -474,10 +508,10 @@ var _ = Describe("handleFinalizer", func() {
 		}
 		Expect(c.Create(ctx, mc)).To(Succeed())
 
-		// Get the created manfiests to confirm they exist before calling finalizer
+		// Get the created manifests to confirm they exist before calling finalizer
 		key := types.NamespacedName{
 			Name:      manifestName,
-			Namespace: clusterNamespace,
+			Namespace: TestClusterInstanceNamespace,
 		}
 		keyMc := types.NamespacedName{
 			Name: manifestName,
@@ -489,20 +523,97 @@ var _ = Describe("handleFinalizer", func() {
 		bmh := &bmh_v1alpha1.BareMetalHost{}
 		Expect(c.Get(ctx, key, bmh)).ToNot(Succeed())
 
-		// Set the deletionTimestamp to force deletion of siteconfig manifests
-		deletionTimeStamp := metav1.Now()
-		clusterInstance.ObjectMeta.DeletionTimestamp = &deletionTimeStamp
+		clusterInstanceKey := client.ObjectKeyFromObject(clusterInstance)
+		expectedNumManifestsToBeDeleted := 2 // ClusterDeployment, ManagedCluster
+		triggerAndVerifyFinalizerHandling(r, clusterInstanceKey, expectedNumManifestsToBeDeleted)
 
-		// Expect the manifests previously created to be deleted after the handleFinalizer is called
-		res, stop, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
-		Expect(res).To(Equal(ctrl.Result{}))
-		Expect(stop).To(BeTrue())
-		Expect(err).ToNot(HaveOccurred())
-
+		// Ensure that rendered manifests are deleted
 		Expect(c.Get(ctx, key, cd)).ToNot(Succeed())
 		Expect(c.Get(ctx, keyMc, mc)).ToNot(Succeed())
 	})
 
+	When("a timeout occurs", func() {
+		It("does not requeue the reconciler", func() {
+
+			deleteWithoutTimeout := false
+			testClient := fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return c.Get(ctx, key, obj, opts...)
+				},
+				Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return c.Create(ctx, obj, opts...)
+				},
+				Delete: func(ctx context.Context, fclient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if deleteWithoutTimeout {
+						return c.Delete(ctx, obj, opts...)
+					}
+					return cierrors.NewDeletionTimeoutError("")
+				},
+				Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return c.Status().Patch(ctx, obj, patch, opts...)
+				},
+			}).Build()
+
+			r = &ClusterInstanceReconciler{
+				Client:          testClient,
+				Scheme:          scheme.Scheme,
+				Log:             testLogger,
+				DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
+			}
+
+			manifestName := TestClusterInstanceName
+			clusterInstance := &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       clusterName,
+					Namespace:  clusterNamespace,
+					Finalizers: []string{clusterInstanceFinalizer},
+				},
+				Status: v1alpha1.ClusterInstanceStatus{
+					ManifestsRendered: []v1alpha1.ManifestReference{
+						{
+							APIGroup:  ptr.To(ClusterDeploymentApiVersion),
+							Kind:      ClusterDeploymentKind,
+							Name:      manifestName,
+							Namespace: clusterNamespace,
+							SyncWave:  1,
+							Status:    v1alpha1.ManifestRenderedSuccess,
+						},
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, clusterInstance)).To(Succeed())
+
+			// Create BareMetalHost object
+			bmh := &bmh_v1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      manifestName,
+					Namespace: clusterNamespace,
+					Labels: map[string]string{
+						ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name),
+					},
+					Finalizers: []string{"block-deletion"},
+				},
+			}
+			Expect(testClient.Create(ctx, bmh)).To(Succeed())
+
+			// Delete ClusterInstance for finalizer
+			deleteWithoutTimeout = true
+			Expect(testClient.Delete(ctx, clusterInstance)).To(Succeed())
+
+			// Enable trigger timeout error on deletion
+			deleteWithoutTimeout = false
+
+			// Fetch the ClusterInstance to get the DeletionTimestamp
+			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+
+			res, err := r.handleFinalizer(ctx, testLogger, clusterInstance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(ctrl.Result{Requeue: false}))
+		})
+	})
 })
 
 var _ = Describe("pruneManifests", func() {
@@ -526,7 +637,9 @@ var _ = Describe("pruneManifests", func() {
 		// list of keys
 		objectKeys []types.NamespacedName
 
-		verifyPruningFn = func(pruneList, doNotPruneList []ci.RenderedObject, pruneKeys, doNotPruneKeys []types.NamespacedName) {
+		manifestsRenderedRefs []v1alpha1.ManifestReference
+
+		verifyPruningFn = func(clusterInstanceKey types.NamespacedName, pruneList, doNotPruneList []ci.RenderedObject, pruneKeys, doNotPruneKeys []types.NamespacedName) {
 			Expect(len(pruneList)).To(Equal(len(pruneKeys)))
 			Expect(len(doNotPruneList)).To(Equal(len(doNotPruneKeys)))
 
@@ -543,6 +656,29 @@ var _ = Describe("pruneManifests", func() {
 				obj2.SetGroupVersionKind(obj.GroupVersionKind())
 				Expect(c.Get(ctx, doNotPruneKeys[index], obj2)).To(Succeed())
 			}
+
+			// Verify that clusterInstance.status.RenderedManifests are updated on second run of pruneManifests
+			clusterInstance := &v1alpha1.ClusterInstance{}
+			Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+			Expect(clusterInstance.Status.ManifestsRendered).To(Satisfy(func(manifests []v1alpha1.ManifestReference) bool {
+				for _, obj := range doNotPruneList {
+					if obj.GetName() != clusterInstanceKey.Name {
+						continue
+					}
+					_, err := v1alpha1.IndexOfManifestByIdentity(obj.ManifestReference(), manifests)
+					Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("object (%s) should be in RenderedManifests", obj.GetResourceId()))
+				}
+
+				for _, obj := range pruneList {
+					if obj.GetName() != clusterInstanceKey.Name {
+						continue
+					}
+					_, err := v1alpha1.IndexOfManifestByIdentity(obj.ManifestReference(), manifests)
+					Expect(err).To(HaveOccurred(), fmt.Sprintf("object (%s) should not be in RenderedManifests [%v]", obj.GetResourceId(), manifests))
+				}
+
+				return true
+			}))
 		}
 	)
 
@@ -553,10 +689,11 @@ var _ = Describe("pruneManifests", func() {
 			Build()
 
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		annotations := map[string]string{
@@ -651,12 +788,15 @@ var _ = Describe("pruneManifests", func() {
 		objectKeys = []types.NamespacedName{cdKey, bmh1Key, bmh2Key, mcKey, cm1Key, cm2Key}
 
 		// Create the manifests and confirm they exist
+		manifestsRenderedRefs = []v1alpha1.ManifestReference(nil)
 		for index, object := range objects {
 			obj := object.GetObject()
 			Expect(c.Create(ctx, &obj)).To(Succeed())
 			obj2 := &unstructured.Unstructured{}
 			obj2.SetGroupVersionKind(obj.GroupVersionKind())
 			Expect(c.Get(ctx, objectKeys[index], obj2)).To(Succeed())
+
+			manifestsRenderedRefs = append(manifestsRenderedRefs, *object.ManifestReference())
 		}
 	})
 
@@ -670,10 +810,11 @@ var _ = Describe("pruneManifests", func() {
 		doNotPruneList := []ci.RenderedObject{}
 		doNotPruneKeys := []types.NamespacedName{}
 
+		clusterInstanceKey := types.NamespacedName{Namespace: TestClusterInstanceNamespace, Name: TestClusterInstanceName}
 		clusterInstance := &v1alpha1.ClusterInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      TestClusterInstanceName,
-				Namespace: TestClusterInstanceNamespace,
+				Name:      clusterInstanceKey.Name,
+				Namespace: clusterInstanceKey.Namespace,
 			},
 			Spec: v1alpha1.ClusterInstanceSpec{
 				PruneManifests: []v1alpha1.ResourceRef{
@@ -703,20 +844,33 @@ var _ = Describe("pruneManifests", func() {
 					},
 				},
 			},
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: manifestsRenderedRefs,
+			},
 		}
 		// Create the ClusterInstance CR
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
 
-		ok, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
+		// key := client.ObjectKeyFromObject(clusterInstance)
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+		pruningCompleted, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ok).To(BeTrue())
+		Expect(pruningCompleted).To(BeFalse())
+
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+		for _, m := range clusterInstance.Status.ManifestsRendered {
+			Expect(m.Status).Should(Equal(v1alpha1.ManifestDeletionInProgress))
+		}
+
+		pruningCompleted, err = r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pruningCompleted).To(BeTrue())
 
 		// Expect the objects previously created to be deleted after pruneManifests is called
-		verifyPruningFn(pruneList, doNotPruneList, pruneKeys, doNotPruneKeys)
+		verifyPruningFn(clusterInstanceKey, pruneList, doNotPruneList, pruneKeys, doNotPruneKeys)
 	})
 
 	It("prunes manifests defined at the node-level", func() {
-
 		pruneList := []ci.RenderedObject{bmh1RenderedObject}
 		pruneKeys := []types.NamespacedName{bmh1Key}
 
@@ -725,10 +879,11 @@ var _ = Describe("pruneManifests", func() {
 		}
 		doNotPruneKeys := []types.NamespacedName{cdKey, bmh2Key, mcKey, cm1Key, cm2Key}
 
+		clusterInstanceKey := types.NamespacedName{Namespace: TestClusterInstanceNamespace, Name: TestClusterInstanceName}
 		clusterInstance := &v1alpha1.ClusterInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      TestClusterInstanceName,
-				Namespace: TestClusterInstanceNamespace,
+				Name:      clusterInstanceKey.Name,
+				Namespace: clusterInstanceKey.Namespace,
 			},
 			Spec: v1alpha1.ClusterInstanceSpec{
 				PruneManifests: []v1alpha1.ResourceRef{},
@@ -747,16 +902,40 @@ var _ = Describe("pruneManifests", func() {
 					},
 				},
 			},
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: manifestsRenderedRefs,
+			},
 		}
 		// Create the ClusterInstance CR
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
 
-		ok, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+
+		pruningCompleted, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ok).To(BeTrue())
+		Expect(pruningCompleted).To(BeFalse())
+
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(Satisfy(func(manifests []v1alpha1.ManifestReference) bool {
+			for _, obj := range pruneList {
+				obj.ManifestReference()
+				index, err := v1alpha1.IndexOfManifestByIdentity(obj.ManifestReference(), manifests)
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("object %s missing from RenderedManifests", obj.GetResourceId()))
+				Expect(manifests[index].Status).To(Equal(v1alpha1.ManifestDeletionInProgress),
+					fmt.Sprintf("object's %s status should be %s", obj.GetResourceId(), v1alpha1.ManifestDeletionInProgress))
+			}
+			return true
+		}))
+
+		pruningCompleted, err = r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pruningCompleted).To(BeTrue())
+
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
 
 		// Expect the objects previously created to be deleted after pruneManifests is called
-		verifyPruningFn(pruneList, doNotPruneList, pruneKeys, doNotPruneKeys)
+		verifyPruningFn(clusterInstanceKey, pruneList, doNotPruneList, pruneKeys, doNotPruneKeys)
 	})
 
 	It("does not prune manifests not-owned by the ClusterInstance", func() {
@@ -770,10 +949,11 @@ var _ = Describe("pruneManifests", func() {
 		}
 		doNotPruneKeys := []types.NamespacedName{cdKey, bmh1Key, bmh2Key, mcKey, cm1Key, cm2Key}
 
+		clusterInstanceKey := types.NamespacedName{Namespace: TestClusterInstanceNamespace, Name: "not-the-owner"}
 		clusterInstance := &v1alpha1.ClusterInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "not-the-owner",
-				Namespace: TestClusterInstanceNamespace,
+				Name:      clusterInstanceKey.Name,
+				Namespace: clusterInstanceKey.Namespace,
 			},
 			Spec: v1alpha1.ClusterInstanceSpec{
 				PruneManifests: []v1alpha1.ResourceRef{
@@ -801,18 +981,24 @@ var _ = Describe("pruneManifests", func() {
 					},
 				},
 			},
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: manifestsRenderedRefs,
+			},
 		}
 		// Create the ClusterInstance CR
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
 
-		ok, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ok).To(BeTrue())
-
-		// Expect the objects previously created to be deleted after pruneManifests is called
+		// Expect the objects previously created to not be deleted after pruneManifests is called
 		expectedPruneList := []ci.RenderedObject{}
 		expectedPruneKeys := []types.NamespacedName{}
-		verifyPruningFn(expectedPruneList, doNotPruneList, expectedPruneKeys, doNotPruneKeys)
+
+		Expect(c.Get(ctx, clusterInstanceKey, clusterInstance)).To(Succeed())
+		pruningCompleted, err := r.pruneManifests(ctx, testLogger, clusterInstance, pruneList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pruningCompleted).To(BeTrue())
+
+		verifyPruningFn(clusterInstanceKey, expectedPruneList, doNotPruneList, expectedPruneKeys, doNotPruneKeys)
+
 	})
 
 })
@@ -843,10 +1029,11 @@ var _ = Describe("handleValidate", func() {
 			Build()
 
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		ci.SetupTestResources(ctx, c, testParams)
@@ -982,10 +1169,11 @@ var _ = Describe("handleRenderTemplates", func() {
 			Build()
 
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		ci.SetupTestResources(ctx, c, testParams)
@@ -1161,10 +1349,11 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 		testLogger := zap.NewNop().Named("Test")
 
 		r := &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		clusterInstance := &v1alpha1.ClusterInstance{
@@ -1192,7 +1381,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			Status: v1alpha1.ClusterInstanceStatus{
 				ManifestsRendered: []v1alpha1.ManifestReference{
 					{
-						APIGroup:  stringToStringPtr(ClusterDeploymentApiVersion),
+						APIGroup:  ptr.To(ClusterDeploymentApiVersion),
 						Kind:      ClusterDeploymentKind,
 						Name:      TestClusterInstanceName,
 						Namespace: TestClusterInstanceNamespace,
@@ -1200,7 +1389,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 						SyncWave:  0,
 					},
 					{
-						APIGroup:  stringToStringPtr(AgentClusterInstallApiVersion),
+						APIGroup:  ptr.To(AgentClusterInstallApiVersion),
 						Kind:      AgentClusterInstallKind,
 						Name:      TestClusterInstanceName,
 						Namespace: TestClusterInstanceNamespace,
@@ -1208,7 +1397,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 						SyncWave:  0,
 					},
 					{
-						APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+						APIGroup:  ptr.To(BareMetalHostApiVersion),
 						Kind:      BareMetalHostKind,
 						Name:      TestNode1Hostname,
 						Namespace: TestClusterInstanceNamespace,
@@ -1216,7 +1405,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 						SyncWave:  0,
 					},
 					{
-						APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+						APIGroup:  ptr.To(BareMetalHostApiVersion),
 						Kind:      BareMetalHostKind,
 						Name:      TestNode2Hostname,
 						Namespace: TestClusterInstanceNamespace,
@@ -1224,7 +1413,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 						SyncWave:  0,
 					},
 					{
-						APIGroup:  stringToStringPtr(NMStateConfigApiVersion),
+						APIGroup:  ptr.To(NMStateConfigApiVersion),
 						Kind:      NMStateConfigKind,
 						Name:      TestNode1Hostname,
 						Namespace: TestClusterInstanceNamespace,
@@ -1232,7 +1421,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 						SyncWave:  0,
 					},
 					{
-						APIGroup:  stringToStringPtr(NMStateConfigApiVersion),
+						APIGroup:  ptr.To(NMStateConfigApiVersion),
 						Kind:      NMStateConfigKind,
 						Name:      TestNode2Hostname,
 						Namespace: TestClusterInstanceNamespace,
@@ -1308,9 +1497,9 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 		}
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
 		for _, expManifest := range args.ExpectedManifests {
-			manifest := findManifestRendered(&expManifest, clusterInstance.Status.ManifestsRendered)
-			Expect(manifest).ToNot(BeNil())
-			Expect(manifest.Status).To(Equal(expManifest.Status))
+			index, err := v1alpha1.IndexOfManifestByIdentity(&expManifest, clusterInstance.Status.ManifestsRendered)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterInstance.Status.ManifestsRendered[index].Status).To(Equal(expManifest.Status))
 		}
 	},
 
@@ -1321,7 +1510,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			NodeLevelSuppressedManifests:    [][]string{{}, {}},
 			ExpectedManifests: []v1alpha1.ManifestReference{
 				{
-					APIGroup:  stringToStringPtr(ClusterDeploymentApiVersion),
+					APIGroup:  ptr.To(ClusterDeploymentApiVersion),
 					Kind:      ClusterDeploymentKind,
 					Name:      TestClusterInstanceName,
 					Namespace: TestClusterInstanceNamespace,
@@ -1329,7 +1518,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 					SyncWave:  0,
 				},
 				{
-					APIGroup:  stringToStringPtr(AgentClusterInstallApiVersion),
+					APIGroup:  ptr.To(AgentClusterInstallApiVersion),
 					Kind:      AgentClusterInstallKind,
 					Name:      TestClusterInstanceName,
 					Namespace: TestClusterInstanceNamespace,
@@ -1337,7 +1526,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 					SyncWave:  0,
 				},
 				{
-					APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
 					Kind:      BareMetalHostKind,
 					Name:      TestNode1Hostname,
 					Namespace: TestClusterInstanceNamespace,
@@ -1345,7 +1534,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 					SyncWave:  0,
 				},
 				{
-					APIGroup:  stringToStringPtr(BareMetalHostApiVersion),
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
 					Kind:      BareMetalHostKind,
 					Name:      TestNode2Hostname,
 					Namespace: TestClusterInstanceNamespace,
@@ -1353,7 +1542,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 					SyncWave:  0,
 				},
 				{
-					APIGroup:  stringToStringPtr(NMStateConfigApiVersion),
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
 					Kind:      NMStateConfigKind,
 					Name:      TestNode1Hostname,
 					Namespace: TestClusterInstanceNamespace,
@@ -1361,7 +1550,7 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 					SyncWave:  0,
 				},
 				{
-					APIGroup:  stringToStringPtr(NMStateConfigApiVersion),
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
 					Kind:      NMStateConfigKind,
 					Name:      TestNode2Hostname,
 					Namespace: TestClusterInstanceNamespace,
@@ -1378,40 +1567,46 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			NodeLevelSuppressedManifests:    [][]string{{}, {}},
 			ExpectedManifests: []v1alpha1.ManifestReference{
 				{
-					APIGroup: stringToStringPtr(ClusterDeploymentApiVersion),
-					Kind:     ClusterDeploymentKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(ClusterDeploymentApiVersion),
+					Kind:      ClusterDeploymentKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(AgentClusterInstallApiVersion),
-					Kind:     AgentClusterInstallKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(AgentClusterInstallApiVersion),
+					Kind:      AgentClusterInstallKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 			},
 		}),
@@ -1426,40 +1621,46 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			},
 			ExpectedManifests: []v1alpha1.ManifestReference{
 				{
-					APIGroup: stringToStringPtr(ClusterDeploymentApiVersion),
-					Kind:     ClusterDeploymentKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(ClusterDeploymentApiVersion),
+					Kind:      ClusterDeploymentKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(AgentClusterInstallApiVersion),
-					Kind:     AgentClusterInstallKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(AgentClusterInstallApiVersion),
+					Kind:      AgentClusterInstallKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 			},
 		}),
@@ -1471,40 +1672,46 @@ var _ = DescribeTable("updateSuppressedManifestsStatus",
 			NodeLevelSuppressedManifests:    [][]string{{""}, {""}},
 			ExpectedManifests: []v1alpha1.ManifestReference{
 				{
-					APIGroup: stringToStringPtr(ClusterDeploymentApiVersion),
-					Kind:     ClusterDeploymentKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(ClusterDeploymentApiVersion),
+					Kind:      ClusterDeploymentKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(AgentClusterInstallApiVersion),
-					Kind:     AgentClusterInstallKind,
-					Name:     TestClusterInstanceName,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(AgentClusterInstallApiVersion),
+					Kind:      AgentClusterInstallKind,
+					Name:      TestClusterInstanceName,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(BareMetalHostApiVersion),
-					Kind:     BareMetalHostKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestSuppressed,
+					APIGroup:  ptr.To(BareMetalHostApiVersion),
+					Kind:      BareMetalHostKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestSuppressed,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode1Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode1Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 				{
-					APIGroup: stringToStringPtr(NMStateConfigApiVersion),
-					Kind:     NMStateConfigKind,
-					Name:     TestNode2Hostname,
-					Status:   v1alpha1.ManifestRenderedSuccess,
+					APIGroup:  ptr.To(NMStateConfigApiVersion),
+					Kind:      NMStateConfigKind,
+					Name:      TestNode2Hostname,
+					Namespace: TestClusterInstanceNamespace,
+					Status:    v1alpha1.ManifestRenderedSuccess,
 				},
 			},
 		}),
@@ -1526,9 +1733,10 @@ var _ = Describe("executeRenderedManifests", func() {
 		}
 		apiGroup    = "ClusterDeploymentApiVersion"
 		expManifest = v1alpha1.ManifestReference{
-			APIGroup: &apiGroup,
-			Kind:     ClusterDeploymentKind,
-			Name:     clusterName,
+			APIGroup:  &apiGroup,
+			Kind:      ClusterDeploymentKind,
+			Name:      clusterName,
+			Namespace: clusterNamespace,
 		}
 		objects []ci.RenderedObject
 	)
@@ -1540,10 +1748,11 @@ var _ = Describe("executeRenderedManifests", func() {
 			Build()
 
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: ci.NewTemplateEngine(),
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      ci.NewTemplateEngine(),
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		clusterInstance = &v1alpha1.ClusterInstance{
@@ -1597,9 +1806,9 @@ var _ = Describe("executeRenderedManifests", func() {
 
 		// Verify ClusterInstance status
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
-		manifest := findManifestRendered(&expManifest, clusterInstance.Status.ManifestsRendered)
-		Expect(manifest).ToNot(BeNil())
-		Expect(manifest.Status).To(Equal(expManifest.Status))
+		index, err := v1alpha1.IndexOfManifestByIdentity(&expManifest, clusterInstance.Status.ManifestsRendered)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(clusterInstance.Status.ManifestsRendered[index].Status).To(Equal(expManifest.Status))
 	})
 
 	It("fails to apply the manifest due to an error while creating the kubernetes resource", func() {
@@ -1618,17 +1827,20 @@ var _ = Describe("executeRenderedManifests", func() {
 		}).Build()
 
 		result, err := r.executeRenderedManifests(ctx, testClient, testLogger, clusterInstance, objects, v1alpha1.ManifestRenderedSuccess)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(testError))
 		Expect(result).To(BeFalse())
 		Expect(called).To(BeTrue())
 
 		// Verify ClusterInstance status
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
-		manifest := findManifestRendered(&expManifest, clusterInstance.Status.ManifestsRendered)
-		Expect(manifest).ToNot(BeNil())
-		Expect(manifest.Status).To(Equal(expManifest.Status))
-		Expect(manifest.Message).To(ContainSubstring(testError))
-
+		index, err := v1alpha1.IndexOfManifestByIdentity(&expManifest, clusterInstance.Status.ManifestsRendered)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(clusterInstance.Status.ManifestsRendered[index]).To(Satisfy(func(manifest v1alpha1.ManifestReference) bool {
+			Expect(manifest.Status).To(Equal(expManifest.Status))
+			Expect(manifest.Message).To(ContainSubstring(testError))
+			return true
+		}))
 	})
 
 	It("succeeds in updating a manifest", func() {
@@ -1652,9 +1864,9 @@ var _ = Describe("executeRenderedManifests", func() {
 
 		// Verify ClusterInstance status
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
-		manifest := findManifestRendered(&expManifest, clusterInstance.Status.ManifestsRendered)
-		Expect(manifest).ToNot(BeNil())
-		Expect(manifest.Status).To(Equal(expManifest.Status))
+		index, err := v1alpha1.IndexOfManifestByIdentity(&expManifest, clusterInstance.Status.ManifestsRendered)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(clusterInstance.Status.ManifestsRendered[index].Status).To(Equal(expManifest.Status))
 	})
 
 	It("fails to update the manifest due to an error while patching the kubernetes resource", func() {
@@ -1673,16 +1885,20 @@ var _ = Describe("executeRenderedManifests", func() {
 		}).Build()
 
 		result, err := r.executeRenderedManifests(ctx, testClient, testLogger, clusterInstance, objects, expManifest.Status)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(testError))
 		Expect(result).To(BeFalse())
 		Expect(called).To(BeTrue())
 
 		// Verify ClusterInstance status
 		Expect(c.Get(ctx, key, clusterInstance)).To(Succeed())
-		manifest := findManifestRendered(&expManifest, clusterInstance.Status.ManifestsRendered)
-		Expect(manifest).ToNot(BeNil())
-		Expect(manifest.Status).To(Equal(expManifest.Status))
-		Expect(manifest.Message).To(ContainSubstring(testError))
+		index, err := v1alpha1.IndexOfManifestByIdentity(&expManifest, clusterInstance.Status.ManifestsRendered)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(clusterInstance.Status.ManifestsRendered[index]).To(Satisfy(func(manifest v1alpha1.ManifestReference) bool {
+			Expect(manifest.Status).To(Equal(expManifest.Status))
+			Expect(manifest.Message).To(ContainSubstring(testError))
+			return true
+		}))
 	})
 
 })
@@ -1867,10 +2083,11 @@ var _ = Describe("applyACMBackupLabelToInstallTemplates", func() {
 			Build()
 		tmplEngine := ci.NewTemplateEngine()
 		r = &ClusterInstanceReconciler{
-			Client:     c,
-			Scheme:     scheme.Scheme,
-			Log:        testLogger,
-			TmplEngine: tmplEngine,
+			Client:          c,
+			Scheme:          scheme.Scheme,
+			Log:             testLogger,
+			TmplEngine:      tmplEngine,
+			DeletionHandler: &deletion.DeletionHandler{Client: c, Logger: testLogger},
 		}
 
 		siteConfigNS := &corev1.Namespace{

--- a/internal/controller/deletion/deletion.go
+++ b/internal/controller/deletion/deletion.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
+	cierrors "github.com/stolostron/siteconfig/internal/controller/errors"
+)
+
+const DefaultDeletionTimeout = 30 * time.Minute
+
+type DeletionHandler struct {
+	Client client.Client
+	Logger *zap.Logger
+}
+
+// DeleteRenderedObjects deletes all rendered objects except those explicitly excluded.
+func (d *DeletionHandler) DeleteRenderedObjects(
+	ctx context.Context,
+	clusterInstance *v1alpha1.ClusterInstance,
+	excludeObjects []ci.RenderedObject,
+	deletionTimeout *time.Duration,
+) (bool, error) {
+	log := d.Logger.With(
+		zap.String("ClusterInstance", fmt.Sprintf("%s/%s", clusterInstance.Namespace, clusterInstance.Name)),
+	)
+
+	if len(clusterInstance.Status.ManifestsRendered) == 0 {
+		log.Info("The manifestsRendered list is empty, nothing to delete")
+		return true, nil
+	}
+
+	objects := objectsForClusterInstance(clusterInstance)
+	return d.DeleteObjects(ctx, clusterInstance, objects, excludeObjects, deletionTimeout)
+}
+
+// DeleteObjects deletes the ClusterInstance rendered manifests by syncWaveGroup.
+// SyncWaves are processed in descending order, that is, highest syncWaveGroup objects are first
+// deleted and the lowest syncWaveGroups are deleted last.
+// Returns: bool, error
+// bool: indicates whether the deletion of all the specified (and owned) objects are successful
+// error: error encountered during deletion attempt
+func (d *DeletionHandler) DeleteObjects(
+	ctx context.Context,
+	clusterInstance *v1alpha1.ClusterInstance,
+	objects, excludeObjects []ci.RenderedObject,
+	deletionTimeout *time.Duration,
+) (deletionCompleted bool, err error) {
+	log := d.Logger.With(
+		zap.String("ClusterInstance", fmt.Sprintf("%s/%s", clusterInstance.Namespace, clusterInstance.Name)),
+	)
+
+	deletionCompleted = false
+	err = nil
+
+	patch := client.MergeFrom(clusterInstance.DeepCopy())
+	manifestsRendered := append([]v1alpha1.ManifestReference{}, clusterInstance.Status.ManifestsRendered...)
+
+	objectSyncWaveMap := ci.SyncWaveMap{}
+	if err := objectSyncWaveMap.AddObjects(objects); err != nil {
+		log.Warn("Incurred error(s) collecting objects for deletion", zap.Error(err))
+	}
+
+	var (
+		manifestsDeleted []v1alpha1.ManifestReference
+		errs             []error
+		deleted          bool
+	)
+
+	defer func() {
+		// Update ManifestsRendered if there are changes
+		manifestsRendered = filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+		if !equality.Semantic.DeepEqual(clusterInstance.Status.ManifestsRendered, manifestsRendered) {
+			clusterInstance.Status.ManifestsRendered = manifestsRendered
+			if updateErr := conditions.PatchCIStatus(ctx, d.Client, clusterInstance, patch); updateErr != nil {
+				log.Error("Failed to update Status.ManifestsRendered", zap.Error(updateErr))
+				errs = append(errs, updateErr)
+			}
+		}
+		err = utilerrors.NewAggregate(errs)
+	}()
+
+	for _, syncWave := range objectSyncWaveMap.GetDescendingSyncWaves() {
+		syncWaveGroupDeleted := true
+
+		for _, object := range objectSyncWaveMap.GetObjectsForSyncWave(syncWave) {
+			resourceId := object.GetResourceId()
+
+			if _, err = ci.IndexOfObjectByIdentity(&object, excludeObjects); err == nil {
+				log.Sugar().Debugf("Excluding object (%s) from deletion", resourceId)
+				continue
+			}
+
+			index, err1 := v1alpha1.IndexOfManifestByIdentity(object.ManifestReference(), manifestsRendered)
+			if err1 != nil {
+				log.Sugar().Debugf(
+					"Skipping deletion of object (%s) not found in ClusterInstance.Status.ManifestsRendered",
+					resourceId)
+				continue
+			}
+
+			manifest := &manifestsRendered[index]
+			deleted, err = d.DeleteObject(ctx, clusterInstance, object, deletionTimeout)
+			if deleted || (err != nil && cierrors.IsNotOwnedObject(err)) {
+				log.Sugar().Debugf("Marking manifest (%s) for removal from Status.ManifestsRendered", manifest.String())
+				manifestsDeleted = append(manifestsDeleted, *manifest)
+				continue
+			}
+
+			if err != nil {
+				log.Sugar().Errorf("unable to delete object (%s)", resourceId, zap.Error(err))
+				errs = append(errs, err)
+				if cierrors.IsDeletionTimeoutError(err) {
+					manifest.UpdateStatus(v1alpha1.ManifestDeletionTimedOut, err.Error())
+					return
+				}
+				manifest.UpdateStatus(v1alpha1.ManifestDeletionFailure, err.Error())
+				continue
+			}
+
+			if manifest.Status != v1alpha1.ManifestDeletionInProgress {
+				log.Sugar().Debugf(
+					"Updating manifest (%s) status from (%s) to (%s)",
+					manifest.String(), manifest.Status, v1alpha1.ManifestDeletionInProgress)
+				manifest.UpdateStatus(v1alpha1.ManifestDeletionInProgress, "")
+			}
+
+			syncWaveGroupDeleted = false
+		}
+
+		if len(errs) > 0 || !syncWaveGroupDeleted {
+			return
+		}
+	}
+
+	log.Info("Successfully deleted objects")
+	deletionCompleted = true
+	return
+}
+
+// DeleteObject ensures the deletion of an owned object.
+func (d *DeletionHandler) DeleteObject(
+	ctx context.Context,
+	clusterInstance *v1alpha1.ClusterInstance,
+	object ci.RenderedObject,
+	deletionTimeout *time.Duration,
+) (bool, error) {
+	log := d.Logger.With(
+		zap.String("ClusterInstance", fmt.Sprintf("%s/%s", clusterInstance.Namespace, clusterInstance.Name)),
+	)
+
+	obj := ptr.To(object.GetObject())
+	resourceId := object.GetResourceId()
+
+	if deleted, err := isObjectDeleted(ctx, d.Client, obj); deleted && err == nil {
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	ownerRefLabel := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+	if err := ci.VerifyOwnership(obj, ownerRefLabel); err != nil {
+		log.Sugar().Warnf("Ownership verification failed for object (%s): %v", resourceId, err.Error())
+		return false, err
+	}
+
+	if obj.GetDeletionTimestamp().IsZero() {
+		log.Sugar().Debugf("Initiating object (%s) deletion", resourceId)
+		if err := initiateObjectDeletion(ctx, d.Client, obj); err != nil {
+			return false, err
+		}
+	} else if timeoutExceeded(obj.GetDeletionTimestamp().Time, deletionTimeout) {
+		return false, cierrors.NewDeletionTimeoutError(resourceId)
+	}
+
+	log.Sugar().Debugf("Waiting for object (%s) to be deleted", resourceId)
+	return false, nil
+}
+
+// Helper functions
+
+func objectsForClusterInstance(clusterInstance *v1alpha1.ClusterInstance) []ci.RenderedObject {
+	objects := make([]ci.RenderedObject, 0, len(clusterInstance.Status.ManifestsRendered))
+	for _, manifest := range clusterInstance.Status.ManifestsRendered {
+		object := ci.RenderedObject{}
+		if err := object.SetObject(map[string]interface{}{
+			"apiVersion": *manifest.APIGroup,
+			"kind":       manifest.Kind,
+			"metadata": map[string]interface{}{
+				"name":      manifest.Name,
+				"namespace": manifest.Namespace,
+			},
+		}); err == nil {
+			objects = append(objects, object)
+		}
+	}
+	return objects
+}
+
+func isObjectDeleted(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to retrieve object: %w", err)
+	}
+	return false, nil
+}
+
+func initiateObjectDeletion(ctx context.Context, c client.Client, obj client.Object) error {
+	return client.IgnoreNotFound(c.Delete(ctx, obj,
+		&client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}))
+}
+
+// timeoutExceeded checks whether the deletion has exceeded the timeout.
+func timeoutExceeded(startTime time.Time, timeout *time.Duration) bool {
+	if timeout == nil {
+		return false
+	}
+	return time.Since(startTime) > *timeout
+}
+
+func filterOutDeletedManifests(manifestsRendered, manifestsDeleted []v1alpha1.ManifestReference,
+) []v1alpha1.ManifestReference {
+
+	filteredManifests := make([]v1alpha1.ManifestReference, 0, len(manifestsRendered))
+	for _, manifest := range manifestsRendered {
+		if _, err := v1alpha1.IndexOfManifestByIdentity(&manifest, manifestsDeleted); err != nil {
+			filteredManifests = append(filteredManifests, manifest)
+		}
+	}
+	return filteredManifests
+}

--- a/internal/controller/deletion/deletion_test.go
+++ b/internal/controller/deletion/deletion_test.go
@@ -1,0 +1,882 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	ci "github.com/stolostron/siteconfig/internal/controller/clusterinstance"
+	cierrors "github.com/stolostron/siteconfig/internal/controller/errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeletion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DeletionSuite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+})
+
+func testFnGenerateObject(ctx context.Context, c client.Client,
+	Name, Namespace, ownerRef, finalizer string, gvk schema.GroupVersionKind,
+) (u *unstructured.Unstructured, o *ci.RenderedObject) {
+	u = &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetName(Name)
+	u.SetNamespace(Namespace)
+	u.SetLabels(map[string]string{ci.OwnedByLabel: ownerRef})
+	u.SetAnnotations(map[string]string{ci.WaveAnnotation: "0"})
+	if finalizer != "" {
+		u.SetFinalizers([]string{finalizer})
+	}
+
+	o = &ci.RenderedObject{}
+	Expect(o.SetObject(u.Object)).To(Succeed())
+
+	Expect(c.Create(ctx, u)).To(Succeed())
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(u), u)).To(Succeed())
+	return
+}
+
+var _ = Describe("DeleteObject", func() {
+	var (
+		ctx             context.Context
+		testLogger      *zap.Logger
+		handler         *DeletionHandler
+		c               client.Client
+		clusterInstance *v1alpha1.ClusterInstance
+
+		Name      = "test"
+		Namespace = "default"
+
+		gvk schema.GroupVersionKind
+	)
+
+	BeforeEach(func() {
+
+		gvk = schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "ConfigMap",
+		}
+		clusterInstance = &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+			},
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: []v1alpha1.ManifestReference{
+					{
+						APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+						Kind:      gvk.Kind,
+						Name:      Name,
+						Namespace: Namespace,
+						SyncWave:  0,
+						Status:    v1alpha1.ManifestRenderedSuccess,
+					},
+				},
+			},
+		}
+
+		ctx = context.TODO()
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
+			WithObjects(clusterInstance).
+			Build()
+		testLogger = zap.NewNop().Named("Test")
+
+		handler = &DeletionHandler{Client: c, Logger: testLogger}
+
+	})
+
+	It("should return true if the object does not exist", func() {
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetName(Name)
+		obj.SetNamespace(Namespace)
+		obj.SetLabels(map[string]string{ci.OwnedByLabel: ownerRef})
+
+		object := ci.RenderedObject{}
+		Expect(object.SetObject(obj.Object)).To(Succeed())
+
+		deleted, err := handler.DeleteObject(ctx, clusterInstance, object, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+	})
+
+	It("should return false if the object exists but ownership verification fails", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetName(Name)
+		obj.SetNamespace(Namespace)
+		obj.SetLabels(map[string]string{ci.OwnedByLabel: "foobar"})
+
+		object := ci.RenderedObject{}
+		Expect(object.SetObject(obj.Object)).To(Succeed())
+
+		Expect(c.Create(ctx, obj)).To(Succeed())
+
+		deleted, err := handler.DeleteObject(ctx, clusterInstance, object, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(cierrors.IsNotOwnedObject(err)).To(BeTrue())
+		Expect(deleted).To(BeFalse())
+	})
+
+	It("should initiate deletion if the object exists and ownership is verified", func() {
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetName(Name)
+		obj.SetNamespace(Namespace)
+		obj.SetLabels(map[string]string{ci.OwnedByLabel: ownerRef})
+
+		object := ci.RenderedObject{}
+		Expect(object.SetObject(obj.Object)).To(Succeed())
+
+		Expect(c.Create(ctx, obj)).To(Succeed())
+
+		deleted, err := handler.DeleteObject(ctx, clusterInstance, object, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+	})
+
+	It("should return an error if deletion times out", func() {
+
+		testClient := fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return c.Create(ctx, obj, opts...)
+			},
+			Delete: func(ctx context.Context, fclient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return cierrors.NewDeletionTimeoutError("")
+			},
+		}).Build()
+
+		handler = &DeletionHandler{Client: testClient, Logger: testLogger}
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetName(Name)
+		obj.SetNamespace(Namespace)
+		obj.SetLabels(map[string]string{ci.OwnedByLabel: ownerRef})
+
+		Expect(testClient.Create(ctx, obj)).To(Succeed())
+
+		object := ci.RenderedObject{}
+		Expect(object.SetObject(obj.Object)).To(Succeed())
+
+		deleted, err := handler.DeleteObject(ctx, clusterInstance, object, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(cierrors.IsDeletionTimeoutError(err)).To(BeTrue())
+		Expect(deleted).To(BeFalse())
+	})
+
+	It("should return false and wait if the object is marked for deletion but not yet deleted", func() {
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		obj.SetName(Name)
+		obj.SetNamespace(Namespace)
+		obj.SetLabels(map[string]string{ci.OwnedByLabel: ownerRef})
+
+		Expect(c.Create(ctx, obj)).To(Succeed())
+
+		object := ci.RenderedObject{}
+		Expect(object.SetObject(obj.Object)).To(Succeed())
+
+		deleted, err := handler.DeleteObject(ctx, clusterInstance, object, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+	})
+
+})
+
+var _ = Describe("DeleteObjects", func() {
+	var (
+		ctx             context.Context
+		testLogger      *zap.Logger
+		handler         *DeletionHandler
+		c               client.Client
+		clusterInstance *v1alpha1.ClusterInstance
+
+		Name1     = "test1"
+		Name2     = "test2"
+		Namespace = "default"
+
+		gvk schema.GroupVersionKind
+	)
+
+	BeforeEach(func() {
+		gvk = schema.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		}
+		clusterInstance = &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name1,
+				Namespace: Namespace,
+			},
+		}
+
+		ctx = context.TODO()
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
+			WithObjects().
+			Build()
+		testLogger = zap.NewNop().Named("Test")
+		handler = &DeletionHandler{Client: c, Logger: testLogger}
+	})
+
+	It("should return true if all objects are successfully deleted", func() {
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name2,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj1, renderedObject1 := testFnGenerateObject(ctx, c, Name1, Namespace, ownerRef, "", gvk)
+		obj2, renderedObject2 := testFnGenerateObject(ctx, c, Name2, Namespace, ownerRef, "", gvk)
+
+		deleted, err := handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *renderedObject2}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(2))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		Expect(clusterInstance.Status.ManifestsRendered[1].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+
+		// Objects should get deleted, but will take another reconcile
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)).ToNot(Succeed())
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj2), obj2)).ToNot(Succeed())
+
+		deleted, err = handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *renderedObject2}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(0))
+	})
+
+	It("should exclude objects specified in the excludeObjects list", func() {
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name2,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj1, renderedObject1 := testFnGenerateObject(ctx, c, Name1, Namespace, ownerRef, "", gvk)
+		excludeObj, excludeRenderedObject := testFnGenerateObject(ctx, c, Name2, Namespace, ownerRef, "", gvk)
+
+		deleted, err := handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *excludeRenderedObject},
+			[]ci.RenderedObject{*excludeRenderedObject}, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(2))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Name).To(Equal(Name1))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		Expect(clusterInstance.Status.ManifestsRendered[1].Name).To(Equal(Name2))
+		Expect(clusterInstance.Status.ManifestsRendered[1].Status).To(Equal(v1alpha1.ManifestRenderedSuccess))
+
+		// Object should get deleted, but will take another reconcile
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)).ToNot(Succeed())
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(excludeObj), excludeObj)).To(Succeed())
+
+		deleted, err = handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *excludeRenderedObject},
+			[]ci.RenderedObject{*excludeRenderedObject}, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(1))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Name).To(Equal(Name2))
+	})
+
+	It("should return false if any object deletion fails", func() {
+
+		testClient := fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return c.Create(ctx, obj, opts...)
+			},
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+			Delete: func(ctx context.Context, fclient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return fmt.Errorf("induced error")
+			},
+			SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				return c.Status().Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+		handler = &DeletionHandler{Client: testClient, Logger: testLogger}
+
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		_, renderedObject := testFnGenerateObject(ctx, testClient, Name1, Namespace, ownerRef, "", gvk)
+
+		deleted, err := handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject}, nil, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("induced error"))
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(1))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionFailure))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Message).To(ContainSubstring("induced error"))
+	})
+
+	When("any object deletion fails and updating the ClusterInstance.Status fails", func() {
+		It("should return false due to deletion failure and should reflect both deletion and update errors ", func() {
+
+			testClient := fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return c.Get(ctx, key, obj, opts...)
+				},
+				Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return c.Create(ctx, obj, opts...)
+				},
+				Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+				Delete: func(ctx context.Context, fclient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					return fmt.Errorf("induced deletion error")
+				},
+				SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					return fmt.Errorf("induced Status patch error")
+				},
+			}).Build()
+
+			handler = &DeletionHandler{Client: testClient, Logger: testLogger}
+
+			clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: []v1alpha1.ManifestReference{
+					{
+						APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+						Kind:      gvk.Kind,
+						Name:      Name1,
+						Namespace: Namespace,
+						SyncWave:  0,
+						Status:    v1alpha1.ManifestRenderedSuccess,
+					},
+				},
+			}
+			Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+			ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+			_, renderedObject := testFnGenerateObject(ctx, testClient, Name1, Namespace, ownerRef, "", gvk)
+
+			deleted, err := handler.DeleteObjects(ctx, clusterInstance, []ci.RenderedObject{*renderedObject}, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("induced deletion error"))
+			Expect(err.Error()).To(ContainSubstring("induced Status patch error"))
+			Expect(deleted).To(BeFalse())
+
+			// Verify that ClusterInstance.Status.ManifestsRendered was not updated
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+			Expect(clusterInstance.Status.ManifestsRendered).Should(HaveLen(1))
+			Expect(clusterInstance.Status.ManifestsRendered[0].Status).Should(Equal(v1alpha1.ManifestRenderedSuccess))
+			Expect(clusterInstance.Status.ManifestsRendered[0].Message).Should(Equal(""))
+		})
+	})
+
+	It("should return false if any object is marked for deletion but not yet deleted", func() {
+
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name2,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj1, renderedObject1 := testFnGenerateObject(ctx, c, Name1, Namespace, ownerRef, "", gvk)
+		obj2, renderedObject2 := testFnGenerateObject(ctx, c, Name2, Namespace, ownerRef, "do-not-delete", gvk)
+
+		deleted, err := handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *renderedObject2}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(2))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		Expect(clusterInstance.Status.ManifestsRendered[1].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+
+		// Verify only Object1 is deleted
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)).ToNot(Succeed())
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj2), obj2)).To(Succeed())
+
+		deleted, err = handler.DeleteObjects(
+			ctx, clusterInstance, []ci.RenderedObject{*renderedObject1, *renderedObject2}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(1))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Name).To(Equal(Name2))
+
+	})
+
+	It("should return a TimedOut error if a deletion times out", func() {
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		testClient := fakeclient.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return c.Create(ctx, obj, opts...)
+			},
+			Delete: func(ctx context.Context, fclient client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return cierrors.NewDeletionTimeoutError("")
+			},
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+			SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				return c.Status().Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+		handler = &DeletionHandler{Client: testClient, Logger: testLogger}
+
+		_, renderedObject := testFnGenerateObject(ctx, c, Name1, Namespace, ownerRef, "", gvk)
+
+		deleted, err := handler.DeleteObjects(ctx, clusterInstance, []ci.RenderedObject{*renderedObject}, nil, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(cierrors.IsDeletionTimeoutError(err)).To(BeTrue())
+		Expect(deleted).To(BeFalse())
+	})
+
+})
+
+var _ = Describe("DeleteRenderedObjects", func() {
+	var (
+		ctx             context.Context
+		testLogger      *zap.Logger
+		handler         *DeletionHandler
+		c               client.Client
+		clusterInstance *v1alpha1.ClusterInstance
+
+		Name1     = "test1"
+		Name2     = "test2"
+		Namespace = "default"
+
+		gvk schema.GroupVersionKind
+	)
+
+	BeforeEach(func() {
+		gvk = schema.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		}
+		clusterInstance = &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name1,
+				Namespace: Namespace,
+			},
+		}
+
+		ctx = context.TODO()
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
+			WithObjects().
+			Build()
+		testLogger = zap.NewNop().Named("Test")
+		handler = &DeletionHandler{Client: c, Logger: testLogger}
+	})
+
+	It("should return true if all rendered objects are successfully deleted", func() {
+		clusterInstance.Status = v1alpha1.ClusterInstanceStatus{
+			ManifestsRendered: []v1alpha1.ManifestReference{
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name1,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+				{
+					APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+					Kind:      gvk.Kind,
+					Name:      Name2,
+					Namespace: Namespace,
+					SyncWave:  0,
+					Status:    v1alpha1.ManifestRenderedSuccess,
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		ownerRef := ci.GenerateOwnedByLabelValue(clusterInstance.Namespace, clusterInstance.Name)
+
+		obj1, _ := testFnGenerateObject(ctx, c, Name1, Namespace, ownerRef, "", gvk)
+		obj2, _ := testFnGenerateObject(ctx, c, Name2, Namespace, ownerRef, "", gvk)
+
+		deleted, err := handler.DeleteRenderedObjects(ctx, clusterInstance, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(2))
+		Expect(clusterInstance.Status.ManifestsRendered[0].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+		Expect(clusterInstance.Status.ManifestsRendered[1].Status).To(Equal(v1alpha1.ManifestDeletionInProgress))
+
+		// Objects should get deleted, but will take another reconcile
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj1), obj1)).ToNot(Succeed())
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj2), obj2)).ToNot(Succeed())
+
+		deleted, err = handler.DeleteRenderedObjects(ctx, clusterInstance, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance)).To(Succeed())
+		Expect(clusterInstance.Status.ManifestsRendered).To(HaveLen(0))
+	})
+})
+
+var _ = Describe("Helper Functions", func() {
+	var (
+		ctx             context.Context
+		c               client.Client
+		clusterInstance *v1alpha1.ClusterInstance
+
+		Name      = "test"
+		Namespace = "default"
+
+		gvk schema.GroupVersionKind
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
+			Build()
+
+		gvk = schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "ConfigMap",
+		}
+		clusterInstance = &v1alpha1.ClusterInstance{
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManifestsRendered: []v1alpha1.ManifestReference{
+					{
+						APIGroup:  ptr.To(gvk.Group + "/" + gvk.Version),
+						Kind:      gvk.Kind,
+						Name:      Name,
+						Namespace: Namespace,
+					},
+				},
+			},
+		}
+	})
+
+	Describe("objectsForClusterInstance", func() {
+		It("should correctly return the list of objects for the ClusterInstance", func() {
+			objects := objectsForClusterInstance(clusterInstance)
+			Expect(objects).To(HaveLen(1))
+			Expect(objects[0].GetName()).To(Equal(Name))
+			Expect(objects[0].GetNamespace()).To(Equal(Namespace))
+			Expect(objects[0].GetGroupVersionKind()).To(Equal(gvk))
+		})
+	})
+
+	Describe("initiateObjectDeletion", func() {
+
+		It("should initiate deletion successfully", func() {
+
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			obj.SetName(Name)
+			obj.SetNamespace(Namespace)
+
+			// Configure a finalizer to verify deletionTimestamp being set
+			obj.SetFinalizers([]string{"hold"})
+
+			Expect(c.Create(ctx, obj)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+			Expect(obj.GetDeletionTimestamp()).To(BeNil())
+
+			// Initiate Deletion
+			Expect(initiateObjectDeletion(ctx, c, obj)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+			Expect(obj.GetDeletionTimestamp()).NotTo(BeNil())
+
+			// Remove finalizer and expect object to be deleted
+			obj.SetFinalizers(nil)
+			Expect(c.Update(ctx, obj)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).NotTo(Succeed())
+
+		})
+
+		It("should handle not found errors gracefully", func() {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			obj.SetName("non-existent")
+			obj.SetNamespace(Namespace)
+
+			err := initiateObjectDeletion(ctx, c, obj)
+			Expect(apierrors.IsNotFound(err)).To(BeFalse())
+		})
+	})
+
+	Describe("isObjectDeleted", func() {
+
+		It("should return true if the object does not exist", func() {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			obj.SetName("non-existent")
+			obj.SetNamespace(Namespace)
+
+			deleted, err := isObjectDeleted(ctx, c, obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleted).To(BeTrue())
+		})
+
+		It("should return false if the object exists", func() {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			obj.SetName(Name)
+			obj.SetNamespace(Namespace)
+
+			Expect(c.Create(ctx, obj)).To(Succeed())
+
+			deleted, err := isObjectDeleted(ctx, c, obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleted).To(BeFalse())
+		})
+	})
+
+	Describe("timeoutExceeded", func() {
+		It("should return false if no timeout is specified", func() {
+			exceeded := timeoutExceeded(time.Now(), nil)
+			Expect(exceeded).To(BeFalse())
+		})
+
+		It("should return true if timeout is exceeded", func() {
+			timeout := 1 * time.Second
+			exceeded := timeoutExceeded(time.Now().Add(-2*time.Second), &timeout)
+			Expect(exceeded).To(BeTrue())
+		})
+
+		It("should return false if timeout is not yet exceeded", func() {
+			timeout := 1 * time.Second
+			exceeded := timeoutExceeded(time.Now(), &timeout)
+			Expect(exceeded).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("filterOutDeletedManifests", func() {
+	var (
+		manifestsRendered []v1alpha1.ManifestReference
+		manifestsDeleted  []v1alpha1.ManifestReference
+	)
+
+	BeforeEach(func() {
+		manifestsRendered = []v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "Deployment", Name: "test", Namespace: "default"},
+			{APIGroup: ptr.To("apps/v1"), Kind: "StatefulSet", Name: "test", Namespace: "default"},
+			{APIGroup: ptr.To("v1"), Kind: "ConfigMap", Name: "test", Namespace: "default"},
+		}
+
+		manifestsDeleted = []v1alpha1.ManifestReference{}
+	})
+
+	It("returns the same list when deleted is empty", func() {
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+		Expect(filtered).To(Equal(manifestsRendered))
+	})
+
+	It("removes a single deleted manifest", func() {
+		manifestsDeleted = []v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "Deployment", Name: "test", Namespace: "default"},
+		}
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+
+		Expect(filtered).To(Equal([]v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "StatefulSet", Name: "test", Namespace: "default"},
+			{APIGroup: ptr.To("v1"), Kind: "ConfigMap", Name: "test", Namespace: "default"},
+		}))
+	})
+
+	It("removes multiple deleted manifests", func() {
+		manifestsDeleted = []v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "Deployment", Name: "test", Namespace: "default"},
+			{APIGroup: ptr.To("v1"), Kind: "ConfigMap", Name: "test", Namespace: "default"},
+		}
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+
+		Expect(filtered).To(Equal([]v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "StatefulSet", Name: "test", Namespace: "default"},
+		}))
+	})
+
+	It("handles no manifests", func() {
+		manifestsRendered = []v1alpha1.ManifestReference{}
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+		Expect(filtered).To(BeEmpty())
+	})
+
+	It("handles no matches between manifests and deleted", func() {
+		manifestsDeleted = []v1alpha1.ManifestReference{
+			{APIGroup: ptr.To("apps/v1"), Kind: "DaemonSet", Name: "test", Namespace: "default"},
+		}
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+
+		Expect(filtered).To(Equal(manifestsRendered))
+	})
+
+	It("handles all manifests being deleted", func() {
+		manifestsDeleted = manifestsRendered
+		filtered := filterOutDeletedManifests(manifestsRendered, manifestsDeleted)
+		Expect(filtered).To(BeEmpty())
+	})
+})

--- a/internal/controller/errors/errors.go
+++ b/internal/controller/errors/errors.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type ClusterInstanceError struct {
+	Type    string
+	Message string
+}
+
+var _ error = &ClusterInstanceError{}
+
+// Error implements the Error interface.
+func (e *ClusterInstanceError) Error() string {
+	return e.Message
+}
+
+// Predefined error types for ClusterInstance operations.
+const (
+	ErrorTypeNotOwnedObject  = "NOT_OWNED_OBJECT"
+	ErrorTypeDeletionTimeout = "DELETION_TIMEOUT"
+	ErrorTypeUnknown         = ""
+)
+
+// New creates a new ClusterInstanceError with a given code and message.
+func New(errType, message string) error {
+	return &ClusterInstanceError{
+		Type:    errType,
+		Message: message,
+	}
+}
+
+// Helper functions to create specific errors.
+
+// NewNotOwnedObjectError returns an error indicating that the ClusterInstance is not the owner of the object.
+func NewNotOwnedObjectError(owner, resourceId string) error {
+	return New(ErrorTypeNotOwnedObject,
+		fmt.Sprintf("ClusterInstance '%s' is not the owner of object (%s)", owner, resourceId))
+}
+
+// NewDeletionTimeoutError returns an error indicating the manifest could not be deleted due to
+// a timeout.
+func NewDeletionTimeoutError(resourceId string) error {
+	return New(ErrorTypeDeletionTimeout,
+		fmt.Sprintf("Timed out waiting to delete object (%s)", resourceId))
+}
+
+func isErrorOfType(err error, errType string) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check if the error is an aggregate
+	if agg, ok := err.(utilerrors.Aggregate); ok {
+		for _, err1 := range agg.Errors() {
+			// Unwrap and check if it matches the error type errType
+			if ciErr, ok := err1.(*ClusterInstanceError); ok &&
+				ciErr.Type == errType {
+				return true
+			}
+		}
+	}
+
+	// If not an aggregate, check the single error directly
+	if ciErr, ok := err.(*ClusterInstanceError); ok &&
+		ciErr.Type == errType {
+		return true
+	}
+
+	return false
+}
+
+// IsNotOwnedObject checks if an error contains a NotOwnedObjectError.
+func IsNotOwnedObject(err error) bool {
+	return isErrorOfType(err, ErrorTypeNotOwnedObject)
+}
+
+// IsDeletionTimeoutError checks if an error contains a DeletionTimeoutError.
+func IsDeletionTimeoutError(err error) bool {
+	return isErrorOfType(err, ErrorTypeDeletionTimeout)
+}

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -182,7 +182,7 @@ metadata:
   name: "{{ .SpecialVars.CurrentNode.HostName }}"
   namespace: "{{ .Spec.ClusterName }}"
   annotations:
-    siteconfig.open-cluster-management.io/sync-wave: "1"
+    siteconfig.open-cluster-management.io/sync-wave: "3"
     inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
 {{ if .SpecialVars.CurrentNode.NodeLabels }}
 {{ range $key, $value := .SpecialVars.CurrentNode.NodeLabels }}


### PR DESCRIPTION
**Enhance SiteConfig Operator Deletion Handling:**   

**PR Description:**  

This pull request introduces significant improvements to the SiteConfig Operator's deletion handling and updates the default assisted-installer template for BareMetalHost.  

### Changes Summary  

#### 1. Enhance SiteConfig Operator Deletion Handling  
- Introduced a `DeletionHandler` to enable graceful deletion of objects owned by a `ClusterInstance` with a configurable timeout.  
- Changed deletion propagation policy to `ForwardPropagationPolicy`.  
- Refactored the `ClusterInstance` finalizer handler to leverage the new `DeletionHandler` and ensure requeuing until all objects are deleted or a timeout occurs.  
- Improved `pruneManifest` functionality for robust object cleanup, integrated with the `DeletionHandler`.  
- Added comprehensive unit tests to validate the new deletion logic.  

These changes ensure reliable and orderly resource deletion, even in timeout scenarios, improving the robustness of the operator.  

#### 2. Update Default BareMetalHost Template for Assisted-Installer  
- Set the BareMetalHost (BMH) `sync-wave` annotation to `3` in the default assisted-installer template.  
- Ensures BMH is the last rendered resource and the first deleted during cleanup.  
- Resolves dependencies on InfraEnv and Namespace resources, ensuring they remain in a non-terminated state for successful BMH cleanup.  

This update ensures proper sequencing of resource deletions, enabling reliable cleanup by assisted installer components.  

**Resolves**: [ACM-16142](https://issues.redhat.com/browse/ACM-16142), [CNF-15746](https://issues.redhat.com/browse/CNF-15746)