### PR TITLE
ACM-24105: Bump Go to 1.24 and update Dockerfile builder images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.14.0
+VERSION ?= 2.15.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1138,7 +1138,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: siteconfig.v2.14.0
+  name: siteconfig.v2.15.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1358,7 +1358,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/stolostron/siteconfig-operator:2.14.0
+                image: quay.io/stolostron/siteconfig-operator:2.15.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -1471,7 +1471,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 2.14.0
+  version: 2.15.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/stolostron/siteconfig-operator
-  newTag: 2.14.0
+  newTag: 2.15.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.23.6
+go 1.24.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Resolves: [ACM-24105](https://issues.redhat.com/browse/ACM-24105)

/cc @carbonin 