### PR TITLE
CNF-16436: Add CPUArchitecture fields to ClusterInstanceSpec and NodeSpec CRDs

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -89,6 +89,15 @@ const (
 	CPUPartitioningAllNodes CPUPartitioningMode = "AllNodes"
 )
 
+// CpuArchitecture is used to define the software architecture of a host.
+type CPUArchitecture string
+
+const (
+	// Supported architectures are x86 and arm
+	CPUArchitectureX86_64 CPUArchitecture = "x86_64"
+	CPUArchitectureAarch64 CPUArchitecture = "aarch64"
+)
+
 // TemplateRef is used to specify the installation CR templates
 type TemplateRef struct {
 	// +required
@@ -156,6 +165,13 @@ type NodeSpec struct {
 	// Hostname is the desired hostname for the host
 	// +required
 	HostName string `json:"hostName"`
+
+	// CPUArchitecture is the software architecture of the node.
+	// If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+	// If both are not defined then it is omitted.
+	// +kubebuilder:validation:Enum=x86_64;aarch64
+	// +optional
+	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
 	// Provide guidance about how to choose the device for the image being provisioned.
 	// +kubebuilder:default:=UEFI
@@ -377,6 +393,12 @@ type ClusterInstanceSpec struct {
 	// +kubebuilder:default=None
 	// +optional
 	CPUPartitioning CPUPartitioningMode `json:"cpuPartitioningMode,omitempty"`
+
+	// CPUArchitecture is the default software architecture used for nodes that do not have an architecture defined.
+	// If CPUArchitecture is not defined then it is omitted.
+	// +kubebuilder:validation:Enum=x86_64;aarch64
+	// +optional
+	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
 	// +kubebuilder:validation:Enum=SNO;HighlyAvailable
 	// +optional

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -93,9 +93,10 @@ const (
 type CPUArchitecture string
 
 const (
-	// Supported architectures are x86 and arm
+	// Supported architectures are x86, arm, or multi
 	CPUArchitectureX86_64 CPUArchitecture = "x86_64"
 	CPUArchitectureAarch64 CPUArchitecture = "aarch64"
+	CPUArchitectureMulti CPUArchitecture = "multi"
 )
 
 // TemplateRef is used to specify the installation CR templates
@@ -168,8 +169,8 @@ type NodeSpec struct {
 
 	// CPUArchitecture is the software architecture of the node.
 	// If it is not defined here then it is inheirited from the ClusterInstanceSpec.
-	// If both are not defined then it is omitted.
 	// +kubebuilder:validation:Enum=x86_64;aarch64
+	// +kubebuilder:default:=x86_64
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
@@ -395,8 +396,8 @@ type ClusterInstanceSpec struct {
 	CPUPartitioning CPUPartitioningMode `json:"cpuPartitioningMode,omitempty"`
 
 	// CPUArchitecture is the default software architecture used for nodes that do not have an architecture defined.
-	// If CPUArchitecture is not defined then it is omitted.
-	// +kubebuilder:validation:Enum=x86_64;aarch64
+	// +kubebuilder:validation:Enum=x86_64;aarch64;multi
+	// +kubebuilder:default:=x86_64
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -94,9 +94,9 @@ type CPUArchitecture string
 
 const (
 	// Supported architectures are x86, arm, or multi
-	CPUArchitectureX86_64 CPUArchitecture = "x86_64"
+	CPUArchitectureX86_64  CPUArchitecture = "x86_64"
 	CPUArchitectureAarch64 CPUArchitecture = "aarch64"
-	CPUArchitectureMulti CPUArchitecture = "multi"
+	CPUArchitectureMulti   CPUArchitecture = "multi"
 )
 
 // TemplateRef is used to specify the installation CR templates

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -120,6 +120,15 @@ spec:
                 - SNO
                 - HighlyAvailable
                 type: string
+              cpuArchitecture:
+                default: x86_64
+                description: CPUArchitecture is the default software architecture
+                  used for nodes that do not have an architecture defined.
+                enum:
+                - x86_64
+                - aarch64
+                - multi
+                type: string
               cpuPartitioningMode:
                 default: None
                 description: |-
@@ -277,6 +286,15 @@ spec:
                       - UEFI
                       - UEFISecureBoot
                       - legacy
+                      type: string
+                    cpuArchitecture:
+                      default: x86_64
+                      description: |-
+                        CPUArchitecture is the software architecture of the node.
+                        If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+                      enum:
+                      - x86_64
+                      - aarch64
                       type: string
                     extraAnnotations:
                       additionalProperties:

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -120,6 +120,15 @@ spec:
                 - SNO
                 - HighlyAvailable
                 type: string
+              cpuArchitecture:
+                default: x86_64
+                description: CPUArchitecture is the default software architecture
+                  used for nodes that do not have an architecture defined.
+                enum:
+                - x86_64
+                - aarch64
+                - multi
+                type: string
               cpuPartitioningMode:
                 default: None
                 description: |-
@@ -277,6 +286,15 @@ spec:
                       - UEFI
                       - UEFISecureBoot
                       - legacy
+                      type: string
+                    cpuArchitecture:
+                      default: x86_64
+                      description: |-
+                        CPUArchitecture is the software architecture of the node.
+                        If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+                      enum:
+                      - x86_64
+                      - aarch64
                       type: string
                     extraAnnotations:
                       additionalProperties:


### PR DESCRIPTION
- Each node can individually be specified with an architecture to allow for homogeneous architecture systems
- A default for otherwise unspecified nodes can be provided to ClusterInstanceSpec
- This will require new/modified templates that will be coming later