### PR TITLE
ACM-18970: Allow changes to clusterImageSetNameRef

### DIFF
--- a/api/v1alpha1/clusterinstance_validation.go
+++ b/api/v1alpha1/clusterinstance_validation.go
@@ -96,6 +96,7 @@ func validatePostProvisioningChanges(
 		"/extraLabels",
 		"/suppressedManifests",
 		"/pruneManifests",
+		"/clusterImageSetNameRef",
 		"/nodes/*/extraAnnotations",
 		"/nodes/*/extraLabels",
 		"/nodes/*/suppressedManifests",

--- a/api/v1alpha1/clusterinstance_validation_test.go
+++ b/api/v1alpha1/clusterinstance_validation_test.go
@@ -157,6 +157,12 @@ var _ = Describe("validatePostProvisioningChanges", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should return nil for clusterImageSetNameRef", func() {
+			newClusterInstance.Spec.ClusterImageSetNameRef = "openshift-test-updated"
+			err := validatePostProvisioningChanges(testLogger, oldClusterInstance, newClusterInstance, false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return nil for extraLabel", func() {
 			newClusterInstance.Spec.ExtraLabels["ClusterDeployment"] = map[string]string{
 				"foo": "bar",


### PR DESCRIPTION
# Summary
This PR permits changes to `spec.clusterImageSetNameRef`.

Resolves: [ACM-18970](https://issues.redhat.com/browse/ACM-18970)

/cc @carbonin 