### PR TITLE
CNF-16611: Add functionality to determine preservation resource counts

### DIFF
--- a/internal/controller/preservation/preservation.go
+++ b/internal/controller/preservation/preservation.go
@@ -213,3 +213,41 @@ func Cleanup(
 
 	return completedCleanup, utilerrors.NewAggregate(errs)
 }
+
+func GetPreservedResourceCounts(
+	ctx context.Context,
+	c client.Client,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (clusterIDCount, otherCount int, err error) {
+
+	if clusterInstance.Spec.Reinstall.PreservationMode == v1alpha1.PreservationModeNone {
+		return 0, 0, nil
+	}
+
+	labelSelector, err := buildRestoreLabelSelector(clusterInstance.Spec.Reinstall.PreservationMode)
+	if err != nil || labelSelector == nil {
+		return 0, 0, err
+	}
+
+	return countMatchingResources(ctx, c, clusterInstance.Namespace, labelSelector, false)
+}
+
+func GetRestoredResourceCounts(
+	ctx context.Context,
+	c client.Client,
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) (clusterIDCount, otherCount int, err error) {
+
+	if clusterInstance.Spec.Reinstall.PreservationMode == v1alpha1.PreservationModeNone {
+		return 0, 0, nil
+	}
+
+	labelSelector, err := buildBackupLabelSelector(clusterInstance.Spec.Reinstall.PreservationMode)
+	if err != nil || labelSelector == nil {
+		return 0, 0, err
+	}
+
+	return countMatchingResources(ctx, c, clusterInstance.Namespace, labelSelector, true)
+}


### PR DESCRIPTION
This commit introduces functions to count the preserved and restored resources.

Resolves: [CNF-16611](https://issues.redhat.com/browse/CNF-16611)

/cc @carbonin 