### PR TITLE
CNF-16437: Enhance templates to pass through CPU architecture information

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -164,7 +164,7 @@ spec:
 {{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
-  cpuArchitecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+  cpuArchitecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
 {{ end }}
   pullSecretRef:
     name: "{{ .Spec.PullSecretRef.Name }}"
@@ -247,7 +247,7 @@ spec:
   automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
   online: true
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
-  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
 {{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -163,6 +163,9 @@ spec:
   proxy:
 {{ .Spec.Proxy | toYaml | indent 4 }}
 {{ end }}
+{{ if .SpecialVars.CurrentNode.CPUArchitecture }}
+  cpuArchitecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+{{ end }}
   pullSecretRef:
     name: "{{ .Spec.PullSecretRef.Name }}"
   ignitionConfigOverride: '{{ .Spec.IgnitionConfigOverride }}'
@@ -243,6 +246,9 @@ spec:
   bootMACAddress: "{{ .SpecialVars.CurrentNode.BootMACAddress }}"
   automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
   online: true
+{{ if .SpecialVars.CurrentNode.CPUArchitecture }}
+  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+{{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:
 {{ .SpecialVars.CurrentNode.RootDeviceHints | toYaml | indent 4 }}

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -142,6 +142,9 @@ spec:
   automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
   online: false
   externallyProvisioned: true
+{{ if .SpecialVars.CurrentNode.CPUArchitecture }}
+  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+{{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:
 {{ .SpecialVars.CurrentNode.RootDeviceHints | toYaml | indent 4 }}

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -143,7 +143,7 @@ spec:
   online: false
   externallyProvisioned: true
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
-  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture | toString }}"
+  architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
 {{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:


### PR DESCRIPTION
CNF-16437: Enhance templates to allow specifying cluster and node architecture
    - Update both assisted-installer and image-based-installer templates to pass the architecture data down from the ClusterInstance
      - For assisted-installer, include cpuArchitecture in the InfraEnv template and include architecture in the BareMetalHost template
      - For image-based-installer, include architecture in the BareMetalHost template
