### PR TITLE
ACM-15720: Add annotations to skip pull secret and BMC presence validation

### DIFF
--- a/api/v1alpha1/clusterinstance_info.go
+++ b/api/v1alpha1/clusterinstance_info.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1alpha1
 
+import "fmt"
+
 // ClusterInstance preservation label constants
 const (
 	PreservationLabelKey      = Group + "/preserve"
@@ -24,5 +26,65 @@ const (
 
 // PausedAnnotation is the annotation that pauses the reconciliation.
 const PausedAnnotation = "clusterinstance." + Group + "/paused"
+
+// ExternallyProvisionedPullSecretAnnotation, when set on a ClusterInstance to an
+// allowed value, skips controller validation that the pull secret exists. Use when
+// the pull secret is supplied by another mechanism.
+const ExternallyProvisionedPullSecretAnnotation = "clusterinstance." + Group + "/externally-provisioned-pull-secret"
+
+// ExternallyProvisionedPullSecretValueTrue is the non-empty value for
+// ExternallyProvisionedPullSecretAnnotation.
+const ExternallyProvisionedPullSecretValueTrue = "true"
+
+// ExternallyProvisionedPullSecretEnabled reports whether pull secret presence
+// validation should be skipped. Returns an error if the annotation is set to an
+// unsupported value.
+func ExternallyProvisionedPullSecretEnabled(annotations map[string]string) (bool, error) {
+	value, ok := annotations[ExternallyProvisionedPullSecretAnnotation]
+	if !ok {
+		return false, nil
+	}
+	switch value {
+	case "", ExternallyProvisionedPullSecretValueTrue:
+		return true, nil
+	default:
+		return false, fmt.Errorf(
+			"annotation %q must be empty or %q, got %q",
+			ExternallyProvisionedPullSecretAnnotation,
+			ExternallyProvisionedPullSecretValueTrue,
+			value,
+		)
+	}
+}
+
+// ExternallyProvisionedBmcSecretAnnotation, when set on a ClusterInstance to an
+// allowed value, skips controller validation that node BMC credential secrets exist.
+// Use when BMC credentials are supplied by another mechanism.
+const ExternallyProvisionedBmcSecretAnnotation = "clusterinstance." + Group + "/externally-provisioned-bmc-secret"
+
+// ExternallyProvisionedBmcSecretValueTrue is the non-empty value for
+// ExternallyProvisionedBmcSecretAnnotation.
+const ExternallyProvisionedBmcSecretValueTrue = "true"
+
+// ExternallyProvisionedBmcSecretEnabled reports whether BMC credential secret presence
+// validation should be skipped. Returns an error if the annotation is set to an
+// unsupported value.
+func ExternallyProvisionedBmcSecretEnabled(annotations map[string]string) (bool, error) {
+	value, ok := annotations[ExternallyProvisionedBmcSecretAnnotation]
+	if !ok {
+		return false, nil
+	}
+	switch value {
+	case "", ExternallyProvisionedBmcSecretValueTrue:
+		return true, nil
+	default:
+		return false, fmt.Errorf(
+			"annotation %q must be empty or %q, got %q",
+			ExternallyProvisionedBmcSecretAnnotation,
+			ExternallyProvisionedBmcSecretValueTrue,
+			value,
+		)
+	}
+}
 
 const LastClusterInstanceSpecAnnotation = "clusterinstance." + Group + "/last-observed-spec"

--- a/docs/skipping_secret_verification.md
+++ b/docs/skipping_secret_verification.md
@@ -1,0 +1,55 @@
+# Skipping pull secret and BMC secret presence checks
+
+Siteconfig’s ClusterInstance controller normally verifies that the pull secret
+and each node’s BMC credential secret exist before reconciliation continues. If
+you manage those secrets with another controller (for example External Secrets
+Operator or Vault), those objects may not exist yet when the `ClusterInstance` is
+applied.
+
+You can opt out of **existence-only** checks by setting optional annotations on
+the `ClusterInstance`. Either annotation may be used alone or together. Other
+validation (ClusterImageSet, extra manifests, template references, CRD/webhook
+rules) is unchanged.
+
+For design background, see
+[skip-cluster-secrets](enhancements/skip-cluster-secrets.md).
+
+## Annotations
+
+| Full annotation key | Purpose |
+| --- | --- |
+| `clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-pull-secret` | Do not require `spec.pullSecretRef` to exist in the ClusterInstance namespace yet. Value must be empty or `"true"`. |
+| `clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-bmc-secret` | Do not require each node’s BMC credentials secret to exist yet (namespace follows `HostRef` when set). Value must be empty or `"true"`. |
+
+For both annotations, only an empty value or `"true"` is accepted; any other value
+fails validation.
+
+## Example
+
+Apply a `ClusterInstance` that sets one or both annotations and the rest of your
+spec as usual. The fragment below only shows metadata and a few spec fields;
+adapt the rest from your cluster template.
+
+```yaml
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1
+kind: ClusterInstance
+metadata:
+  name: sno4-bmc-test
+  namespace: sno4
+  annotations:
+    clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-pull-secret: ""
+    clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-bmc-secret: ""
+spec:
+  clusterName: sno4
+  pullSecretRef:
+    name: pullsecret-cluster-sno4
+  clusterImageSetNameRef: img4.18.15-x86-64-appsub
+  # ... remainder of ClusterInstance spec ...
+```
+
+## Operational notes
+
+- You are responsible for ensuring secrets exist before any downstream install
+  path needs them; skipping checks does not create or sync secrets.
+- After secrets are in place, you may remove the annotations so the controller
+  enforces presence again on future reconciles.

--- a/internal/controller/clusterinstance/validator.go
+++ b/internal/controller/clusterinstance/validator.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +28,36 @@ import (
 	"github.com/stolostron/siteconfig/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// LogObservedExternallyProvisionedSecretAnnotations logs when allowed skip annotations
+// are set. Invalid annotation values are not logged; validation reports those separately.
+func LogObservedExternallyProvisionedSecretAnnotations(
+	log *zap.Logger,
+	clusterInstance *v1alpha1.ClusterInstance,
+) {
+	annos := clusterInstance.Annotations
+	externallyProvisionedPullSecret, pullErr := v1alpha1.ExternallyProvisionedPullSecretEnabled(annos)
+	externallyProvisionedBmcSecret, bmcErr := v1alpha1.ExternallyProvisionedBmcSecretEnabled(annos)
+	if pullErr != nil || bmcErr != nil {
+		return
+	}
+	if !externallyProvisionedPullSecret && !externallyProvisionedBmcSecret {
+		return
+	}
+
+	skipAnnotations := make([]string, 0, 2)
+	if externallyProvisionedPullSecret {
+		skipAnnotations = append(skipAnnotations, v1alpha1.ExternallyProvisionedPullSecretAnnotation)
+	}
+	if externallyProvisionedBmcSecret {
+		skipAnnotations = append(skipAnnotations, v1alpha1.ExternallyProvisionedBmcSecretAnnotation)
+	}
+	log.Info("Observed skip annotation for externally provisioned secrets; skipping presence validation",
+		zap.String("namespace", clusterInstance.Namespace),
+		zap.String("clusterInstance", clusterInstance.Name),
+		zap.Strings("annotations", skipAnnotations),
+	)
+}
 
 func validateResources(ctx context.Context, c client.Client, clusterInstance *v1alpha1.ClusterInstance) error {
 	if clusterInstance.Spec.ClusterImageSetNameRef == "" {
@@ -39,12 +71,26 @@ func validateResources(ctx context.Context, c client.Client, clusterInstance *v1
 			clusterInstance.Spec.ClusterImageSetNameRef, err)
 	}
 
+	annos := clusterInstance.Annotations
+	externallyProvisionedPullSecret, pullSecretAnnoErr := v1alpha1.ExternallyProvisionedPullSecretEnabled(annos)
+	if pullSecretAnnoErr != nil {
+		return fmt.Errorf("failed to validate %q annotation: %w",
+			v1alpha1.ExternallyProvisionedPullSecretAnnotation, pullSecretAnnoErr)
+	}
+	externallyProvisionedBmcSecret, bmcSecretAnnoErr := v1alpha1.ExternallyProvisionedBmcSecretEnabled(annos)
+	if bmcSecretAnnoErr != nil {
+		return fmt.Errorf("failed to validate %q annotation: %w",
+			v1alpha1.ExternallyProvisionedBmcSecretAnnotation, bmcSecretAnnoErr)
+	}
+
 	// Check that pull secret exists in cluster namespace
-	pullSecret := &corev1.Secret{}
-	key = types.NamespacedName{Name: clusterInstance.Spec.PullSecretRef.Name, Namespace: clusterInstance.Namespace}
-	if err := c.Get(ctx, key, pullSecret); err != nil {
-		return fmt.Errorf("failed to validate Pull Secret: [%s in namespace %s], err: %w",
-			key.Name, key.Namespace, err)
+	if !externallyProvisionedPullSecret {
+		pullSecret := &corev1.Secret{}
+		key = types.NamespacedName{Name: clusterInstance.Spec.PullSecretRef.Name, Namespace: clusterInstance.Namespace}
+		if err := c.Get(ctx, key, pullSecret); err != nil {
+			return fmt.Errorf("failed to validate Pull Secret: [%s in namespace %s], err: %w",
+				key.Name, key.Namespace, err)
+		}
 	}
 
 	// If extraManifests are defined - check that they exist
@@ -60,17 +106,19 @@ func validateResources(ctx context.Context, c client.Client, clusterInstance *v1
 	}
 
 	// Check that node BMC secrets exist in namespace
-	for _, node := range clusterInstance.Spec.Nodes {
-		bmcCredentialNS := clusterInstance.Namespace
-		if node.HostRef != nil {
-			bmcCredentialNS = node.HostRef.Namespace
-		}
-		key = types.NamespacedName{Name: node.BmcCredentialsName.Name, Namespace: bmcCredentialNS}
-		bmcSecret := &corev1.Secret{}
-		if err := c.Get(ctx, key, bmcSecret); err != nil {
-			return fmt.Errorf(
-				"failed to validate BMC credentials: %s in namespace %s [Node: Hostname=%s], err: %w",
-				node.BmcCredentialsName.Name, bmcCredentialNS, node.HostName, err)
+	if !externallyProvisionedBmcSecret {
+		for _, node := range clusterInstance.Spec.Nodes {
+			bmcCredentialNS := clusterInstance.Namespace
+			if node.HostRef != nil {
+				bmcCredentialNS = node.HostRef.Namespace
+			}
+			key = types.NamespacedName{Name: node.BmcCredentialsName.Name, Namespace: bmcCredentialNS}
+			bmcSecret := &corev1.Secret{}
+			if err := c.Get(ctx, key, bmcSecret); err != nil {
+				return fmt.Errorf(
+					"failed to validate BMC credentials: %s in namespace %s [Node: Hostname=%s], err: %w",
+					node.BmcCredentialsName.Name, bmcCredentialNS, node.HostName, err)
+			}
 		}
 	}
 

--- a/internal/controller/clusterinstance/validator_test.go
+++ b/internal/controller/clusterinstance/validator_test.go
@@ -123,6 +123,32 @@ var _ = Describe("Validate", func() {
 		Expect(err).To(MatchError(ContainSubstring("failed to validate Pull Secret")))
 	})
 
+	DescribeTable("successfully validates when pull secret is absent but ExternallyProvisionedPullSecretAnnotation is set",
+		func(annotationValue string) {
+			clusterInstance.Spec.PullSecretRef = corev1.LocalObjectReference{Name: doesNotExist}
+			clusterInstance.Annotations = map[string]string{
+				v1alpha1.ExternallyProvisionedPullSecretAnnotation: annotationValue,
+			}
+			Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+			Expect(Validate(ctx, c, clusterInstance)).To(Succeed())
+		},
+		Entry("when annotation value is empty", ""),
+		Entry("when annotation value is true", "true"),
+	)
+
+	It("fails validation when ExternallyProvisionedPullSecretAnnotation has an invalid value", func() {
+		clusterInstance.Spec.PullSecretRef = corev1.LocalObjectReference{Name: doesNotExist}
+		clusterInstance.Annotations = map[string]string{
+			v1alpha1.ExternallyProvisionedPullSecretAnnotation: "false",
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		err := Validate(ctx, c, clusterInstance)
+		Expect(err).To(MatchError(ContainSubstring(
+			`annotation "clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-pull-secret" must be empty or "true"`)))
+	})
+
 	It("fails validation due to invalid cluster-level installConfigOverrides JSON-formatted strings", func() {
 		clusterInstance.Spec.InstallConfigOverrides = "foobar"
 		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
@@ -167,6 +193,32 @@ var _ = Describe("Validate", func() {
 
 		err := Validate(ctx, c, clusterInstance)
 		Expect(err).To(MatchError(ContainSubstring("failed to validate BMC credentials")))
+	})
+
+	DescribeTable("successfully validates when BMC credential secret is absent but ExternallyProvisionedBmcSecretAnnotation is set",
+		func(annotationValue string) {
+			clusterInstance.Spec.Nodes[0].BmcCredentialsName = v1alpha1.BmcCredentialsName{Name: doesNotExist}
+			clusterInstance.Annotations = map[string]string{
+				v1alpha1.ExternallyProvisionedBmcSecretAnnotation: annotationValue,
+			}
+			Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+			Expect(Validate(ctx, c, clusterInstance)).To(Succeed())
+		},
+		Entry("when annotation value is empty", ""),
+		Entry("when annotation value is true", "true"),
+	)
+
+	It("fails validation when ExternallyProvisionedBmcSecretAnnotation has an invalid value", func() {
+		clusterInstance.Spec.Nodes[0].BmcCredentialsName = v1alpha1.BmcCredentialsName{Name: doesNotExist}
+		clusterInstance.Annotations = map[string]string{
+			v1alpha1.ExternallyProvisionedBmcSecretAnnotation: "false",
+		}
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+
+		err := Validate(ctx, c, clusterInstance)
+		Expect(err).To(MatchError(ContainSubstring(
+			`annotation "clusterinstance.siteconfig.open-cluster-management.io/externally-provisioned-bmc-secret" must be empty or "true"`)))
 	})
 
 	It("fails validation due to missing BMC credential secret in referenced Node namespace", func() {

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -496,6 +496,7 @@ func (r *ClusterInstanceReconciler) handleValidate(
 
 	newCond := metav1.Condition{Type: string(v1alpha1.ClusterInstanceValidated)}
 	log.Info("Starting validation")
+	ci.LogObservedExternallyProvisionedSecretAnnotations(log, clusterInstance)
 	err := ci.Validate(ctx, r.Client, clusterInstance)
 	if err != nil {
 		log.Error("ClusterInstance validation failed due to error", zap.Error(err))


### PR DESCRIPTION
Introduce SkipPullSecretPresenceValidationAnnotation and SkipBmcSecretPresenceValidationAnnotation on ClusterInstance so the controller can bypass optional secret existence checks. Add validator tests for both bypass paths.

Made-with: Cursor

<!-- 
Thank you for contributing to siteconfig!

This template is not mandatory, but it is highly recommended.
Please fill out this template to help reviewers understand your changes.
For detailed guidelines, see CONTRIBUTING.md
-->

## Problem / Requirement / Reason for change

<!-- 
Clearly describe the problem being solved or feature being added.
What is the current behavior? Why does it need to change?
-->
The problem is with vault secret operator managing secret creation. The secrets have to exist before the clusterinstance's child CRs are rendered.  

## Changes Made

<!-- 
Summarize the key changes in your implementation.
Use bullet points for clarity.
-->

- Create two const annotations for skipping pull secret and bmc secret
- In the event of these annotations skip the validation loops for each respectively. 

## Testing

<!-- 
Describe how you tested the changes.
Include test cases, manual testing steps, or validation performed.
For documentation-only changes, you may write "N/A - Documentation only"
-->

- Utilizing CI testing with test case in code

## JIRA
https://redhat.atlassian.net/browse/ACM-15720
<!-- 
Link to the JIRA issue (if applicable).
Format: https://issues.redhat.com/browse/JIRA-XXXXX
Or write "NO-ISSUE" if this is a minor change (docs, typos, minor up-versioning)
-->

## AI Assistance

<!-- 
If you used AI tools (e.g., Claude, Gemini, GPT-4, GitHub Copilot) to generate, co-develop, 
or assist with your code changes, disclose that information here.

If you did NOT use AI assistance, you can delete this section or write "None"
-->

- **Model Used**: <!-- e.g., Claude 4.5 Sonnet via Cursor IDE, GitHub Copilot, GPT-4 -->
- **Scope**: <!-- Which parts of the code were AI-generated or AI-assisted -->
- **Level**: <!-- Code generation / Code assistance / Co-development / Code review -->
- **Human Review**: <!-- Confirm all AI-generated code was reviewed, tested, and validated -->

Used cursor with agent router with the following prompt:
@internal/controller/clusterinstance/validator.go:30-31 Help me create a workaround that will check for an annotation on the clusterinstance and bypass validation checks for pull secret and BMC secrets in the function validateResources. Create a separate annotation for pull secret and BMC secret. Last, we will need to create a @internal/controller/clusterinstance/validator_test.go test case for testing both of these use cases

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [ ] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [ ] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two ClusterInstance annotations to optionally skip pull-secret and node BMC credentials presence validation.

* **Tests**
  * Added tests confirming validation is bypassed when the respective annotations are set.

* **Documentation**
  * New doc describing the skip annotations, examples, behavior notes (skipping does not create or sync secrets), and guidance to restore enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->