### PR TITLE
ACM-19035: Remove --http2-disable argument as it is not supported in the ACM kube-rbac-proxy image

### DIFF
--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -455,7 +455,6 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                - --http2-disable=true
                 image: quay.io/openshift/origin-kube-rbac-proxy:4.18
                 name: kube-rbac-proxy
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -94,7 +94,6 @@ spec:
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"
-        - "--http2-disable=true"
         ports:
         - containerPort: 8443
           protocol: TCP


### PR DESCRIPTION
Resolves [ACM-19035](https://issues.redhat.com/browse/ACM-19035)

/cc @carbonin @gparvin 