### PR TITLE
CNF-18294: Add a ReleaseImage field to SpecialVars tracking the Cluster Image Set

### DIFF
--- a/internal/controller/clusterinstance/template_engine.go
+++ b/internal/controller/clusterinstance/template_engine.go
@@ -132,6 +132,8 @@ func (te *TemplateEngine) renderTemplates(
 		for templateKey, template := range templatesConfigMap.Data {
 
 			object, err := te.renderManifestFromTemplate(
+				ctx,
+				c,
 				log,
 				clusterInstance,
 				node,
@@ -178,6 +180,8 @@ func appendAnnotationsAndLabels(
 }
 
 func (te *TemplateEngine) renderManifestFromTemplate(
+	ctx context.Context,
+	c client.Client,
 	log *zap.Logger,
 	clusterInstance *v1alpha1.ClusterInstance,
 	node *v1alpha1.NodeSpec,
@@ -188,7 +192,7 @@ func (te *TemplateEngine) renderManifestFromTemplate(
 
 	log = log.Named("renderManifestFromTemplate")
 
-	clusterData, err := buildClusterData(clusterInstance, node)
+	clusterData, err := buildClusterData(ctx, c, clusterInstance, node)
 	if err != nil {
 		log.Error("Failed to build ClusterInstance data", zap.Error(err))
 		return object, err

--- a/internal/controller/clusterinstance/test_utils.go
+++ b/internal/controller/clusterinstance/test_utils.go
@@ -41,14 +41,15 @@ const (
 )
 
 type TestParams struct {
-	ClusterName         string
-	ClusterNamespace    string
-	PullSecret          string
-	BmcCredentialsName  string
-	ClusterImageSetName string
-	ExtraManifestName   string
-	ClusterTemplateRef  string
-	NodeTemplateRef     string
+	ClusterName          string
+	ClusterNamespace     string
+	PullSecret           string
+	BmcCredentialsName   string
+	ClusterImageSetName  string
+	ClusterImageSetImage string
+	ExtraManifestName    string
+	ClusterTemplateRef   string
+	NodeTemplateRef      string
 }
 
 func (tp *TestParams) GeneratePullSecret() *corev1.Secret {
@@ -60,7 +61,7 @@ func (tp *TestParams) GenerateBMCSecret() *corev1.Secret {
 }
 
 func (tp *TestParams) GenerateClusterImageSet() *hivev1.ClusterImageSet {
-	return GetMockClusterImageSet(tp.ClusterImageSetName)
+	return GetMockClusterImageSet(tp.ClusterImageSetName, tp.ClusterImageSetImage)
 }
 
 func (tp *TestParams) GenerateExtraManifest() *corev1.ConfigMap {
@@ -94,6 +95,10 @@ func (tp *TestParams) GetResources() map[string]string {
 		resources[tp.ClusterImageSetName] = "ClusterImageSet"
 	}
 
+	if tp.ClusterImageSetImage != "" {
+		resources[tp.ClusterImageSetImage] = "ReleaseImage"
+	}
+
 	if tp.ClusterTemplateRef != "" {
 		resources[tp.ClusterTemplateRef] = configMapResource
 	}
@@ -118,12 +123,13 @@ func GetMockBmcSecret(name, namespace string) *corev1.Secret {
 		Data: map[string][]byte{"username": []byte("admin"), "password": []byte("password")}}
 }
 
-func GetMockClusterImageSet(name string) *hivev1.ClusterImageSet {
+func GetMockClusterImageSet(name, image string) *hivev1.ClusterImageSet {
 	return &hivev1.ClusterImageSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "",
-		}}
+		},
+		Spec: hivev1.ClusterImageSetSpec{ReleaseImage: image}}
 }
 
 func GetMockPullSecret(name, namespace string) *corev1.Secret {
@@ -301,6 +307,21 @@ spec:
 {{ .SpecialVars.CurrentNode.NodeNetwork.NetConfig  | toYaml | indent 4}}
   interfaces:
 {{ .SpecialVars.CurrentNode.NodeNetwork.Interfaces | toYaml | indent 4 }}`
+}
+
+func GetMockNodePoolTemplate() string {
+	return `apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: "{{ .Spec.ClusterName }}"
+  namespace: "{{ .Spec.ClusterName }}"
+  annotations:
+    siteconfig.open-cluster-management.io/sync-wave: "2"
+spec:
+  clusterName: "{{ .Spec.ClusterName }}"
+  replicas: {{ .SpecialVars.ControlPlaneAgents }}
+  release:
+    image: "{{ .SpecialVars.ReleaseImage }}"`
 }
 
 type NetConfigData struct {


### PR DESCRIPTION
This PR updates the variables available to templates in the `SpecialVars` structure to include a `ReleaseImage` that is populated from the `clusterinstance.spec.clusterImageSetNameRef`.

The purpose of this change is to enable support of cluster installation methods that use the release image as a string, and do not support the `ClusterImageSet` API, namely Hypershift aka Hosted Control Planes.

A lookup of the provided `ClusterImageSet` is performed once per `ClusterInstance` reconcile and is passed by reference through the stack of template engine functions until the `buildClusterData` function uses it to create the `ClusterData` structure for template rendering.

JIRA: [CNF-18294: Reconcile ClusterImage and HostedCluster handling of install images](https://issues.redhat.com/browse/CNF-18294)

Assisted-by: Cursor and claude-4-sonnet