### PR TITLE
Remove JAVA_COMMUNITY_DEPENDENCIES from konflux pipelines

### DIFF
--- a/.tekton/siteconfig-main-pull-request.yaml
+++ b/.tekton/siteconfig-main-pull-request.yaml
@@ -133,9 +133,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:

--- a/.tekton/siteconfig-main-push.yaml
+++ b/.tekton/siteconfig-main-push.yaml
@@ -130,9 +130,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:


### PR DESCRIPTION
This PR removes the `JAVA_COMMUNITY_DEPENDENCIES` from the konflux pipeline results in support of https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.3/MIGRATION.md.