### PR TITLE
OCPEDGE-1312: feat: add initial support for arbiter nodes

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -206,7 +206,7 @@ type NodeSpec struct {
 	// +optional
 	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
 
-	// +kubebuilder:validation:Enum=master;worker
+	// +kubebuilder:validation:Enum=master;worker;arbiter
 	// +kubebuilder:default:=master
 	// +optional
 	Role string `json:"role,omitempty"`
@@ -245,9 +245,10 @@ type NodeSpec struct {
 type ClusterType string
 
 const (
-	ClusterTypeSNO                ClusterType = "SNO"
-	ClusterTypeHighlyAvailable    ClusterType = "HighlyAvailable"
-	ClusterTypeHostedControlPlane ClusterType = "HostedControlPlane"
+	ClusterTypeSNO                    ClusterType = "SNO"
+	ClusterTypeHighlyAvailable        ClusterType = "HighlyAvailable"
+	ClusterTypeHostedControlPlane     ClusterType = "HostedControlPlane"
+	ClusterTypeHighlyAvailableArbiter ClusterType = "HighlyAvailableArbiter"
 )
 
 // PreservationMode represents the modes of data preservation for a ClusterInstance during reinstallation.
@@ -419,7 +420,7 @@ type ClusterInstanceSpec struct {
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
-	// +kubebuilder:validation:Enum=SNO;HighlyAvailable;HostedControlPlane
+	// +kubebuilder:validation:Enum=SNO;HighlyAvailable;HostedControlPlane;HighlyAvailableArbiter
 	// +optional
 	ClusterType ClusterType `json:"clusterType,omitempty"`
 

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -123,6 +123,7 @@ spec:
                 - SNO
                 - HighlyAvailable
                 - HostedControlPlane
+                - HighlyAvailableArbiter
                 type: string
               cpuArchitecture:
                 default: x86_64
@@ -430,6 +431,7 @@ spec:
                       enum:
                       - master
                       - worker
+                      - arbiter
                       type: string
                     rootDeviceHints:
                       description: |-

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -123,6 +123,7 @@ spec:
                 - SNO
                 - HighlyAvailable
                 - HostedControlPlane
+                - HighlyAvailableArbiter
                 type: string
               cpuArchitecture:
                 default: x86_64
@@ -430,6 +431,7 @@ spec:
                       enum:
                       - master
                       - worker
+                      - arbiter
                       type: string
                     rootDeviceHints:
                       description: |-

--- a/config/samples/assisted-installer/example-2node-with-arbiter.yaml
+++ b/config/samples/assisted-installer/example-2node-with-arbiter.yaml
@@ -1,0 +1,182 @@
+# example-node[12345]-bmh-secret & assisted-deployment-pull-secret need to be created under same namespace example-ai-arbiter
+---
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1
+kind: ClusterInstance
+metadata:
+  name: "example-ai-arbiter"
+  namespace: "example-ai-arbiter"
+spec:
+  baseDomain: "example.com"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "openshift-4.16"
+  sshPublicKey: "ssh-rsa AAAA..."
+  clusterName: "example-ai-arbiter"
+  clusterType: HighlyAvailableArbiter
+  networkType: "OVNKubernetes"
+  # Include references to extraManifest ConfigMaps.
+  extraManifestsRefs:
+    - name: example-extra-manifest-configmap
+  extraLabels:
+    ManagedCluster:
+      # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples
+      du-profile: "latest"
+      # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
+      # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'
+      common: true
+      # ../policygentemplates/group-du-3node-ranGen.yaml will apply to all clusters with 'group-du-3node: ""'
+      group-du-3node: ""
+      # ../policygentemplates/example-multinode-site.yaml will apply to all clusters with 'sites: "example-multinode"'
+      # Normally this should match or contain the cluster name so it only applies to a single cluster
+      sites : "example-multinode"
+  clusterNetwork:
+    - cidr: 1001:1::/48
+      hostPrefix: 64
+  # For clusters with static IPs, the API and Ingress IPs must be configured here
+  apiVIPs:
+    - 1111:2222:3333:4444::1:1
+  ingressVIPs:
+    - 1111:2222:3333:4444::1:2
+  serviceNetwork:
+    - cidr: 1001:2::/112
+  additionalNTPSources:
+    - 1111:2222:3333:4444::2
+  templateRefs:
+    - name: ai-cluster-templates-v1
+      namespace: siteconfig-operator
+  nodes:
+    # First master node
+    - hostName: "example-node1.example.com"
+      role: "master"
+      nodeLabels:
+        node-role.kubernetes.io/master-du:
+        custom-label/parameter1: true
+      bmcAddress: "idrac-virtualmedia+https://[1111:2222:3333:4444::bbbb:1]/redfish/v1/Systems/System.Embedded.1"
+      bmcCredentialsName:
+        name: "example-node1-bmh-secret"
+      bootMACAddress: "AA:BB:CC:DD:EE:11"
+      # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable
+      bootMode: "UEFISecureBoot"
+      rootDeviceHints:
+        deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
+      nodeNetwork:
+        interfaces:
+          - name: eno1
+            macAddress: "AA:BB:CC:DD:EE:11"
+        config:
+          interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: false
+              ipv6:
+                enabled: true
+                address:
+                - ip: 1111:2222:3333:4444::aaaa:1
+                  prefix-length: 64
+          dns-resolver:
+            config:
+              search:
+              - example.com
+              server:
+              - 1111:2222:3333:4444::2
+          routes:
+            config:
+            - destination: ::/0
+              next-hop-interface: eno1
+              next-hop-address: 1111:2222:3333:4444::1
+              table-id: 254
+      templateRefs:
+        - name: ai-node-templates-v1
+          namespace: siteconfig-operator
+
+    # Second master node
+    - hostName: "example-node2.example.com"
+      role: "master"
+      bmcAddress: "idrac-virtualmedia+https://[1111:2222:3333:4444::bbbb:2]/redfish/v1/Systems/System.Embedded.1"
+      bmcCredentialsName:
+        name: "example-node2-bmh-secret"
+      bootMACAddress: "AA:BB:CC:DD:EE:22"
+      # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable
+      bootMode: "UEFISecureBoot"
+      rootDeviceHints:
+        deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
+      nodeNetwork:
+        interfaces:
+          - name: eno1
+            macAddress: "AA:BB:CC:DD:EE:22"
+        config:
+          interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: false
+              ipv6:
+                enabled: true
+                address:
+                - ip: 1111:2222:3333:4444::aaaa:2
+                  prefix-length: 64
+          dns-resolver:
+            config:
+              search:
+              - example.com
+              server:
+              - 1111:2222:3333:4444::2
+          routes:
+            config:
+            - destination: ::/0
+              next-hop-interface: eno1
+              next-hop-address: 1111:2222:3333:4444::1
+              table-id: 254
+      templateRefs:
+        - name: ai-node-templates-v1
+          namespace: siteconfig-operator
+
+    # First arbiter node
+    - hostName: "example-node3.example.com"
+      role: "arbiter"
+      nodeLabels:
+        node-role.kubernetes.io/arbiter:
+        custom-label/arbiter: true
+      bmcAddress: "idrac-virtualmedia+https://[1111:2222:3333:4444::bbbb:4]/redfish/v1/Systems/System.Embedded.1"
+      bmcCredentialsName:
+        name: "example-node3-bmh-secret"
+      bootMACAddress: "AA:BB:CC:DD:EE:44"
+      # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable
+      bootMode: "UEFISecureBoot"
+      rootDeviceHints:
+        deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
+      nodeNetwork:
+        interfaces:
+          - name: eno1
+            macAddress: "AA:BB:CC:DD:EE:44"
+        config:
+          interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: false
+              ipv6:
+                enabled: true
+                address:
+                - ip: 1111:2222:3333:4444::aaaa:4
+                  prefix-length: 64
+          dns-resolver:
+            config:
+              search:
+              - example.com
+              server:
+              - 1111:2222:3333:4444::2
+          routes:
+            config:
+            - destination: ::/0
+              next-hop-interface: eno1
+              next-hop-address: 1111:2222:3333:4444::1
+              table-id: 254
+      templateRefs:
+        - name: ai-node-templates-v1
+          namespace: siteconfig-operator
+

--- a/internal/controller/clusterinstance/helper.go
+++ b/internal/controller/clusterinstance/helper.go
@@ -39,9 +39,9 @@ const (
 )
 
 type SpecialVars struct {
-	CurrentNode                          v1alpha1.NodeSpec
-	InstallConfigOverrides, ReleaseImage string
-	ControlPlaneAgents, WorkerAgents     int
+	CurrentNode                                     v1alpha1.NodeSpec
+	InstallConfigOverrides, ReleaseImage            string
+	ControlPlaneAgents, WorkerAgents, ArbiterAgents int
 }
 
 // ClusterData is a special object that provides an interface to the ClusterInstance spec fields for use in rendering
@@ -145,15 +145,18 @@ func buildClusterData(
 		installConfigOverrides = ""
 	}
 
-	// Determine the number of control-plane and worker agents
+	// Determine the number of control-plane, worker, and arbiter agents
 	controlPlaneAgents := 0
 	workerAgents := 0
+	arbiterAgents := 0
 	for _, node := range clusterInstance.Spec.Nodes {
 		switch node.Role {
 		case "master":
 			controlPlaneAgents++
 		case "worker":
 			workerAgents++
+		case "arbiter":
+			arbiterAgents++
 		}
 	}
 
@@ -181,6 +184,7 @@ func buildClusterData(
 			InstallConfigOverrides: installConfigOverrides,
 			ControlPlaneAgents:     controlPlaneAgents,
 			WorkerAgents:           workerAgents,
+			ArbiterAgents:          arbiterAgents,
 			ReleaseImage:           releaseImage,
 		},
 	}

--- a/internal/controller/clusterinstance/helper_test.go
+++ b/internal/controller/clusterinstance/helper_test.go
@@ -198,6 +198,7 @@ func Test_buildClusterData(t *testing.T) {
 					InstallConfigOverrides: expectedInstallConfigOverrides,
 					ControlPlaneAgents:     1,
 					WorkerAgents:           0,
+					ArbiterAgents:          0,
 					ReleaseImage:           "test-image",
 				},
 			},
@@ -274,11 +275,104 @@ func Test_buildClusterData(t *testing.T) {
 					InstallConfigOverrides: expectedInstallConfigOverrides,
 					ControlPlaneAgents:     2,
 					WorkerAgents:           1,
+					ArbiterAgents:          0,
 					ReleaseImage:           "test-image",
 				},
 			},
 			error: nil,
 			name:  "3 node (2 master, 1 worker) ClusterInstance with nodeId set to first node",
+		},
+		{
+			clusterInstance: &v1alpha1.ClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-cluster",
+				},
+				Spec: v1alpha1.ClusterInstanceSpec{
+					NetworkType:            NetworkType,
+					InstallConfigOverrides: InstallConfigOverrides,
+					CPUPartitioning:        CPUPartitioning,
+					ClusterImageSetNameRef: "test-clusterimageset",
+					Nodes: []v1alpha1.NodeSpec{
+						{
+							HostName: "node1",
+							Role:     "master",
+						},
+						{
+							HostName: "node2",
+							Role:     "master",
+						},
+						{
+							HostName: "node3",
+							Role:     "arbiter",
+						},
+						{
+							HostName: "node4",
+							Role:     "worker",
+						},
+						{
+							HostName: "node5",
+							Role:     "arbiter",
+						},
+					},
+				},
+			},
+			clusterImageSet: &hivev1.ClusterImageSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-clusterimageset",
+					Namespace: "",
+				},
+				Spec: hivev1.ClusterImageSetSpec{
+					ReleaseImage: "test-image",
+				},
+			},
+			node: &v1alpha1.NodeSpec{
+				HostName: "node3",
+				Role:     "arbiter",
+			},
+			expected: ClusterData{
+				Spec: v1alpha1.ClusterInstanceSpec{
+					NetworkType:            NetworkType,
+					InstallConfigOverrides: InstallConfigOverrides,
+					CPUPartitioning:        CPUPartitioning,
+					ClusterImageSetNameRef: "test-clusterimageset",
+					Nodes: []v1alpha1.NodeSpec{
+						{
+							HostName: "node1",
+							Role:     "master",
+						},
+						{
+							HostName: "node2",
+							Role:     "master",
+						},
+						{
+							HostName: "node3",
+							Role:     "arbiter",
+						},
+						{
+							HostName: "node4",
+							Role:     "worker",
+						},
+						{
+							HostName: "node5",
+							Role:     "arbiter",
+						},
+					},
+				},
+				SpecialVars: SpecialVars{
+					CurrentNode: v1alpha1.NodeSpec{
+						HostName: "node3",
+						Role:     "arbiter",
+					},
+					InstallConfigOverrides: expectedInstallConfigOverrides,
+					ControlPlaneAgents:     2,
+					WorkerAgents:           1,
+					ArbiterAgents:          2,
+					ReleaseImage:           "test-image",
+				},
+			},
+			error: nil,
+			name:  "5 node (2 master, 1 worker, 2 arbiter) ClusterInstance with nodeId set to arbiter node",
 		},
 		{
 			clusterInstance: &v1alpha1.ClusterInstance{

--- a/internal/controller/clusterinstance/template_engine_test.go
+++ b/internal/controller/clusterinstance/template_engine_test.go
@@ -167,7 +167,7 @@ func TestTemplateEngineRender(t *testing.T) {
 						"clusterNetwork": []interface{}{map[string]interface{}{"cidr": "203.0.113.0/24", "hostPrefix": 23}},
 						"machineNetwork": []interface{}{map[string]interface{}{"cidr": "203.0.113.0/24"}},
 						"serviceNetwork": []interface{}{"203.0.113.0/24"}},
-					"provisionRequirements": map[string]interface{}{"controlPlaneAgents": 1, "workerAgents": 0},
+					"provisionRequirements": map[string]interface{}{"controlPlaneAgents": 1, "workerAgents": 0, "arbiterAgents": 0},
 					"sshPublicKey":          "ssh-rsa"}},
 			wantErr: false,
 		},

--- a/internal/controller/clusterinstance/test_utils.go
+++ b/internal/controller/clusterinstance/test_utils.go
@@ -247,6 +247,7 @@ spec:
   provisionRequirements:
     controlPlaneAgents: {{ .SpecialVars.ControlPlaneAgents }}
     workerAgents: {{ .SpecialVars.WorkerAgents }}
+    arbiterAgents: {{ .SpecialVars.ArbiterAgents }}
 {{ if .Spec.Proxy }}
   proxy:
 {{ .Spec.Proxy | toYaml | indent 4 }}

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -69,6 +69,7 @@ spec:
   provisionRequirements:
     controlPlaneAgents: {{ .SpecialVars.ControlPlaneAgents }}
     workerAgents: {{ .SpecialVars.WorkerAgents }}
+    arbiterAgents: {{ .SpecialVars.ArbiterAgents }}
 {{ if .Spec.Proxy }}
   proxy:
 {{ .Spec.Proxy | toYaml | indent 4 }}


### PR DESCRIPTION
<!-- 
Thank you for contributing to siteconfig!

This template is not mandatory, but it is highly recommended.
Please fill out this template to help reviewers understand your changes.
For detailed guidelines, see CONTRIBUTING.md
-->

## Problem / Requirement / Reason for change

<!-- 
Clearly describe the problem being solved or feature being added.
What is the current behavior? Why does it need to change?
-->

Highly Available Arbiter was a new cluster type added to OpenShift to allow customers to deploy a cluster with 2 regular control plane nodes and 1 smaller arbiter node that is used primarly to support etcd and keep the cluster HA. This feature is in the OCP installer, assisted installer and the agent based installer. We wish to make sure we expose this cluster type to ZTP to allow ACM users to also deploy an HA Arbiter cluster.

## Changes Made

<!-- 
Summarize the key changes in your implementation.
Use bullet points for clarity.
-->

- added config options for creating an arbiter node for HighlyAvailableArbiter control plane topology clusters

## Testing

<!-- 
Describe how you tested the changes.
Include test cases, manual testing steps, or validation performed.
For documentation-only changes, you may write "N/A - Documentation only"
-->

- Unit tests added
- Code coverage for new code: 100%

## JIRA

<!-- 
Link to the JIRA issue (if applicable).
Format: https://issues.redhat.com/browse/JIRA-XXXXX
Or write "NO-ISSUE" if this is a minor change (docs, typos, minor up-versioning)
-->

https://issues.redhat.com/browse/OCPEDGE-1312

## AI Assistance

None

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [ ] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)
