### PR TITLE
NO-ISSUE: Fix konflux pipeline Dockerfile reference

### DIFF
--- a/.tekton/siteconfig-acm-212-pull-request.yaml
+++ b/.tekton/siteconfig-acm-212-pull-request.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: Dockerfile
+    value: build/Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineSpec:

--- a/.tekton/siteconfig-acm-212-push.yaml
+++ b/.tekton/siteconfig-acm-212-push.yaml
@@ -28,7 +28,7 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: Dockerfile
+    value: build/Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineSpec:

--- a/.tekton/siteconfig-acm-215-pull-request.yaml
+++ b/.tekton/siteconfig-acm-215-pull-request.yaml
@@ -31,7 +31,7 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: Dockerfile
+    value: build/Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineSpec:

--- a/.tekton/siteconfig-acm-215-push.yaml
+++ b/.tekton/siteconfig-acm-215-push.yaml
@@ -28,7 +28,7 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: Dockerfile
+    value: build/Dockerfile.rhtap
   - name: path-context
     value: .
   pipelineSpec:


### PR DESCRIPTION
# Summary

This PR fixes the auto-generated konflux files to reference the appropriate `Dockerfile` for building the siteconfig-operator image.
 
/cc @dhaiducek  @dislbenn 