### PR TITLE
ACM-20748: Set the number of workers to 0 for SNO

### DIFF
--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -150,6 +150,13 @@ func buildClusterData(clusterInstance *v1alpha1.ClusterInstance, node *v1alpha1.
 		}
 	}
 
+	if clusterInstance.Spec.ClusterType == v1alpha1.ClusterTypeSNO {
+		// Set the number of workers to 0 for SNO (Single Node OpenShift) clusters.
+		// This is required due to immutability constraints enforced by the Assisted Installer,
+		// specifically by AgentClusterInstall when attempting to expand an SNO cluster.
+		workerAgents = 0
+	}
+
 	data = &ClusterData{
 		Spec: clusterInstance.Spec,
 		SpecialVars: SpecialVars{

--- a/internal/controller/clusterinstance/helper_test.go
+++ b/internal/controller/clusterinstance/helper_test.go
@@ -146,10 +146,15 @@ func Test_buildClusterData(t *testing.T) {
 					NetworkType:            NetworkType,
 					InstallConfigOverrides: InstallConfigOverrides,
 					CPUPartitioning:        CPUPartitioning,
+					ClusterType:            v1alpha1.ClusterTypeSNO,
 					Nodes: []v1alpha1.NodeSpec{
 						{
 							HostName: "node1",
 							Role:     "master",
+						},
+						{
+							HostName: "node2",
+							Role:     "worker",
 						},
 					},
 				},
@@ -160,10 +165,15 @@ func Test_buildClusterData(t *testing.T) {
 					NetworkType:            NetworkType,
 					InstallConfigOverrides: InstallConfigOverrides,
 					CPUPartitioning:        CPUPartitioning,
+					ClusterType:            v1alpha1.ClusterTypeSNO,
 					Nodes: []v1alpha1.NodeSpec{
 						{
 							HostName: "node1",
 							Role:     "master",
+						},
+						{
+							HostName: "node2",
+							Role:     "worker",
 						},
 					},
 				},


### PR DESCRIPTION
# Summary

This PR ensures that the number of worker agents is explicitly set to 0 for Single Node OpenShift (SNO) clusters. This change is necessary to comply with immutability restrictions enforced by the Assisted Installer, specifically by the `AgentClusterInstall` resource, which prevents modifying the worker count during or after an attempted SNO expansion.

Resolves: [ACM-20748](https://issues.redhat.com/browse/ACM-20748)

/cc @carbonin 