### PR TITLE
NO-ISSUE: Fix enhancement lint SIGPIPE failure on large files

### DIFF
--- a/hack/enhancement-lint.sh
+++ b/hack/enhancement-lint.sh
@@ -77,7 +77,7 @@ check_frontmatter() {
         return 1
     fi
 
-    if ! sed -n '2,$p' "$file" | grep -q '^---$'; then
+    if ! grep -q '^---$' <(sed -n '2,$p' "$file"); then
         echo "  ERROR: missing closing --- marker in YAML frontmatter" >&2
         return 1
     fi


### PR DESCRIPTION
## Problem / Requirement / Reason for change

`hack/enhancement-lint.sh` fails with "missing closing --- marker in YAML
frontmatter" on enhancement proposals longer than ~50 lines, even when the
frontmatter is valid. The root cause is that `set -euo pipefail` combined with
`sed | grep -q` causes SIGPIPE: `grep -q` exits immediately after finding the
closing `---` marker, but `sed` is still writing the remaining lines into the
now-closed pipe, triggering a broken-pipe error that `pipefail` treats as
failure.

## Changes Made

- Replace `sed -n '2,$p' "$file" | grep -q '^---$'` with process substitution
  `grep -q '^---$' <(sed -n '2,$p' "$file")` to avoid the broken pipe

## Testing

- Ran `hack/enhancement-lint.sh` against a 550-line enhancement proposal — passes
- Ran `hack/enhancement-lint.sh` against the existing template — passes
- `make ci-job` target includes `enhancement-lint` — no regressions

- Code coverage for new code: N/A (shell script)

## JIRA

NO-ISSUE

## AI Assistance

N/A

---

## Pull Request Checklist

- [x] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass
- [ ] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @imiller0 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the efficiency of an internal linting tool script with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->