### PR TITLE
ACM-20922: Fix admissibility for changes to nodeNetwork.interfaces.macAddress for cluster reinstallations

### DIFF
--- a/api/v1alpha1/clusterinstance_validation.go
+++ b/api/v1alpha1/clusterinstance_validation.go
@@ -109,7 +109,7 @@ func validatePostProvisioningChanges(
 			"/reinstall",
 			"/nodes/*/bmcAddress",
 			"/nodes/*/bootMACAddress",
-			"/nodes/*/nodeNetwork/interfaces/macAddress",
+			"/nodes/*/nodeNetwork/interfaces/*/macAddress",
 			"/nodes/*/rootDeviceHints",
 		}...)
 	}


### PR DESCRIPTION
# Summary

This PR fixes a bug affecting the admission validating webhook for cluster reinstallation scenarios, where changes to `nodeNetwork.interfaces.macAddress` were incorrectly considered inadmissible.

Resolves: [ACM-20922](https://issues.redhat.com/browse/ACM-20922)

/cc @carbonin 