### PR TITLE
CNF-16437: Fix cpu architecture templating deficiency

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -188,7 +188,6 @@ type NodeSpec struct {
 	// CPUArchitecture is the software architecture of the node.
 	// If it is not defined here then it is inheirited from the ClusterInstanceSpec.
 	// +kubebuilder:validation:Enum=x86_64;aarch64
-	// +kubebuilder:default:=x86_64
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -291,7 +291,6 @@ spec:
                       - legacy
                       type: string
                     cpuArchitecture:
-                      default: x86_64
                       description: |-
                         CPUArchitecture is the software architecture of the node.
                         If it is not defined here then it is inheirited from the ClusterInstanceSpec.

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -291,7 +291,6 @@ spec:
                       - legacy
                       type: string
                     cpuArchitecture:
-                      default: x86_64
                       description: |-
                         CPUArchitecture is the software architecture of the node.
                         If it is not defined here then it is inheirited from the ClusterInstanceSpec.

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -165,6 +165,11 @@ spec:
 {{ end }}
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
   cpuArchitecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
+{{ else if and
+    (.Spec.CPUArchitecture)
+    (ne .Spec.CPUArchitecture "multi")
+}}
+  cpuArchitecture: "{{ .Spec.CPUArchitecture }}"
 {{ end }}
   pullSecretRef:
     name: "{{ .Spec.PullSecretRef.Name }}"
@@ -248,6 +253,11 @@ spec:
   online: true
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
   architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
+{{ else if and
+    (.Spec.CPUArchitecture)
+    (ne .Spec.CPUArchitecture "multi")
+}}
+  architecture: "{{ .Spec.CPUArchitecture }}"
 {{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -144,11 +144,6 @@ spec:
   externallyProvisioned: true
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
   architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
-{{ else if and
-    (.Spec.CPUArchitecture)
-    (ne .Spec.CPUArchitecture "multi")
-}}
-  architecture: "{{ .Spec.CPUArchitecture }}"
 {{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:

--- a/internal/templates/image-based-installer/template.go
+++ b/internal/templates/image-based-installer/template.go
@@ -144,6 +144,11 @@ spec:
   externallyProvisioned: true
 {{ if .SpecialVars.CurrentNode.CPUArchitecture }}
   architecture: "{{ .SpecialVars.CurrentNode.CPUArchitecture }}"
+{{ else if and
+    (.Spec.CPUArchitecture)
+    (ne .Spec.CPUArchitecture "multi")
+}}
+  architecture: "{{ .Spec.CPUArchitecture }}"
 {{ end }}
 {{ if .SpecialVars.CurrentNode.RootDeviceHints }}
   rootDeviceHints:


### PR DESCRIPTION
- The default value from the ClusterInstance should be used if there is no value defined on the Node
- Remove Kubebuilder defaults from the Node field to allow overriding from ClusterInstance
