### PR TITLE
Add GitHub repository labels to container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV SUMMARY="SiteConfig Operator is a template-driven cluster provisioning solut
 provision clusters with all available installation methods."
 
 LABEL name="siteconfig" \
+      url="https://github.com/stolostron/siteconfig" \
       summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       com.redhat.component="siteconfig-operator" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** main

**Components affected:** siteconfig

**Branch details:** siteconfig (revision: main, fast-forwarded to: main)

**Label added:**
- url: https://github.com/stolostron/siteconfig

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.