### PR TITLE
Add config and bundle directories to be excluded by sonarqube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=open-cluster-management_siteconfig-operator
 sonar.projectName=siteconfig-operator
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,internal/templates/**,**/test_utils.go
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,internal/templates/**,**/test_utils.go,config/**,bundle/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**


### PR DESCRIPTION
# Summary

This PR adds the `config/` and `bundle/` directories to the sonarqube exclusion list.

/cc @carbonin 