### PR TITLE
CNF-16324: kustomize: Replace patchesStrategicMerge with patches

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,11 +26,14 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+  - path: manager_auth_proxy_patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
 
 
 


### PR DESCRIPTION
Updates the Kustomize configuration to replace the deprecated patchesStrategicMerge field with the patches field as per Kustomize 5.x recommendations. More details at [CNF-16324](https://issues.redhat.com/browse/CNF-16324).

/cc @sakhoury 