### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for siteconfig-acm-214

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -31,7 +31,8 @@ ENV SUMMARY="SiteConfig Operator is a template-driven cluster provisioning solut
     DESCRIPTION="SiteConfig operator as a template-driven cluster provisioning solution, which allows you to \
 provision clusters with all available installation methods."
 
-LABEL name="siteconfig" \
+LABEL name="rhacm2/acm-siteconfig-rhel9" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       com.redhat.component="siteconfig-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
