### PR TITLE
Add missing pipeline params to Konflux

### DIFF
--- a/.tekton/siteconfig-acm-212-pull-request.yaml
+++ b/.tekton/siteconfig-acm-212-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.12"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-212
@@ -19,6 +18,10 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: 'true'
+  - name: build-source-image
+    value: 'true'
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/siteconfig-acm-212-push.yaml
+++ b/.tekton/siteconfig-acm-212-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.12"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-212
@@ -18,6 +17,10 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: 'true'
+  - name: build-source-image
+    value: 'true'
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -27,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context

--- a/.tekton/siteconfig-acm-215-pull-request.yaml
+++ b/.tekton/siteconfig-acm-215-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.15"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-215
@@ -19,6 +18,10 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: 'true'
+  - name: build-source-image
+    value: 'true'
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/siteconfig-acm-215-push.yaml
+++ b/.tekton/siteconfig-acm-215-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.15"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-215
@@ -18,6 +17,10 @@ metadata:
   namespace: crt-redhat-acm-tenant
 spec:
   params:
+  - name: hermetic
+    value: 'true'
+  - name: build-source-image
+    value: 'true'
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -27,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context


### PR DESCRIPTION
# Summary

This PR adds the missing konflux params causing enterprise failures for siteconfig in 2.15 pipelines. The 2.12 files are also updated.

/cc @dhaiducek @dislbenn 