### PR TITLE
ACM-18511: Replace deprecated kube-rbac-proxy image

### DIFF
--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -455,7 +455,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.18
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
           name: cert
           readOnly: true        
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.18
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
# Summary
The image `gcr.io/kubebuilder/kube-rbac-proxy` is deprecated and will become [unavailable](https://github.com/kubernetes-sigs/kubebuilder/discussions/3907). This commit replaces it with the Red Hat-maintained equivalent to ensure continued support and compatibility.

Resolves: [ACM-18511](https://issues.redhat.com/browse/ACM-18511)

/cc @carbonin 