### PR TITLE
ACM-14385: Stop ClusterDeployment reconciler from continuously updating completed ClusterInstances

### DIFF
--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stolostron/siteconfig/internal/controller/conditions"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return requeueWithError(err)
 	}
 
+	oldStatus := clusterInstance.Status.DeepCopy()
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
 
 	// Initialize ClusterInstance clusterdeployment reference if unset
@@ -99,8 +101,11 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	updateCIProvisionedStatus(clusterDeployment, clusterInstance, log)
 	updateCIDeploymentConditions(clusterDeployment, clusterInstance)
-	if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
-		return requeueWithError(updateErr)
+
+	if !equality.Semantic.DeepEqual(oldStatus, &clusterInstance.Status) {
+		if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
+			return requeueWithError(updateErr)
+		}
 	}
 
 	return doNotRequeue(), nil
@@ -227,15 +232,16 @@ func updateCIDeploymentConditions(cd *hivev1.ClusterDeployment, ci *v1alpha1.Clu
 			installCond.LastTransitionTime = now
 			installCond.LastProbeTime = now
 			ci.Status.DeploymentConditions = append(ci.Status.DeploymentConditions, *installCond)
-		} else {
+		} else if ciCond.Status != installCond.Status ||
+			ciCond.Reason != installCond.Reason ||
+			ciCond.Message != installCond.Message {
+			if ciCond.Status != installCond.Status {
+				ciCond.LastTransitionTime = now
+			}
 			ciCond.Status = installCond.Status
 			ciCond.Reason = installCond.Reason
 			ciCond.Message = installCond.Message
 			ciCond.LastProbeTime = now
-
-			if ciCond.Status != installCond.Status {
-				ciCond.LastTransitionTime = now
-			}
 		}
 	}
 }

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -508,6 +508,73 @@ var _ = Describe("Reconcile", func() {
 		Expect(found.Message).To(Equal("Cluster is installed (detected from ClusterDeployment Spec.Installed=true)"))
 	})
 
+	It("does not update ClusterInstance status when reconciled with unchanged ClusterDeployment conditions", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+
+		clusterDeployment := &hivev1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+				Labels: map[string]string{
+					ci.OwnedByLabel: ci.GenerateOwnedByLabelValue(clusterNamespace, clusterName),
+				},
+			},
+			Spec: hivev1.ClusterDeploymentSpec{
+				Installed: true,
+			},
+			Status: hivev1.ClusterDeploymentStatus{
+				Conditions: []hivev1.ClusterDeploymentCondition{
+					{
+						Type:    hivev1.ClusterInstallRequirementsMetClusterDeploymentCondition,
+						Status:  corev1.ConditionTrue,
+						Reason:  "ClusterAlreadyInstalling",
+						Message: "The cluster requirements are met",
+					},
+					{
+						Type:    hivev1.ClusterInstallStoppedClusterDeploymentCondition,
+						Status:  corev1.ConditionTrue,
+						Reason:  "InstallationCompleted",
+						Message: "The installation has stopped because it completed successfully",
+					},
+					{
+						Type:    hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+						Status:  corev1.ConditionTrue,
+						Reason:  "InstallationCompleted",
+						Message: "The installation has completed: Cluster is installed",
+					},
+					{
+						Type:    hivev1.ClusterInstallFailedClusterDeploymentCondition,
+						Status:  corev1.ConditionFalse,
+						Reason:  "InstallationNotFailed",
+						Message: "The installation has not failed",
+					},
+				},
+			},
+		}
+
+		Expect(c.Create(ctx, clusterDeployment)).To(Succeed())
+
+		// First reconcile: initializes ClusterInstance status
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, key, ci)).To(Succeed())
+		resourceVersionAfterFirst := ci.GetResourceVersion()
+
+		// Second reconcile: nothing changed, should not patch
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		Expect(c.Get(ctx, key, ci)).To(Succeed())
+		Expect(ci.GetResourceVersion()).To(Equal(resourceVersionAfterFirst))
+	})
+
 	DescribeTable("sets Provisioned to Completed when Spec.Installed=true regardless of condition state",
 		func(statusConditions []hivev1.ClusterDeploymentCondition) {
 			key := types.NamespacedName{


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The ClusterDeployment reconciler continuously patches ClusterInstance status every ~10-15 seconds for already-completed clusters, flooding `oc get clusterinstance -w` with redundant events and generating unnecessary API server load. This was observed at scale with 297 SNOs, where every completed cluster received continuous status updates indefinitely.

A production diff confirmed that the only fields changing were the four `lastProbeTime` values in `status.deploymentConditions` - all other fields (spec, conditions, manifests) were stable.

Root cause: `updateCIDeploymentConditions()` unconditionally sets `LastProbeTime = now` on every reconciliation, even when Status/Reason/Message haven't changed. Combined with an unconditional `PatchCIStatus` call, this always writes a diff to the API server. The resulting ClusterInstance status update triggers the unfiltered `WatchesRawSource` on the ClusterDeployment reconciler, which maps it back to a new reconcile request - creating a self-sustaining feedback loop.

## Changes Made

- Made `updateCIDeploymentConditions()` idempotent: only update fields (including `LastProbeTime`) when Status, Reason, or Message actually changed
- Added `equality.Semantic.DeepEqual` guard before `PatchCIStatus` to skip the patch entirely when status is unchanged (follows the existing pattern used in `clusterinstance_controller.go`)
- Added a test verifying that a second reconcile with identical data does not bump the ClusterInstance `ResourceVersion`

## Testing

- All 93 existing unit tests pass
- golangci-lint reports 0 issues
- New idempotency test: reconciles a completed cluster twice with identical ClusterDeployment data and asserts `ResourceVersion` is unchanged after the second reconcile
- Code coverage for new code: existing tests cover the "conditions change" path; new test covers the "no change" path

## JIRA

https://issues.redhat.com/browse/ACM-14385

## AI Assistance

- **Model Used**: Claude Opus 4.6 (1M context) via Claude Code CLI
- **Scope**: Implementation, and test authoring
- **Level**: Co-development
- **Human Review**: All code was reviewed, tested, and validated by the developer

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @Missxiaoguo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved efficiency of status update operations by implementing smarter change detection; redundant patches are now avoided when deployment status remains semantically unchanged.
  * Enhanced condition update logic to properly track status transitions separately from metadata updates, ensuring accurate timestamp handling.

* **Tests**
  * Added idempotency verification test to ensure stable and consistent behavior across multiple reconciliation cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->