### PR TITLE
Removed hard coded etcd storage from hcp template

### DIFF
--- a/internal/templates/hosted-cluster/template.go
+++ b/internal/templates/hosted-cluster/template.go
@@ -47,10 +47,6 @@ spec:
   etcd:
     managed:
       storage:
-        persistentVolume:
-          size: 8Gi
-          storageClassName: lvms-local
-        restoreSnapshotURL: null
         type: PersistentVolume
     managementType: Managed
   fips: false


### PR DESCRIPTION
Remove accidental hard-coding of a storage class where it was not required