### PR TITLE
Bump Go version to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.23.6
+go 1.24.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Simply changes go version (future requirement for hypershift API inclusion)