### PR TITLE
ACM-29551: Bump Go toolchain to 1.24.12 to fix CVE-2025-61726

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/stolostron/siteconfig
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Problem / Requirement / Reason for change

CVE-2025-61726: The Go standard library's `net/url.ParseQuery` and `net/http.Request.ParseForm` functions do not limit the number of query parameters parsed. An attacker can craft a request with an extremely large number of unique key-value pairs to exhaust server memory (denial of service).

All Go versions prior to 1.24.12 are affected on the 1.24.x line. The release-2.13 branch currently uses `toolchain go1.24.6`, which is vulnerable.

Ref: https://redhat.atlassian.net/browse/ACM-29551

## Changes Made

- Bumped Go toolchain from `go1.24.6` to `go1.24.12` in `go.mod`, which includes the fix for CVE-2025-61726 (hard limit of 10,000 query parameters added to `net/url`)
- No application code changes required — this is a Go stdlib fix

## Testing

- `make ci-job` passes
- No functional changes to application code; fix is in the Go toolchain
- Code coverage for new code: N/A

## JIRA

https://issues.redhat.com/browse/ACM-29551

## AI Assistance

N/A

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [ ] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin 