### PR TITLE
[release-2.13] ACM-33600: Use latest UBI base image instead of pinned tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on \
 
 #####################################################################################################
 # Build the controller image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV SUMMARY="SiteConfig Operator is a template-driven cluster provisioning solution" \
     DESCRIPTION="SiteConfig operator as a template-driven cluster provisioning solution, which allows you to \


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The Dockerfile on the release-2.13 branch uses a pinned UBI base image tag (`ubi9/ubi-minimal:9.6-1760515502`) instead of `:latest`. This prevents rebuilds from automatically picking up the latest base image security fixes, which is the expected pattern for ACM/MCE components.

## Changes Made

- Updated `Dockerfile` base image from `registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502` to `registry.access.redhat.com/ubi9/ubi-minimal:latest`

## Testing

- N/A - Dockerfile base image tag change only
- Verified all other release branches (2.14-2.17) already use `:latest`

## JIRA

https://issues.redhat.com/browse/ACM-33600

## AI Assistance

N/A

---

## Pull Request Checklist

- [ ] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass
- [ ] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [ ] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin