### PR TITLE
ACM-20654: Add image-digest param for sast-coverity-check konflux task

### DIFF
--- a/.tekton/siteconfig-acm-214-pull-request.yaml
+++ b/.tekton/siteconfig-acm-214-pull-request.yaml
@@ -476,6 +476,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE

--- a/.tekton/siteconfig-acm-214-push.yaml
+++ b/.tekton/siteconfig-acm-214-push.yaml
@@ -473,6 +473,8 @@ spec:
         - "false"
     - name: sast-coverity-check
       params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE


### PR DESCRIPTION
Resolves: [ACM-20654](https://issues.redhat.com/browse/ACM-20654)

/cc @dislbenn @dhaiducek 