### PR TITLE
ACM-18144: Update default IBI BareMetalHost template

### DIFF
--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -143,7 +143,7 @@ spec:
     credentialsName: "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .SpecialVars.CurrentNode.BootMACAddress }}"
   automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
-  online: true
+  online: false
   externallyProvisioned: true
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:


### PR DESCRIPTION
# Summary

This PR updates the default Image-based Install (IBI) `BareMetalHost` template by setting `online` to `false`. 

Resolves: [ACM-18144](https://issues.redhat.com/browse/ACM-18144)

/cc @carbonin 