### PR TITLE
ACM-18512: Disable HTTP/2 in kube-rbac-proxy to mitigate CVE-2023-44487

### DIFF
--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -454,7 +454,8 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
-                - --v=0
+                - --v=10
+                - --http2-disable=true
                 image: quay.io/openshift/origin-kube-rbac-proxy:4.18
                 name: kube-rbac-proxy
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -93,7 +93,8 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=0"
+        - "--v=10"
+        - "--http2-disable=true"
         ports:
         - containerPort: 8443
           protocol: TCP


### PR DESCRIPTION
# Summary

This PR adds `--http2-disable=true` to the kube-rbac-proxy args in config/manager/manager.yaml to mitigate CVE-2023-44487 (HTTP/2 Rapid Reset attack). Additionally, `--v=10` is added to enable detailed debug logging.

Resolves: [ACM-18512](https://issues.redhat.com/browse/ACM-18512)

/cc @carbonin @gparvin 