### PR TITLE
ACM-24685: Add conditional guards for additionalNTPSources in default templates

### DIFF
--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -181,8 +181,10 @@ spec:
 {{ else }}
       nmstate-label: "{{ .SpecialVars.CurrentNode.HostName }}"
 {{ end }}
+{{ if .Spec.AdditionalNTPSources }}
   additionalNTPSources:
-{{ .Spec.AdditionalNTPSources | toYaml | indent 4 }}`
+{{ .Spec.AdditionalNTPSources | toYaml | indent 4 }}
+{{ end }}`
 
 const NMStateConfig = `{{ if .SpecialVars.CurrentNode.NodeNetwork }}
 apiVersion: agent-install.openshift.io/v1beta1

--- a/internal/templates/hosted-cluster/template.go
+++ b/internal/templates/hosted-cluster/template.go
@@ -179,8 +179,10 @@ spec:
 {{ else }}
       nmstate-label: "{{ .SpecialVars.CurrentNode.HostName }}"
 {{ end }}
+{{ if .Spec.AdditionalNTPSources }}
   additionalNTPSources:
-{{ .Spec.AdditionalNTPSources | toYaml | indent 4 }}`
+{{ .Spec.AdditionalNTPSources | toYaml | indent 4 }}
+{{ end }}`
 
 const NodePool = `apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool


### PR DESCRIPTION
# Summary

Add conditional guards around `additionalNTPSources` in assisted-installer and hosted-cluster templates to avoid Server-Side Apply validation errors when the field is empty.

Resolves: [ACM-24685](https://issues.redhat.com/browse/ACM-24685)

/cc @carbonin @achuzhoy 