### PR TITLE
ACM-33382: Add enhancement proposal process

### DIFF
--- a/.github/workflows/enhancement-lint.yml
+++ b/.github/workflows/enhancement-lint.yml
@@ -1,0 +1,33 @@
+# Copyright 2026.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Enhancement Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/enhancements/*.md'
+
+jobs:
+  markdownlint:
+    name: Lint enhancement docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: 'docs/enhancements/*.md'

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,21 @@
+config:
+  first-line-heading: false
+  single-title: false
+  no-hard-tabs: false
+  no-bare-urls: false
+  commands-show-output: false
+  line-length:
+    line_length: 400
+  no-emphasis-as-heading: false
+  no-inline-html: false
+  ul-style: false
+  ol-prefix: false
+  blanks-around-fences: false
+  blanks-around-headings: false
+  blanks-around-lists: false
+  single-trailing-newline: false
+  no-multiple-blanks: false
+  no-trailing-spaces: false
+  emphasis-style: false
+  strong-style: false
+  no-space-in-emphasis: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@
 - [Testing Requirements](#testing-requirements)
 - [Code Coverage Requirements](#code-coverage-requirements)
 - [API and CRD Changes](#api-and-crd-changes)
+- [Enhancement Proposals](#enhancement-proposals)
 - [Documentation Requirements](#documentation-requirements)
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [Contributing a patch](#contributing-a-patch)
@@ -237,6 +238,20 @@ Breaking API changes must be:
 - Backed by a JIRA issue with architecture/design review
 - Discussed with maintainers before implementation
 - Include deprecation warnings in the previous version when possible
+
+## Enhancement Proposals
+
+Significant changes to the siteconfig project require an enhancement proposal before implementation begins. This includes:
+
+- New features or significant behavioral changes
+- Changes to the ClusterInstance API or CRDs
+- Architectural decisions affecting controllers, templates, or the rendering pipeline
+
+Enhancement proposals are Markdown documents that describe the motivation, design, and impact of a change. They are reviewed and approved through the normal PR process.
+
+For the full process, template, and lifecycle details, see the [Enhancement Proposals guide](docs/enhancements/README.md).
+
+Enhancement proposals must be merged before implementation PRs are submitted.
 
 ## Documentation Requirements
 

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,11 @@ bashate: ## Run bashate.
 	@echo "Running bashate"
 	hack/bashate.sh
 
+.PHONY: enhancement-lint
+enhancement-lint: ## Validate enhancement proposal structure.
+	@echo "Running enhancement lint"
+	hack/enhancement-lint.sh
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	@echo "Running go vet"
@@ -165,7 +170,7 @@ ci-test-unit:
 		./...
 
 .PHONY: ci-job
-ci-job: common-deps-update generate fmt vet golangci-lint unittest shellcheck bashate bundle-check
+ci-job: common-deps-update generate fmt vet golangci-lint unittest shellcheck bashate enhancement-lint bundle-check
 
 ##@ Build
 

--- a/docs/enhancements/README.md
+++ b/docs/enhancements/README.md
@@ -1,0 +1,70 @@
+# Siteconfig Enhancement Proposals
+
+This directory contains enhancement proposals for the siteconfig project. Enhancement proposals document the design and rationale for significant changes before implementation begins.
+
+This process is inspired by and adapted from the [openshift-kni/kni-enhancements](https://github.com/openshift-kni/kni-enhancements) repository.
+
+## When to Write an Enhancement Proposal
+
+An enhancement proposal is required for:
+
+- New features or significant behavioral changes
+- Changes to the ClusterInstance API or CRDs
+- Architectural decisions affecting controllers, templates, or the rendering pipeline
+- Changes that affect upgrade/downgrade or version skew
+
+An enhancement proposal is NOT required for:
+
+- Bug fixes
+- Minor refactors or code cleanup
+- Documentation updates
+- Dependency updates
+
+When in doubt, discuss with a maintainer before writing a full proposal.
+
+## How to Create a Proposal
+
+1. Copy the [enhancement template](./guidelines/enhancement_template.md)
+2. Name your file using kebab-case (e.g., `cluster-reinstallation-workflow.md`)
+3. Place it directly in `docs/enhancements/` (no subdirectories)
+4. Fill out at minimum the **Summary** and **Motivation** sections
+5. Open a pull request with your proposal
+
+Proposals can start lightweight — fill in just the Summary and Motivation to
+gauge interest from the team. If the idea has enough support, complete the
+remaining required sections in follow-up commits to the same PR. The enhancement
+lint will fail until all required sections are filled in, which is expected for
+early-stage proposals.
+
+## Review and Approval
+
+Enhancement proposals follow the same review process as code changes, using the project-wide OWNERS. The proposal PR should be assigned to domain experts for review. The PR only receives approval once all required sections are complete and the enhancement lint passes. Once the PR is merged, implementation can begin.
+
+Enhancement proposals must be merged before implementation PRs are submitted.
+
+## Enhancement Lifecycle
+
+```text
+                 PR opened           consensus            code
+   Author         with               reached &           merged
+   drafts       proposal             PR merged           in main
+   proposal        |                    |                   |
+      |            v                    v                   v
+      +-----> [provisional] -----> [implementable] -----> [implemented]
+                   |                    |
+                   |     needs rework   |
+                   +<-------------------+
+```
+
+Proposals track their status via the `status` field in the YAML frontmatter:
+
+- **`provisional`**: Design is being discussed. The proposal PR is open and under review.
+- **`implementable`**: Design has been agreed upon. The proposal PR has been merged. Implementation can begin.
+- **`implemented`**: The feature has been implemented and released. The author updates the `status` and `last-updated` fields.
+
+## Naming Conventions
+
+- **Filename**: kebab-case, descriptive of the feature (e.g., `vsphere-platform-support.md`)
+- **No numbering prefix**: filenames are descriptive, not sequential
+- **Flat structure**: all proposals live directly in `docs/enhancements/`; the `guidelines/` subdirectory is reserved for the template only
+- **YAML `title` field**: should match the filename but can be more readable

--- a/docs/enhancements/guidelines/enhancement_template.md
+++ b/docs/enhancements/guidelines/enhancement_template.md
@@ -1,0 +1,170 @@
+---
+title: neat-enhancement-idea
+authors:
+  - "@github-username"
+reviewers:
+  - "@github-username"
+approvers:
+  - "@github-username"
+api-approvers:
+  - "None"
+creation-date: YYYY-MM-DD
+last-updated: YYYY-MM-DD
+status: provisional
+tracking-link:
+  - TBD
+see-also:
+  - "/docs/enhancements/related-proposal.md"
+replaces:
+  - "/docs/enhancements/old-proposal.md"
+superseded-by:
+  - "/docs/enhancements/new-proposal.md"
+---
+
+# Neat Enhancement Idea
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria are defined
+- [ ] User-facing documentation is updated
+
+## Summary
+
+The summary of the enhancement. No more than one paragraph.
+
+## Motivation
+
+Why is this change needed? What problem does it solve?
+
+### User Stories
+
+As a [role], I want [action] so that [goal].
+
+Include a story about day-2 operations. Consider:
+
+- **Lifecycle**: How does the feature interact with ClusterInstance finalizers,
+  deletion (sync wave ordering), and reinstallation workflows?
+- **Monitoring**: Does the feature add or affect status conditions
+  (e.g., `Provisioned`, `RenderedTemplatesApplied`)? Are structured logs
+  sufficient for debugging?
+- **Remediation**: How do admins recover when the feature fails? Does it use the
+  pause annotation pattern? What requeue delays apply? Is there troubleshooting
+  guidance?
+- **Scale**: Does it affect `maxConcurrentReconciles`? How does it behave with
+  many ClusterInstances?
+
+### Goals
+
+List specific, measurable goals from the user's perspective. Focus on outcomes,
+not implementation details.
+
+### Non-Goals
+
+List what is explicitly out of scope. Things that may be deferred to later
+phases belong here.
+
+## Proposal
+
+### Workflow Description
+
+Describe the detailed user workflow. Include all actors, roles, APIs, and
+interfaces involved. Use sub-sections for variations such as error handling and
+failure recovery.
+
+### API Extensions
+
+Describe any CRDs, admission/conversion webhooks, aggregated API servers, or
+finalizers that this enhancement adds or modifies. If no API changes are
+involved, state "None".
+
+### Siteconfig Impact
+
+Summarize which siteconfig components are affected:
+
+- **Controllers**: Which controllers are modified? (ClusterInstanceReconciler,
+  ClusterDeploymentReconciler, ConfigurationMonitor)
+- **Templates**: Are new templates added or existing ones modified? Which
+  installation flow? (Assisted Installer, Image Based Installer, Hosted Control
+  Plane)
+- **API fields**: Are new fields added to ClusterInstance or related types?
+- **Validation**: Are webhook or spec validation rules changed?
+
+### Implementation Details/Notes/Constraints [optional]
+
+Caveats, important details, core concepts and relationships.
+
+### Risks and Mitigations
+
+What are the risks of this proposal? Consider security, UX, and ecosystem
+impact. How are they mitigated?
+
+### Drawbacks
+
+Why should this enhancement NOT be implemented? Discuss trade-offs: technical
+cost, UX impact, flexibility, supportability, and maintenance burden.
+
+## Design Details
+
+### Open Questions [optional]
+
+Areas requiring closure before implementation.
+
+### Test Plan
+
+Describe how this enhancement will be tested. Consider:
+
+- Unit tests vs. integration tests vs. e2e tests
+- Testing in isolation vs. with other components
+- What scenarios need to be covered
+
+### Graduation Criteria
+
+Define the milestones for this enhancement:
+
+- [ ] Design reviewed and approved by maintainers
+- [ ] Implementation merged with adequate test coverage
+- [ ] Documented in user-facing docs
+- [ ] Released in version X.Y.Z
+
+### Upgrade / Downgrade Strategy
+
+What changes are required on upgrade? What are the expectations around
+availability during upgrade? Are there manual steps required for downgrade or
+rollback?
+
+### Version Skew Strategy
+
+How will the component handle version skew with other components? What happens
+during upgrades when components are at different versions?
+
+### Operational Aspects of API Extensions [optional]
+
+For CRDs, webhooks, aggregated API servers, or finalizers: describe SLIs for
+administrators, impact on existing SLIs (scalability, API throughput,
+availability), and measurement strategy.
+
+#### Failure Modes
+
+Possible failure modes of API extensions, impact on overall cluster health, and
+which teams are likely to be called on escalation.
+
+#### Support Procedures
+
+How to detect failure modes (symptoms, events, metrics, logs), how to disable
+the API extension, and consequences on cluster health and workloads.
+
+## Implementation History
+
+Major milestones in the lifecycle of this proposal.
+
+## Alternatives
+
+Other possible approaches to delivering the same value. Explain why they were
+not chosen.
+
+## Infrastructure Needed [optional]
+
+New subprojects, repos, testing infrastructure, or other resources needed.

--- a/hack/enhancement-lint.sh
+++ b/hack/enhancement-lint.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Validates enhancement proposal files for required sections and YAML frontmatter.
+
+set -euo pipefail
+
+ENHANCEMENTS_DIR="docs/enhancements"
+
+REQUIRED_HEADERS=(
+    "## Release Signoff Checklist"
+    "## Summary"
+    "## Motivation"
+    "### User Stories"
+    "### Goals"
+    "### Non-Goals"
+    "## Proposal"
+    "### Workflow Description"
+    "### API Extensions"
+    "### Siteconfig Impact"
+    "### Risks and Mitigations"
+    "### Drawbacks"
+    "## Design Details"
+    "### Test Plan"
+    "### Graduation Criteria"
+    "### Upgrade / Downgrade Strategy"
+    "### Version Skew Strategy"
+    "## Implementation History"
+    "## Alternatives"
+)
+
+REQUIRED_METADATA=(
+    "title:"
+    "authors:"
+    "status:"
+    "creation-date:"
+    "tracking-link:"
+)
+
+VALID_STATUSES="provisional|implementable|implemented"
+
+find_changed_files() {
+    local changed_files=()
+
+    if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+        echo "warning: not a git repository, scanning all enhancement files" >&2
+        while IFS= read -r -d '' file; do
+            changed_files+=("$file")
+        done < <(find "${ENHANCEMENTS_DIR}" -maxdepth 1 -name '*.md' ! -name 'README.md' -print0 2>/dev/null)
+    else
+        local base_ref="${PULL_BASE_SHA:-origin/main}"
+        local diff_output
+        if ! diff_output=$(git diff --name-only --diff-filter=d "${base_ref}...HEAD" -- "${ENHANCEMENTS_DIR}" 2>/dev/null); then
+            echo "warning: unable to diff against ${base_ref}; scanning all enhancement files" >&2
+            while IFS= read -r -d '' file; do
+                changed_files+=("$file")
+            done < <(find "${ENHANCEMENTS_DIR}" -maxdepth 1 -name '*.md' ! -name 'README.md' -print0 2>/dev/null)
+        else
+            while IFS= read -r file; do
+                changed_files+=("$file")
+            done < <(printf '%s\n' "$diff_output" | \
+                grep '\.md$' | \
+                grep -v "${ENHANCEMENTS_DIR}/README.md" | \
+                grep -v "${ENHANCEMENTS_DIR}/guidelines/" || true)
+        fi
+    fi
+
+    if [ ${#changed_files[@]} -gt 0 ]; then
+        printf '%s\n' "${changed_files[@]}"
+    fi
+}
+
+check_frontmatter() {
+    local file="$1"
+    local errors=0
+
+    if ! head -1 "$file" | grep -q '^---$'; then
+        echo "  ERROR: missing YAML frontmatter (file must start with ---)" >&2
+        return 1
+    fi
+
+    if ! sed -n '2,$p' "$file" | grep -q '^---$'; then
+        echo "  ERROR: missing closing --- marker in YAML frontmatter" >&2
+        return 1
+    fi
+
+    local frontmatter
+    frontmatter=$(sed -n '2,/^---$/{ /^---$/d; p; }' "$file")
+
+    if [ -z "$frontmatter" ]; then
+        echo "  ERROR: empty YAML frontmatter" >&2
+        return 1
+    fi
+
+    for field in "${REQUIRED_METADATA[@]}"; do
+        if ! echo "$frontmatter" | grep -q "^${field}"; then
+            echo "  ERROR: missing required metadata field: ${field}" >&2
+            errors=$((errors + 1))
+        fi
+    done
+
+    local status_value
+    status_value=$(echo "$frontmatter" | grep "^status:" | sed 's/^status:[[:space:]]*//')
+    if [ -n "$status_value" ] && ! echo "$status_value" | grep -qE "^(${VALID_STATUSES})$"; then
+        echo "  ERROR: invalid status value: ${status_value}. Must be one of: ${VALID_STATUSES}" >&2
+        errors=$((errors + 1))
+    fi
+
+    return $errors
+}
+
+check_sections() {
+    local file="$1"
+    local errors=0
+
+    if ! grep -q '^# ' "$file"; then
+        echo "  ERROR: missing document title (line starting with '# ')" >&2
+        errors=$((errors + 1))
+    fi
+
+    for header in "${REQUIRED_HEADERS[@]}"; do
+        if ! grep -qF "$header" "$file"; then
+            echo "  ERROR: missing required section: ${header}" >&2
+            errors=$((errors + 1))
+        fi
+    done
+
+    return $errors
+}
+
+main() {
+    local files=()
+
+    if [ $# -gt 0 ]; then
+        files=("$@")
+    else
+        while IFS= read -r file; do
+            [ -n "$file" ] && files+=("$file")
+        done < <(find_changed_files)
+    fi
+
+    if [ ${#files[@]} -eq 0 ]; then
+        echo "No enhancement files to validate."
+        exit 0
+    fi
+
+    local total_errors=0
+
+    for file in "${files[@]}"; do
+        if [ ! -f "$file" ]; then
+            echo "WARNING: file not found: $file" >&2
+            continue
+        fi
+
+        echo "Validating: $file"
+        local file_errors=0
+
+        check_frontmatter "$file" || file_errors=$((file_errors + $?))
+        check_sections "$file" || file_errors=$((file_errors + $?))
+
+        if [ "$file_errors" -eq 0 ]; then
+            echo "  OK"
+        fi
+
+        total_errors=$((total_errors + file_errors))
+    done
+
+    if [ "$total_errors" -gt 0 ]; then
+        echo ""
+        echo "Enhancement lint failed with ${total_errors} error(s)."
+        exit 1
+    fi
+
+    echo ""
+    echo "All enhancement files passed validation."
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The siteconfig project lacks a formal process for documenting and reviewing significant design decisions before implementation begins. Contributors currently go straight to code PRs without a shared record of the motivation, alternatives considered, or expected impact on controllers, templates, and APIs. This makes it harder for reviewers to evaluate changes and for future contributors to understand why decisions were made.

## Changes Made

- Added enhancement proposal template (`docs/enhancements/guidelines/enhancement_template.md`) with YAML frontmatter and required sections adapted from [openshift-kni/kni-enhancements](https://github.com/openshift-kni/kni-enhancements), including a siteconfig-specific "Siteconfig Impact" section
- Added enhancement process README (`docs/enhancements/README.md`) documenting the lifecycle (`provisional` -> `implementable` -> `implemented`), naming conventions, and review process
- Added validation script (`hack/enhancement-lint.sh`) that checks required sections, YAML frontmatter fields, and valid status values; exits cleanly when no enhancement files are changed
- Added markdownlint configuration (`.markdownlint-cli2.yaml`) with permissive rules for enhancement docs
- Added GitHub Actions workflow (`.github/workflows/enhancement-lint.yml`) for markdown quality checks, triggered only when `docs/enhancements/*.md` files change
- Wired `enhancement-lint` target into `make ci-job` after `bashate`
- Added "Enhancement Proposals" section to `CONTRIBUTING.md` with Table of Contents entry

## Testing

- Ran `make enhancement-lint` with no enhancement files changed — exits 0 with "No enhancement files to validate."
- Ran `hack/enhancement-lint.sh` against the template — passes all checks
- Ran `hack/enhancement-lint.sh` against a file missing frontmatter — correctly fails with 20 errors and exit code 1
- Ran `hack/enhancement-lint.sh` against a file with invalid status value (`draft`) — correctly rejects with error message
- Ran `bash -n hack/enhancement-lint.sh` — syntax OK
- Ran `shellcheck hack/enhancement-lint.sh` — clean, no warnings
- Code coverage for new code: N/A - Documentation and shell script only

## JIRA

https://redhat.atlassian.net/browse/ACM-33382

## AI Assistance

- **Model Used**: Claude Opus 4.6 (1M context) via Claude Code CLI
- **Scope**: All files in this PR were AI-assisted — template, README, lint script, markdownlint config, GitHub Actions workflow, Makefile changes, and CONTRIBUTING.md update
- **Level**: Co-development
- **Human Review**: All generated code was reviewed, tested, and validated. The lint script was tested against valid and invalid inputs and passed shellcheck.

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @imiller0 @sabbir-47 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhancement proposal workflow added for proposing and tracking significant changes, API/CRD updates, and architectural decisions.

* **Documentation**
  * Added comprehensive enhancement guidelines, a proposal template, lifecycle rules, naming conventions, required frontmatter, and contributing guidance requiring proposals be merged before implementations.

* **Chores**
  * CI linting added to validate enhancement proposals, markdown lint configuration introduced, and a validation script plus Makefile target integrated into CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->