### PR TITLE
Add cluster reinstallation documentation

### DIFF
--- a/docs/reinstallation/README.md
+++ b/docs/reinstallation/README.md
@@ -1,0 +1,381 @@
+# Cluster reinstallation using the SiteConfig operator
+
+<details>
+  <summary>Table of Contents</summary>
+
+1. [Overview](#overview)
+   - [Cluster identity preservation](#cluster-identity-preservation)
+2. [Cluster reinstallation workflow](#cluster-reinstallation-workflow)  
+3. [Enabling cluster reinstallation in the SiteConfig operator](#1-enabling-cluster-reinstallation-in-the-siteconfig-operator)  
+   - [Checking the current configuration](#checking-the-current-configuration)  
+   - [Enabling cluster reinstallation](#enabling-cluster-reinstallation)  
+4. [Labeling resources for preservation](#2-labeling-resources-for-preservation)  
+5. [Initiating a cluster reinstallation](#3-initiating-a-cluster-reinstallation)  
+   - [Updating the ClusterInstance resource](#updating-the-clusterinstance-resource)  
+   - [Applying the changes](#applying-the-changes)  
+6. [Optional. Monitoring the cluster reinstallation](#4-optional-monitoring-the-cluster-reinstallation)
+7. [Verify cluster availability](#5-verify-cluster-availability)
+8. [Advanced topics](#advanced-topics)  
+   - [Image-Based Break/Fix](#image-based-breakfix-for-single-node-openshift-hardware-replacement)
+
+</details>
+
+## Overview
+The SiteConfig operator simplifies OpenShift cluster reinstallation through the `ClusterInstance` API while preserving critical configuration data.
+
+With a GitOps-compatible, declarative approach, users can trigger reinstallations by updating the `ClusterInstance` resource. The operator also includes a backup and restore mechanism for hub-side `Secret` and `ConfigMap` resources, ensuring essential cluster data, such as authentication credentials and configuration resources, remains intact.
+
+### Cluster identity preservation
+Cluster reinstallation supports both single-node OpenShift and multi-node OpenShift clusters. However, cluster identity preservation is only supported for single-node OpenShift clusters installed using the Image Based Install provisioning method.
+
+## Cluster reinstallation workflow  
+To perform a cluster reinstallation, complete the following steps:
+
+1. [Enable the SiteConfig operator reinstallation service.](#1-enabling-cluster-reinstallation-in-the-siteconfig-operator)
+2. [Optional. Label resources for preservation.](#2-labeling-resources-for-preservation)
+3. [Initiate a cluster reinstallation.](#3-initiating-a-cluster-reinstallation)
+4. [Optional. Monitor the reinstallation progress.](#4-optional-monitoring-the-cluster-reinstallation)
+5. [Verify that the cluster is provisioned and available.](#5-verify-cluster-availability)
+
+You can complete step 1. and 2. well before initiating the cluster reinstallation.
+
+### 1. Enabling cluster reinstallation in the SiteConfig operator
+
+You must explicitly enable cluster reinstallation in the `siteconfig-operator-configuration` `ConfigMap` resource, which you can complete well before initiating the process.
+
+#### Checking the current configuration  
+By default, reinstallation is disabled. You can check the current configuration by completing the following steps:
+
+Create the `NAMESPACE` environment variable for the `siteconfig-operator-configuration` `ConfigMap` resource. The namespace must match the namespace where the SiteConfig operator is installed. Run the following command:
+
+```sh
+NAMESPACE=<namespace>
+```
+
+Verify the current configuration by running the following command:
+
+```sh
+oc get configmap siteconfig-operator-configuration -n $NAMESPACE -o yaml
+```
+
+```yaml
+apiVersion: v1  
+kind: `ConfigMap`  
+metadata:  
+  name: siteconfig-operator-configuration  
+  namespace: <namespace>  
+data:  
+  allowsReinstalls: false  
+  ...  
+```
+
+- `<namespace>`: The namespace where the SiteConfig operator is installed.  
+- `allowsReinstalls`: Set to `true` enables reinstallation. 
+
+The operator continuously monitors `siteconfig-operator-configuration` `ConfigMap` resource for changes.
+
+#### Enabling cluster reinstallation
+
+Update the `ConfigMap` resource by running the following command:
+
+```sh
+oc patch configmap siteconfig-operator-configuration \  
+  -n $NAMESPACE \  
+  --type=json \  
+  -p '[{"op": "replace", "path": "/data/allowsReinstalls", "value": "true"}]'  
+```
+
+Verify the update by running the following command:
+
+```sh
+oc get configmap siteconfig-operator-configuration -n $NAMESPACE -o yaml  
+```
+
+
+### 2. Optional. Labeling resources for preservation
+
+If you want to retain essential cluster configuration data after reinstallation, the SiteConfig operator provides a backup and restore mechanism for hub-side `Secret` and `ConfigMap` resources within the `ClusterInstance` namespace.
+
+To preserve specific resources, apply the appropriate preservation label as described in the [preservation document](#preservation.md). You can label your resources well before initiating the reinstallation.
+
+The SiteConfig operator backs up resources based on the following labels:
+
+- `siteconfig.open-cluster-management.io/preserve: "<arbitrary-value>"`: Indicates to the operator to back up resources with the label only when the preservation mode is set to `All`. If no resources are labeled, the operator proceeds with the reinstallation without backing up any resources.
+- `siteconfig.open-cluster-management.io/preserve: "cluster-identity"`: Indicates to the operator to back up resources with the label when the preservation mode is set to `All` or `ClusterIdentity`. If the preservation mode is set to `ClusterIdentity` and the operator does not find at least one resource with the `siteconfig.open-cluster-management.io/preserve: "cluster-identity"` label, the reinstallation stops.
+
+To label a resource for preservation, run the following command:
+
+```sh
+oc label configmap <your_configmap> "siteconfig.open-cluster-management.io/preserve="
+```
+
+The `ClusterInstance` custom resource is updated with the correct `preservationMode` corresponding to the applied labels. The following preservation modes are supported:
+
+- `None`: No data is backed up.
+- `All`: Backs up all `Secret` and `ConfigMap` resources that have the `siteconfig.open-cluster-management.io/preserve` label. If no resources are labeled, the operator proceeds with the reinstallation without backing up any resources.
+- `ClusterIdentity`: Backs up only `Secret` and `ConfigMap` resources labeled with `siteconfig.open-cluster-management.io/preserve: "cluster-identity"`. If no resources are labeled, the operator stops the reinstallation and displays an error message.
+
+For more information, see [Preservation Modes](preservation.md#preservation-modes).
+
+### 3. Initiating a cluster reinstallation
+
+To start the reinstallation, update the `ClusterInstance` resource with a new `spec.reinstall.generation` value.
+
+#### Updating the ClusterInstance resource  
+
+Modify the `spec.reinstall.generation` value in the `ClusterInstance` resource:
+
+```yaml
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1  
+kind: `ClusterInstance`  
+metadata:  
+  name: clusterinstance-example  
+  namespace: some-namespace  
+spec:  
+  reinstall:  
+    generation: "unique-generation-string"  
+    preservationMode: "<your-preservation-mode>"  
+```
+
+:information_source: Ensure you set the appropriate preservation mode when you modify the `ClusterInstance` resource. `"None"`, `"All"`, or `"ClusterIdentity"` are valid values.
+
+
+When defining the `spec.reinstall` object, you can modify the following additional fields in the `ClusterInstance` resource:
+
+- `spec.extraAnnotations`
+- `spec.extraLabels`
+- `spec.suppressedManifests`
+- `spec.pruneManifests`
+- `spec.nodes/<node-id>/extraAnnotations`
+- `spec.nodes/<node-id>/extraLabels`
+- `spec.nodes/<node-id>/suppressedManifests`
+- `spec.nodes/<node-id>/pruneManifests`
+- `spec.nodes/<node-id>/bmcAddress`
+- `spec.nodes/<node-id>/bootMACAddress`
+- `spec.nodes/<node-id>/nodeNetwork/interfaces/macAddress`
+- `spec.nodes/<node-id>/rootDeviceHints`
+
+:information_source: `<node-id>` represents the updated `NodeSpec` object.
+
+
+#### Applying the changes  
+Use one of the following methods:
+
+- **GitOps Approach**: Commit and push the updated `ClusterInstance` resource to your Git repository.
+- **Manual Application**: Apply the changes directly on the hub cluster:
+
+  ```sh
+  oc apply -f clusterinstance-example.yaml  
+  ```  
+
+### 4. Optional. Monitoring the cluster reinstallation
+
+The reinstallation has two phases:
+
+- **Phase 1**: Reinstallation request handling
+  - **Request validation**: The SiteConfig operator validates the request.
+  - **Data preservation**: The SiteConfig operator backs up labeled resources.
+  - **Cleanup**: The SiteConfig operator removes existing installation manifests. If this step times out, the reinstallation stops and the `ClusterInstance` resource is paused.
+  - **Data restoration**: The SiteConfig operator restores preserved data.
+
+- **Phase 2**: Cluster provisioning
+  - **Manifest regeneration**: The SiteConfig operator generates new manifests from templates.
+  - **Cluster installation**: The cluster is provisioned using the new manifests.
+
+You can track progress in the `status.reinstall.conditions` and `status.conditions` fields for phase 1 and 2, respectively. To track the cluster reinstallation progress, the SiteConfig operator provides the following status conditions:
+
+- `ReinstallRequestProcessed` – Indicates the overall status of the reinstallation request.
+- `ReinstallRequestValidated` – Confirms the validity of the reinstallation request.
+- `ReinstallPreservationDataBackedUp` – Tracks the backup status of preserved data.
+- `ReinstallClusterIdentityDataDetected` – Determines whether cluster identity data is available for preservation.
+- `ReinstallRenderedManifestsDeleted` – Monitors the deletion of rendered manifests associated with the `ClusterInstance` resource.
+- `ReinstallPreservationDataRestored` – Tracks the restoration status of preserved data.
+
+The`status.reinstall` field provides further information about the reinstallation process with the following fields:
+
+- `InProgressGeneration` – Identifies the active generation being processed for reinstallation.
+- `ObservedGeneration` – Indicates the last successfully processed reinstallation request.
+- `RequestStartTime` – Indicates the time when the reinstallation request was initiated.
+- `RequestEndTime` – Indicates the time when the reinstallation process was completed.
+- `History` – Displays past reinstallation attempts, including generation details, timestamps, and specification changes to the `ClusterInstance` resource.
+
+For more information about the reinstallation conditions, see [Cluster reinstallation status conditions](status_conditions.md).
+
+To monitor the cluster reinstallation progress, complete the following steps:
+
+1. Verify that the reinstallation request is being processed:  
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallRequestProcessed")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallRequestProcessed"
+    "reason": "InProgress",
+    "status": "False",
+    ...
+    }
+    ```
+
+2. Verify that the cluster reinstallation request is validated successfully:
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallRequestValidated")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallRequestValidated"
+    "reason": "Completed",
+    "status": "True",
+    ...
+    }
+    ```
+
+3. Optional. If you set the `spec.reinstall.preservationMode` field to `All` or `ClusterIdentity`, verify that the cluster identity data is preserved:
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallPreservationDataBackedup")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallPreservationDataBackedup"
+    "reason": "Completed",
+    "status": "True",
+    ...
+    }
+    ```
+
+4. Optional. If you set the `spec.reinstall.preservationMode` field to `All` or `ClusterIdentity`, verify that the cluster identity data is detected:
+   
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallClusterIdentityDataDetected")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallClusterIdentityDataDetected"
+    "reason": "DataAvailable",
+    "status": "True",
+    ...
+    }
+    ```
+
+
+5. Verify that the installation manifests are deleted. The deletion can take several minutes to complete.
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallRenderedManifestsDeleted")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallRenderedManifestsDeleted"
+    "reason": "Completed",
+    "status": "True",
+    ...
+    }
+    ```
+
+6. Optional. If you set the `preseservationMode` field to `All` or `ClusterIdentity`, verify that the data preserved earlier are restored:
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallPreservationDataRestored")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallPreservationDataRestored"
+    "reason": "Completed",
+    "status": "True",
+    ...
+    }
+    ```
+
+7. After you verified the previous steps, ensure that the reinstallation request completed successfully:
+
+    ```sh
+    oc get clusterinstance clusterinstance-example -n some-namespace -o json | jq -r '.status.reinstall.conditions[] | select(.type=="ReinstallRequestProcessed")'
+    ```
+
+    Example output:
+    ```sh
+    {
+    "type": "ReinstallRequestProcessed"
+    "reason": "Completed",
+    "status": "True",
+    ...
+    }
+    ```
+
+### 5. Verify cluster availability
+
+Confirm that the cluster is successfully reinstalled and is operational by running an `oc` command with the `kubeconfig` file that is associated with the reinstalled cluster.
+
+## Advanced topics
+
+### Image-Based Break/Fix for single-node OpenShift hardware replacement
+
+The Image-Based Break/Fix feature utilizes the cluster reinstallation mechanism of the SiteConfig operator to simplify single-node OpenShift hardware replacement. The feature minimizes downtime by preserving the original identity of the cluster. The Image-Based Break/Fix feature retains critical cluster details, including identifiers, cryptographic keys, such as `kubeconfig`, and authentication credentials, which enables the replacement node to seamlessly assume the identity of the failed hardware.
+
+Designed for like-for-like hardware replacements in single-node OpenShift clusters installed using the Image Based Install method, Image-Based Break/Fix introduces a GitOps-compatible, declarative API. Users can initiate hardware replacement with a single Git commit. Powered by the SiteConfig operator and Image Based Install Operator, Image-Based Break/Fix enables cluster redeployment using the existing `ClusterInstance` custom resource.
+
+With Image-Based Break/Fix, OpenShift users gain a resilient, automated, and GitOps-native solution for quickly restoring single-node OpenShift clusters after hardware failures.
+
+#### Requirements
+
+To reinstall an OpenShift cluster using the SiteConfig operator, ensure the following conditions are met:
+- The cluster is a singe-node OpenShift cluster installed using the Image Based Install provisioning method.
+- The faulty hardware is replaced with a new node with identical specifications.
+
+#### Image-Based Break/Fix cluster reinstallation workflow
+
+The Image-Based Break/Fix workflow is similar to the cluster reinstallation workflow with certain differences. 
+To familiarize yourself with the differences in the workflows, see the high-level overview of the Image-Based Break/Fix cluster reinstallation workflow:
+
+1. [Enable the SiteConfig operator reinstallation service.](#1-enabling-cluster-reinstallation-in-the-siteconfig-operator)
+2. [Initiate a cluster reinstallation.](#3-initiating-a-cluster-reinstallation)
+   - Set `spec.reinstall.preservationMode: "ClusterIdentity"`.
+   - Update the `spec.nodes` object with the changed hardware information.
+   - :information_source: Note that the Image Based Install Operator automatically labels cluster identity resources.
+3. [Optional. Monitor the reinstallation progress.](#4-optional-monitoring-the-cluster-reinstallation)
+   - During cluster provisioning, the operators consuming the installation manifests provision the cluster using the newly generated manifests.
+     :information_source: Note that the [Image Based Install Operator](https://github.com/openshift/image-based-install-operator) detects the preserved cluster identity data and incorporates it into the configuration ISO image.
+4. [Verify that the cluster is provisioned and available.](#5-verify-cluster-availability)
+   - Use the `kubeconfig` that is associated with the failed hardware to access the reinstalled spoke cluster.
+
+#### Initiating the Image-Based Break/Fix cluster reinstallation
+
+To initiate the Image-Based Break/Fix cluster reinstallation, update the `ClusterInstance` resource by setting the `spec.reinstall.generation` field and updating the `spec.nodes` object with the changed hardware information.
+
+Modify the `spec.reinstall.generation` field and update the `spec.nodes` object in the `ClusterInstance` resource with the new node details:
+
+```yaml
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1  
+kind: `ClusterInstance`  
+metadata:  
+  name: clusterinstance-example  
+  namespace: some-namespace  
+spec:
+  ...
+  reinstall:  
+    generation: "unique-generation-string"  
+    preservationMode: "ClusterIdentity"  
+  nodes:
+    - bmcAddress: <new-node-bmcAddress> 
+      bootMACAddress: <new-node-bootMACAddress>
+      rootDeviceHints: <new-node-rootDeviceHints>
+      nodeNetwork:
+        interfaces:
+          macAddress: <new-node-macAddress>
+          ...          
+      ...      
+```

--- a/docs/reinstallation/preservation.md
+++ b/docs/reinstallation/preservation.md
@@ -1,34 +1,28 @@
 # Safeguarding ConfigMaps and Secrets During Cluster Reinstalls with SiteConfig Operator
 
-## Table of Contents
+<details>
+  <summary>Table of Contents</summary>
 
 1. [Introduction](#introduction)
 2. [Key Features](#key-features)
-   - [Backup](#backup)
-   - [Restore](#restore)
-   - [Selective Resource Management](#selective-resource-management)
 3. [Preservation Modes](#preservation-modes)
-   - [None](#none)
-   - [All](#all)
-   - [ClusterIdentity](#clusteridentity)
+   - [None](#1-none)
+   - [All](#2-all)
+   - [ClusterIdentity](#3-clusteridentity)
 4. [Backup Workflow](#backup-workflow)
    - [Backup ConfigMaps and Secrets](#backup-configmaps-and-secrets)
 5. [Restoration Workflow](#restoration-workflow)
    - [Restore ConfigMaps and Secrets](#restore-configmaps-and-secrets)
-     - [ConfigMaps](#configmaps)
-     - [Secrets](#secrets)
 6. [Example Usage](#example-usage)
    - [Preserving a ConfigMap](#preserving-a-configmap)
 
----
+</details>
 
 ## Introduction
 
-The **preservation** feature within the **SiteConfig Operator** provides a mechanism to back up and restore important
+The **preservation** feature within the **SiteConfig operator** provides a mechanism to back up and restore important
 Kubernetes resources such as **ConfigMaps** and **Secrets** that reside in the same namespace as the
 **ClusterInstance** Custom Resource (CR). This functionality ensures cluster data integrity during reinstallations.
-
----
 
 ## Key Features
 
@@ -37,23 +31,22 @@ Kubernetes resources such as **ConfigMaps** and **Secrets** that reside in the s
 3. **Selective Resource Management**: Employs **Preservation Modes** to determine which resources are backed up and
    restored.
 
----
 
 ## Preservation Modes
 
-The SiteConfig Operator allows users to control data preservation through three distinct modes:
+The SiteConfig operator allows users to control data preservation through three distinct modes:
 
 ### 1. **None**
 - **Behavior**: No ConfigMaps or Secrets are preserved.
 - **Usage**: Select this mode if data preservation is unnecessary for the cluster during reinstallation.
 
----
 
 ### 2. **All**
 - **Behavior**:
   - All ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve` (any value) in the same
-    namespace as the ClusterInstance CR are backed up.
+    namespace as the `ClusterInstance` CR are backed up.
   - The original CRs of these resources are stored as immutable Kubernetes secrets.
+  - If the SiteConfig operator does not find any labeled resources, the operator proceeds with the reinstallation without data preservation.
 
 **Label Requirement**: Add the label `siteconfig.open-cluster-management.io/preserve` with any value.
 
@@ -62,13 +55,13 @@ The SiteConfig Operator allows users to control data preservation through three 
 siteconfig.open-cluster-management.io/preserve: ""
 ```
 
----
 
 ### 3. **ClusterIdentity**
 - **Behavior**:
   - Only ConfigMaps and Secrets labeled with `siteconfig.open-cluster-management.io/preserve: "cluster-identity"` in
-    the same namespace as the ClusterInstance CR are backed up.
+    the same namespace as the `ClusterInstance` CR are backed up.
   - The original CRs of these resources are stored as immutable Kubernetes secrets.
+  - If the SiteConfig operator does not find any labeled resources, the operator stops the reinstallation process and displays an error message.
 
 **Label Requirement**: Add the label `siteconfig.open-cluster-management.io/preserve` with the value `cluster-identity`.
 
@@ -77,13 +70,12 @@ siteconfig.open-cluster-management.io/preserve: ""
 siteconfig.open-cluster-management.io/preserve: "cluster-identity"
 ```
 
----
 
 ## Backup Workflow
 
 ### Backup ConfigMaps and Secrets
 
-The SiteConfig Operator ensures the preservation of ConfigMaps and Secrets by performing the following steps:
+The SiteConfig operator ensures the preservation of ConfigMaps and Secrets by performing the following steps:
 - **Sanitizing Metadata**: Information (such as creation timestamp, UID, and owner references) is removed from
   the resource metadata.
 - **Serialization**: The resource's data is serialized into YAML format, ensuring that all relevant configuration
@@ -94,7 +86,6 @@ The SiteConfig Operator ensures the preservation of ConfigMaps and Secrets by pe
 The backup data is encoded in base64 within the Secret, preserving both the original resource data and metadata in a
 format that can be easily restored later.
 
----
 
 ## Restoration Workflow
 
@@ -107,13 +98,12 @@ Restoring a previously backed-up resource involves the following steps:
 - **Restoration**: The resource is either created or updated within the cluster to match the original state, with a
   `restoredAt` timestamp added for reference.
 
----
 
 ## Example Usage
 
 ### Preserving a ConfigMap
 
-Given the following ClusterInstance definition:
+Given the following `ClusterInstance` definition:
 
 ```yaml
 apiVersion: siteconfig.open-cluster-management.io/v1alpha1
@@ -127,7 +117,7 @@ spec:
     preservationMode: "All"
 ```
 
-#### Original ConfigMap Resource
+#### Original `ConfigMap` Resource
 
 This is the original resource that will be preserved:
 
@@ -147,7 +137,7 @@ data:
 ```
 
 
-#### Example Preserved ConfigMap Resource
+#### Example Preserved `ConfigMap` Resource
 
 The preserved resource, stored as an immutable Kubernetes Secret:
 
@@ -170,7 +160,7 @@ data:
   original-resource: YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGV4YW1wbGUtMQogIG5hbWVzcGFjZTogZGVmYXVsdAogIGxhYmVsczoKICAgIHNpdGVjb25maWcub3Blbi1jbHVzdGVyLW1hbmFnZW1lbnQuaW8vcHJlc2VydmU6ICIiCiAgYW5ub3RhdGlvbnM6CiAgICBleGFtcGxlLWFubm90YXRpb246ICJvcmlnaW5hbC1jb25maWdtYXAiCmRhdGE6CiAga2V5MTogInZhbHVlMSIKICBrZXkyOiAidmFsdWUyIg==
 ```
 
-#### Example Restored ConfigMap Resource
+#### Example Restored `ConfigMap` Resource
 
 Once the resource is restored, it will appear as follows, with a new annotation indicating the restoration time:
 

--- a/docs/reinstallation/status_conditions.md
+++ b/docs/reinstallation/status_conditions.md
@@ -1,0 +1,69 @@
+# Cluster reinstallation status conditions
+
+The SiteConfig operator defines several reinstallation status conditions to help track the progress of a cluster reinstallation. These conditions provide insights into various stages of the process.
+
+## Condition types
+
+The following condition types are available:
+
+1. `ReinstallRequestProcessed` - Indicates the overall status of the reinstallation request.
+2. `ReinstallRequestValidated` - Verifies the validity of the reinstallation request.
+3. `ReinstallPreservationDataBackedup` - Tracks the backup status of preserved data.
+4. `ReinstallClusterIdentityDataDetected` - Determines whether cluster identity data is available for preservation.
+5. `ReinstallRenderedManifestsDeleted` - Monitors the deletion of rendered manifests associated with the `ClusterInstance` custom resource.
+6. `ReinstallPreservationDataRestored` - Tracks the restoration status of preserved data.
+
+## Condition details
+
+### ReinstallRequestValidated
+Indicates whether the reinstallation request is validated.
+
+#### Condition reasons:
+- `Completed`: The reinstallation request is valid.
+- `Failed`: The reinstallation request is invalid.
+
+### ReinstallPreservationDataBackedup
+Tracks the backup process of `Secret` and `ConfigMap` objects required for preservation.
+
+#### Condition reasons:
+- `PreservationNotRequired`: No backup required as `spec.reinstall.preservationMode: None` is set.
+- `DataUnavailable`: No `Secret` or `ConfigMap` objects with the preservation label are found in the `ClusterInstance` namespace.
+- `Completed`: `Secret` and `ConfigMap` objects are successfully backed up.
+- `Failed`: One or more `Secret` and `ConfigMap` objects were not be backed up.
+
+### ReinstallClusterIdentityDataDetected
+Determines if cluster identity data is available for preservation.
+
+#### Condition reasons:
+- `PreservationNotRequired`: Data preservation is not required. The `preservationMode` field is set to `None`.
+- `DataAvailable`: Cluster identity `Secret` and `ConfigMap` objects are successfully located.
+- `DataUnavailable`: No cluster identity `Secret` or `ConfigMap` objects were detected.
+- `Failed`: The preservation mode is set to `ClusterIdentity`, but no cluster identity data was found.
+
+### ReinstallRenderedManifestsDeleted
+Tracks the deletion of rendered manifests associated with the ClusterInstance.
+
+#### Condition reasons:
+- `InProgress`: Deleting rendered manifests is in progress.
+- `Completed`: Successfully deleted all rendered manifests.
+- `Failed`: Failed to delete one or more rendered manifests.
+- `TimedOut`: Timed out while waiting for rendered manifests to be deleted.
+
+### ReinstallPreservationDataRestored
+Tracks the restoration of previously backed-up `Secret` and `ConfigMap` objects.
+
+#### Condition reasons:
+- `PreservationNotRequired`: Preservation is not required (`preservationMode: None`).
+- `DataUnavailable`: No preserved `Secret` or `ConfigMap` objects detected for restoration.
+- `Completed`: `Secret` and `ConfigMap` objects are successfully restored.
+- `Failed`: Failed to restore one or more `Secret` and `ConfigMap` objects.
+
+### ReinstallRequestProcessed
+Indicates the overall status of the reinstallation request processing.
+
+#### Condition reasons:
+- `InProgress`: The reinstallation process is ongoing.
+- `Completed`: The reinstallation process successfully completed, and the cluster is ready for reprovisioning.
+- `Failed`: The reinstallation process encountered an error and failed.
+- `TimedOut`: The reinstallation process exceeded the expected time limit and did not complete successfully.
+


### PR DESCRIPTION
# Summary  

This PR introduces the following documentation updates:  

- **New documentation:**  
  - Cluster reinstallation using the SiteConfig Operator  
  - Image-Based Break/Fix (IBBF) for SNO hardware replacement  
  - Cluster reinstallation status conditions  
- **File relocation:**  
  - Moved `preservation.md` to `docs/reinstallation/` to centralize all reinstallation-related documentation.  


Partially resolves: [TELCODOCS-2014](https://issues.redhat.com/browse/TELCODOCS-2014)

/cc @carbonin @browsell @amolnar-rh @swopebe 