### PR TITLE
Future proof assisted-service API use of deprecated webhook

### DIFF
--- a/hack/patch-vendor.sh
+++ b/hack/patch-vendor.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script patches vendor files to fix webhook.Validator deprecation issues
+# Run this after 'go mod vendor'
+
+set -e
+
+echo "Patching vendor files for webhook.Validator deprecation..."
+
+# Files to patch
+WEBHOOK_FILES=(
+    "vendor/github.com/openshift/assisted-service/api/v1beta1/agent_webhook.go"
+    "vendor/github.com/openshift/assisted-service/api/v1beta1/agentclassification_webhook.go"
+    "vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_webhook.go"
+)
+
+for file in "${WEBHOOK_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        echo "Patching $file..."
+
+        # Add context import if not present
+        if ! grep -q '"context"' "$file"; then
+            sed -i '/^import (/a\\t"context"' "$file"
+        fi
+
+        # Replace webhook.Validator with webhook.CustomValidator
+        sed -i 's/webhook\.Validator/webhook.CustomValidator/g' "$file"
+
+        # Fix ValidateCreate method signature
+        sed -Ei 's/func (.*) ValidateCreate\(\) (.*)/func \1 ValidateCreate(ctx context.Context, obj runtime.Object) \2/g' "$file"
+
+        # Fix ValidateUpdate method signature  
+        sed -Ei 's/func (.*) ValidateUpdate\(old runtime\.Object\)/func \1 ValidateUpdate(ctx context.Context, old, newObj runtime.Object)/g' "$file"
+
+        # Fix ValidateDelete method signature
+        sed -Ei 's/func (.*) ValidateDelete\(\) (.*)/func \1 ValidateDelete(ctx context.Context, obj runtime.Object) \2/g' "$file"
+
+        echo "Patched $file successfully"
+    else
+        echo "Warning: $file not found"
+    fi
+done
+
+echo "Vendor patching completed!"

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_webhook.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/assisted-service/models"
@@ -40,15 +41,15 @@ func (r *Agent) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/validate-agent-install-openshift-io-v1beta1-agent,mutating=false,failurePolicy=fail,sideEffects=None,groups=agent-install.openshift.io,resources=agents,verbs=create;update,versions=v1beta1,name=vagent.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &Agent{}
+var _ webhook.CustomValidator = &Agent{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Agent) ValidateCreate() (admission.Warnings, error) {
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *Agent) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Agent) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *Agent) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
 	agentlog.Info("validate update", "name", r.Name)
 	oldObject, ok := old.(*Agent)
 	if !ok {
@@ -72,8 +73,8 @@ func (r *Agent) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Agent) ValidateDelete() (admission.Warnings, error) {
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *Agent) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentclassification_webhook.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentclassification_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -47,10 +48,10 @@ func (r *AgentClassification) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/validate-agent-install-openshift-io-v1beta1-agentclassification,mutating=false,failurePolicy=fail,sideEffects=None,groups=agent-install.openshift.io,resources=agentclassifications,verbs=create;update,versions=v1beta1,name=vagentclassification.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &AgentClassification{}
+var _ webhook.CustomValidator = &AgentClassification{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *AgentClassification) ValidateCreate() (admission.Warnings, error) {
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *AgentClassification) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	agentclassificationlog.Info("validate create", "name", r.Name)
 	f := field.NewPath("spec")
 	errs := validation.ValidateLabels(map[string]string{ClassificationLabelPrefix + r.Spec.LabelKey: r.Spec.LabelValue}, f)
@@ -73,8 +74,8 @@ func (r *AgentClassification) ValidateCreate() (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *AgentClassification) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *AgentClassification) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
 	agentclassificationlog.Info("validate update", "name", r.Name)
 
 	oldAgentClassification, ok := old.(*AgentClassification)
@@ -92,7 +93,7 @@ func (r *AgentClassification) ValidateUpdate(old runtime.Object) (admission.Warn
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *AgentClassification) ValidateDelete() (admission.Warnings, error) {
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *AgentClassification) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_webhook.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,10 +39,10 @@ func (r *InfraEnv) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/validate-agent-install-openshift-io-v1beta1-infraenv,mutating=false,failurePolicy=fail,sideEffects=None,groups=agent-install.openshift.io,resources=infraenvs,verbs=create;update,versions=v1beta1,name=vinfraenv.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &InfraEnv{}
+var _ webhook.CustomValidator = &InfraEnv{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *InfraEnv) ValidateCreate() (admission.Warnings, error) {
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *InfraEnv) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	infraenvlog.Info("validate create", "name", r.Name)
 	if r.Spec.ClusterRef != nil && r.Spec.OSImageVersion != "" {
 		err := fmt.Errorf("Failed validation: Either Spec.ClusterRef or Spec.OSImageVersion should be specified (not both).")
@@ -52,8 +53,8 @@ func (r *InfraEnv) ValidateCreate() (admission.Warnings, error) {
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *InfraEnv) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *InfraEnv) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
 	infraenvlog.Info("validate update", "name", r.Name)
 	oldInfraEnv, ok := old.(*InfraEnv)
 	if !ok {
@@ -67,7 +68,7 @@ func (r *InfraEnv) ValidateUpdate(old runtime.Object) (admission.Warnings, error
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *InfraEnv) ValidateDelete() (admission.Warnings, error) {
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (r *InfraEnv) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This patch does not affect the part of the API used by siteconfig, it just allows successful compilation in future versions where the webhook calls are removed.

- Adds script to sed patch assisted-service API usage of deprecated webhook calls
- Adds make targets vendor, vendor-patch
- Adds target vendor-patch to ci job
- Adds a timeout to kustomize script pull that was causing flakes in ci-job

Signed-off-by: cwilkers cwilkers@redhat.com
With assistance by AI, (claude-sonnet-4@20250514)