### PR TITLE
Fix Deletion Handler to ignore objects not found

### DIFF
--- a/internal/controller/deletion/deletion.go
+++ b/internal/controller/deletion/deletion.go
@@ -240,11 +240,11 @@ func isObjectDeleted(ctx context.Context, c client.Client, obj client.Object) (b
 }
 
 func initiateObjectDeletion(ctx context.Context, c client.Client, obj client.Object) error {
-	if err := c.Delete(ctx, obj, &client.DeleteOptions{
+	if err := client.IgnoreNotFound(c.Delete(ctx, obj, &client.DeleteOptions{
 		PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
-	}); err != nil {
+	})); err != nil {
 		return fmt.Errorf(
-			"failed to delete object (%s/%s): %w", obj.GetNamespace(), obj.GetName(), client.IgnoreNotFound(err))
+			"failed to delete object (%s/%s): %w", obj.GetNamespace(), obj.GetName(), err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR corrects an unintended change in deletion logic introduced by an earlier PR (https://github.com/stolostron/siteconfig/pull/181), which mistakenly altered the handling of non-existent objects. See [[commit](https://github.com/stolostron/siteconfig/pull/181/commits/44646f5d6616353207a0f0f5529a526e81102608)](https://github.com/stolostron/siteconfig/pull/181/commits/44646f5d6616353207a0f0f5529a526e81102608) for details.

/cc @carbonin 