### PR TITLE
ACM-32731: Improve ClusterInstance CRD field descriptions

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -88,8 +88,9 @@ type TangConfig struct {
 // type sub-field to select the encryption mode and tang to provide
 // Tang server details when using network-bound disk encryption.
 type DiskEncryption struct {
-	// type specifies the disk encryption mode. Valid values depend on the
-	// installation flow. The default is "none" (encryption disabled).
+	// type specifies the disk encryption mode. The default "none" disables
+	// encryption. Use "tpmv2" for TPM 2.0 or "tang" for network-bound disk
+	// encryption via Tang servers (requires the tang field).
 	// +kubebuilder:default:=none
 	// +optional
 	Type string `json:"type,omitempty"`

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -508,7 +508,7 @@ type ClusterInstanceSpec struct {
 
 	// caBundleRef is a reference to a ConfigMap containing a bundle of
 	// trusted CA certificates. The controller passes this reference to
-	// the downstream CRD (HostedCluster or ImageClusterInstall). Not
+	// the downstream resource (HostedCluster or ImageClusterInstall). Not
 	// applicable to the Assisted Installer flow.
 	// +optional
 	CaBundleRef *corev1.LocalObjectReference `json:"caBundleRef,omitempty"`

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -54,29 +54,49 @@ type ServiceNetworkEntry struct {
 	CIDR string `json:"cidr"`
 }
 
-// BmcCredentialsName
+// BmcCredentialsName is a reference to a BareMetalHost BMC credentials Secret.
 type BmcCredentialsName struct {
+	// name is the name of the Secret containing the BMC credentials
+	// (requires keys "username" and "password").
 	// +required
 	Name string `json:"name"`
 }
 
-// IronicInspect is used to specify if automatic introspection carried out during registration
-// of BMH is enabled or disabled.
+// IronicInspect controls automatic hardware introspection performed by Ironic
+// during BareMetalHost registration. The default empty string enables
+// inspection. Set to "disabled" to skip hardware inspection.
 // +kubebuilder:validation:Enum="";disabled
 type IronicInspect string
 
-// PlatformType is a specific supported infrastructure provider.
+// PlatformType specifies the infrastructure platform for installation.
+// Only applicable to the Assisted Installer flow. When empty, the field
+// is omitted from the rendered AgentClusterInstall, allowing the installer
+// to select a default.
 // +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
 type PlatformType string
 
+// TangConfig holds the configuration for a single Tang server used for
+// network-bound disk encryption (NBDE).
 type TangConfig struct {
-	URL        string `json:"url,omitempty"`
+	// url is the URL of the Tang server.
+	URL string `json:"url,omitempty"`
+	// thumbprint is the thumbprint of the Tang server's signing key.
 	Thumbprint string `json:"thumbprint,omitempty"`
 }
 
+// DiskEncryption configures disk encryption for cluster nodes. Use the
+// type sub-field to select the encryption mode and tang to provide
+// Tang server details when using network-bound disk encryption.
 type DiskEncryption struct {
+	// type specifies the disk encryption mode. Valid values depend on the
+	// installation flow. The default is "none" (encryption disabled).
 	// +kubebuilder:default:=none
-	Type string       `json:"type,omitempty"`
+	// +optional
+	Type string `json:"type,omitempty"`
+	// tang is a list of Tang server configurations used for network-bound
+	// disk encryption (NBDE). Each entry specifies a Tang server URL and
+	// its thumbprint.
+	// +optional
 	Tang []TangConfig `json:"tang,omitempty"`
 }
 
@@ -134,7 +154,9 @@ type ResourceRef struct {
 	Kind string `json:"kind"`
 }
 
-// NodeSpec
+// NodeSpec defines the desired configuration for a single node (host) in
+// a ClusterInstance, including bare-metal host details, network settings,
+// and node-level template overrides.
 type NodeSpec struct {
 	// BmcAddress holds the URL for accessing the controller on the network.
 	// +required
@@ -186,50 +208,70 @@ type NodeSpec struct {
 	HostRef *HostRef `json:"hostRef,omitempty"`
 
 	// CPUArchitecture is the software architecture of the node.
-	// If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+	// If it is not defined here then it is inherited from the ClusterInstanceSpec.
 	// +kubebuilder:validation:Enum=x86_64;aarch64
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
-	// Provide guidance about how to choose the device for the image being provisioned.
+	// bootMode selects the method of initializing the hardware during boot.
+	// Defaults to UEFI.
 	// +kubebuilder:default:=UEFI
 	// +optional
 	BootMode bmh_v1alpha1.BootMode `json:"bootMode,omitempty"`
 
-	// Json formatted string containing the user overrides for the host's coreos installer args
+	// installerArgs is a JSON-formatted string of arguments passed to the
+	// coreos-installer via the bare metal agent controller. Rendered as the
+	// bmac.agent-install.openshift.io/installer-args annotation on the
+	// BareMetalHost resource. Must be valid JSON when provided.
 	// +optional
 	InstallerArgs string `json:"installerArgs,omitempty"`
 
-	// Json formatted string containing the user overrides for the host's ignition config
-	// IgnitionConfigOverride enables the assignment of partitions for persistent storage.
-	// Adjust disk ID and size to the specific hardware.
+	// ignitionConfigOverride is a JSON-formatted string containing
+	// host-specific Ignition config overrides. Rendered as the
+	// bmac.agent-install.openshift.io/ignition-config-overrides annotation
+	// on the BareMetalHost resource. Must be valid JSON when provided.
 	// +optional
 	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
 
+	// role specifies the role of this node in the cluster. Defaults to "master".
 	// +kubebuilder:validation:Enum=master;worker;arbiter
 	// +kubebuilder:default:=master
 	// +optional
 	Role string `json:"role,omitempty"`
 
-	// Additional node-level annotations to be applied to the rendered templates
+	// extraAnnotations specifies additional node-level annotations keyed by
+	// resource Kind. If a Kind is present in the node-level map, those
+	// annotations are used for this node instead of any cluster-level
+	// annotations for the same Kind. Kinds not defined at node level fall
+	// back to cluster-level extraAnnotations.
 	// +optional
 	ExtraAnnotations map[string]map[string]string `json:"extraAnnotations,omitempty"`
 
-	// Additional node-level labels to be applied to the rendered templates
+	// extraLabels specifies additional node-level labels keyed by resource
+	// Kind. If a Kind is present in the node-level map, those labels are
+	// used for this node instead of any cluster-level labels for the same
+	// Kind. Kinds not defined at node level fall back to cluster-level
+	// extraLabels.
 	// +optional
 	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
 
-	// SuppressedManifests is a list of node-level manifest names to be excluded from the template rendering process
+	// suppressedManifests is a list of Kubernetes resource Kinds to exclude
+	// from rendering for this node. Combined with cluster-level
+	// suppressedManifests. Matching manifests are not applied and are
+	// recorded as "suppressed" in status.
 	// +optional
 	SuppressedManifests []string `json:"suppressedManifests,omitempty"`
 
-	// PruneManifests represents a list of Kubernetes resource references that indicates which "node-level" manifests
-	// should be pruned (removed).
+	// pruneManifests is a list of resource references (apiVersion + kind)
+	// identifying node-level manifests that should be skipped during
+	// rendering and deleted from the cluster if previously applied.
+	// Combined with cluster-level pruneManifests.
 	// +optional
 	PruneManifests []ResourceRef `json:"pruneManifests,omitempty"`
 
-	// IronicInspect is used to specify if automatic introspection carried out during registration of BMH is enabled or
-	// disabled
+	// ironicInspect controls automatic hardware introspection performed by
+	// Ironic during BareMetalHost registration. The default empty string
+	// enables inspection. Set to "disabled" to skip hardware inspection.
 	// +kubebuilder:default:=""
 	// +optional
 	IronicInspect IronicInspect `json:"ironicInspect,omitempty"`
@@ -241,7 +283,7 @@ type NodeSpec struct {
 	TemplateRefs []TemplateRef `json:"templateRefs"`
 }
 
-// ClusterType is a string representing the cluster type
+// ClusterType specifies the topology of the cluster.
 type ClusterType string
 
 const (
@@ -288,12 +330,11 @@ type ReinstallSpec struct {
 	PreservationMode PreservationMode `json:"preservationMode"`
 }
 
-// ClusterInstanceSpec defines the desired state of ClusterInstance
+// ClusterInstanceSpec defines the desired state for a cluster, including
+// topology, networking, platform, node roles, and installation settings.
 type ClusterInstanceSpec struct {
-	// Desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// ClusterName is the name of the cluster.
+	// clusterName is the name of the cluster. It is used as the base name
+	// for generated resources and their namespace.
 	// +required
 	ClusterName string `json:"clusterName"`
 
@@ -331,9 +372,10 @@ type ClusterInstanceSpec struct {
 	// +optional
 	IngressVIPs []string `json:"ingressVIPs,omitempty"`
 
-	// HoldInstallation will prevent installation from happening when true.
-	// Inspection and validation will proceed as usual, but once the RequirementsMet condition is true,
-	// installation will not begin until this field is set to false.
+	// holdInstallation prevents the Assisted Installer from starting the
+	// installation when set to true. Inspection and validation proceed
+	// normally, but installation is held until this field is set to false.
+	// Can only be enabled at creation time. Defaults to false.
 	// +kubebuilder:default:=false
 	// +optional
 	HoldInstallation bool `json:"holdInstallation,omitempty"`
@@ -355,35 +397,54 @@ type ClusterInstanceSpec struct {
 	// +optional
 	ServiceNetwork []ServiceNetworkEntry `json:"serviceNetwork,omitempty"`
 
-	// NetworkType is the Container Network Interface (CNI) plug-in to install
-	// The default value is OpenShiftSDN for IPv4, and OVNKubernetes for IPv6 or SNO
+	// networkType specifies the Container Network Interface (CNI) plugin
+	// to install. Defaults to OVNKubernetes.
 	// +kubebuilder:validation:Enum=OpenShiftSDN;OVNKubernetes
 	// +kubebuilder:default:=OVNKubernetes
 	// +optional
 	NetworkType string `json:"networkType,omitempty"`
 
-	// PlatformType is the name for the specific platform upon which to perform the installation.
+	// platformType specifies the infrastructure platform for installation.
+	// Only applicable to the Assisted Installer flow. When empty, the field
+	// is omitted from the rendered AgentClusterInstall, allowing the installer
+	// to select a default.
 	// +optional
 	PlatformType PlatformType `json:"platformType,omitempty"`
 
-	// Additional cluster-wide annotations to be applied to the rendered templates
+	// extraAnnotations specifies additional cluster-level annotations keyed by
+	// resource Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind,
+	// the annotations are merged into the matching rendered manifest's metadata.
+	// Annotations already defined in the template take precedence and are not
+	// overwritten by extraAnnotations.
 	// +optional
 	ExtraAnnotations map[string]map[string]string `json:"extraAnnotations,omitempty"`
 
-	// Additional cluster-wide labels to be applied to the rendered templates
+	// extraLabels specifies additional cluster-level labels keyed by resource
+	// Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind, the
+	// labels are merged into the matching rendered manifest's metadata.
+	// Labels already defined in the template take precedence and are not
+	// overwritten by extraLabels.
 	// +optional
 	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
 
-	// InstallConfigOverrides is a Json formatted string that provides a generic way of passing
-	// install-config parameters.
+	// installConfigOverrides is a JSON-formatted string of install-config
+	// parameters. The controller automatically merges networkType and
+	// cpuPartitioningMode into this value. Rendered as the
+	// agent-install.openshift.io/install-config-overrides annotation on
+	// AgentClusterInstall. Applies to the Assisted Installer flow only.
 	// +optional
 	InstallConfigOverrides string `json:"installConfigOverrides,omitempty"`
 
-	// Json formatted string containing the user overrides for the initial ignition config
+	// ignitionConfigOverride is a JSON-formatted string containing overrides
+	// for the discovery-phase Ignition config. Rendered into
+	// InfraEnv.spec.ignitionConfigOverride. Applies to Assisted Installer
+	// and Hosted Control Plane flows.
 	// +optional
 	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
 
-	// DiskEncryption is the configuration to enable/disable disk encryption for cluster nodes.
+	// diskEncryption configures disk encryption for cluster nodes. Use the
+	// type sub-field to select the encryption mode and tang to provide
+	// Tang server details when using network-bound disk encryption.
 	// +optional
 	DiskEncryption *DiskEncryption `json:"diskEncryption,omitempty"`
 
@@ -395,12 +456,18 @@ type ClusterInstanceSpec struct {
 	// +optional
 	ExtraManifestsRefs []corev1.LocalObjectReference `json:"extraManifestsRefs,omitempty"`
 
-	// SuppressedManifests is a list of manifest names to be excluded from the template rendering process
+	// suppressedManifests is a list of Kubernetes resource Kinds to exclude
+	// from rendering. Manifests whose rendered Kind matches an entry in this
+	// list are not applied to the cluster and are recorded as "suppressed" in
+	// status. Cluster-level suppression also applies to node-level manifests.
 	// +optional
 	SuppressedManifests []string `json:"suppressedManifests,omitempty"`
 
-	// PruneManifests represents a list of Kubernetes resource references that indicates which manifests should be
-	// pruned (removed).
+	// pruneManifests is a list of resource references (apiVersion + kind)
+	// identifying manifests that should be skipped during rendering and
+	// deleted from the cluster if they were previously applied. Unlike
+	// suppressedManifests, pruning actively removes existing resources.
+	// Cluster-level prune entries also apply to node-level manifests.
 	// +optional
 	PruneManifests []ResourceRef `json:"pruneManifests,omitempty"`
 
@@ -420,6 +487,14 @@ type ClusterInstanceSpec struct {
 	// +optional
 	CPUArchitecture CPUArchitecture `json:"cpuArchitecture,omitempty"`
 
+	// clusterType specifies the topology of the cluster.
+	// One of: SNO (Single Node OpenShift — exactly 1 control-plane node; worker nodes
+	// may also be specified and are provisioned independently of the initial installation),
+	// HighlyAvailable (multiple control-plane and worker nodes),
+	// HostedControlPlane (control plane hosted externally via HyperShift, no control-plane
+	// nodes in this spec),
+	// HighlyAvailableArbiter (at least 2 control-plane nodes with at least 1 arbiter node
+	// for stretched clusters).
 	// +kubebuilder:validation:Enum=SNO;HighlyAvailable;HostedControlPlane;HighlyAvailableArbiter
 	// +optional
 	ClusterType ClusterType `json:"clusterType,omitempty"`
@@ -430,15 +505,23 @@ type ClusterInstanceSpec struct {
 	// +required
 	TemplateRefs []TemplateRef `json:"templateRefs"`
 
-	// CABundle is a reference to a config map containing the new bundle of trusted certificates for the host.
+	// caBundleRef is a reference to a ConfigMap containing a bundle of
+	// trusted CA certificates. The controller passes this reference to
+	// the downstream CRD (HostedCluster or ImageClusterInstall). Not
+	// applicable to the Assisted Installer flow.
 	// +optional
 	CaBundleRef *corev1.LocalObjectReference `json:"caBundleRef,omitempty"`
 
-	// List of node objects
+	// nodes is the list of nodes to provision for this cluster. The number
+	// and roles of nodes must be compatible with the selected clusterType.
 	// +required
 	Nodes []NodeSpec `json:"nodes"`
 
-	// Reinstall specifications
+	// reinstall triggers a cluster reinstallation workflow when populated.
+	// This is a destructive operation: all rendered resources (except
+	// ManagedCluster) are deleted and reprovisioned. Requires the controller
+	// to be configured with allowReinstalls enabled. Each reinstall must use
+	// a unique generation value.
 	// +optional
 	Reinstall *ReinstallSpec `json:"reinstall,omitempty"`
 }
@@ -608,7 +691,11 @@ type ClusterInstanceStatus struct {
 //+kubebuilder:printcolumn:name="ProvisionDetails",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].message"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
-// ClusterInstance is the Schema for the clusterinstances API
+// ClusterInstance defines the desired configuration for provisioning an
+// OpenShift cluster. Based on the selected templateRefs and clusterType,
+// the controller renders and applies the Kubernetes resources needed for
+// cluster installation (e.g., ClusterDeployment, ManagedCluster,
+// BareMetalHost, or HostedCluster depending on the installation flow).
 type ClusterInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -170,6 +170,9 @@ type NodeSpec struct {
 
 	// Which MAC address will PXE boot? This is optional for some
 	// types, but required for libvirt VMs driven by vbmc.
+	// This MAC address should correspond to one of the interfaces
+	// defined in nodeNetwork so that the host can be provisioned
+	// on the correct network.
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	// +required
 	BootMACAddress string `json:"bootMACAddress"`
@@ -241,25 +244,32 @@ type NodeSpec struct {
 	Role string `json:"role,omitempty"`
 
 	// extraAnnotations specifies additional node-level annotations keyed by
-	// resource Kind. If a Kind is present in the node-level map, those
-	// annotations are used for this node instead of any cluster-level
-	// annotations for the same Kind. Kinds not defined at node level fall
-	// back to cluster-level extraAnnotations.
+	// the Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+	// The key is matched against the kind field of each rendered manifest.
+	// If a Kind is present in the node-level map, those annotations are
+	// used for this node instead of any cluster-level annotations for the
+	// same Kind. Kinds not defined at node level fall back to cluster-level
+	// extraAnnotations. Annotations already defined in the template take
+	// precedence and are not overwritten.
 	// +optional
 	ExtraAnnotations map[string]map[string]string `json:"extraAnnotations,omitempty"`
 
-	// extraLabels specifies additional node-level labels keyed by resource
-	// Kind. If a Kind is present in the node-level map, those labels are
-	// used for this node instead of any cluster-level labels for the same
-	// Kind. Kinds not defined at node level fall back to cluster-level
-	// extraLabels.
+	// extraLabels specifies additional node-level labels keyed by the
+	// Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+	// The key is matched against the kind field of each rendered manifest.
+	// If a Kind is present in the node-level map, those labels are used
+	// for this node instead of any cluster-level labels for the same Kind.
+	// Kinds not defined at node level fall back to cluster-level
+	// extraLabels. Labels already defined in the template take precedence
+	// and are not overwritten.
 	// +optional
 	ExtraLabels map[string]map[string]string `json:"extraLabels,omitempty"`
 
 	// suppressedManifests is a list of Kubernetes resource Kinds to exclude
 	// from rendering for this node. Combined with cluster-level
 	// suppressedManifests. Matching manifests are not applied and are
-	// recorded as "suppressed" in status.
+	// recorded as "suppressed" in status. Previously applied resources
+	// are not deleted; use pruneManifests to remove them.
 	// +optional
 	SuppressedManifests []string `json:"suppressedManifests,omitempty"`
 
@@ -335,7 +345,10 @@ type ReinstallSpec struct {
 // topology, networking, platform, node roles, and installation settings.
 type ClusterInstanceSpec struct {
 	// clusterName is the name of the cluster. It is used as the base name
-	// for generated resources and their namespace.
+	// for generated resources and their namespace. Must be a valid
+	// Kubernetes namespace name: lowercase alphanumeric characters or
+	// hyphens, must start and end with an alphanumeric character, and at
+	// most 63 characters long.
 	// +required
 	ClusterName string `json:"clusterName"`
 
@@ -361,6 +374,7 @@ type ClusterInstanceSpec struct {
 	// Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
 	// most one IP address per IP stack used). The order of stacks should be the same as order
 	// of subnets in Cluster Networks, Service Networks, and Machine Networks.
+	// Not applicable to Single Node OpenShift (SNO) clusters.
 	// +kubebuilder:validation:MaxItems=2
 	// +optional
 	ApiVIPs []string `json:"apiVIPs,omitempty"`
@@ -369,6 +383,7 @@ type ClusterInstanceSpec struct {
 	// Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
 	// most one IP address per IP stack used). The order of stacks should be the same as order
 	// of subnets in Cluster Networks, Service Networks, and Machine Networks.
+	// Not applicable to Single Node OpenShift (SNO) clusters.
 	// +kubebuilder:validation:MaxItems=2
 	// +optional
 	IngressVIPs []string `json:"ingressVIPs,omitempty"`
@@ -446,6 +461,8 @@ type ClusterInstanceSpec struct {
 	// diskEncryption configures disk encryption for cluster nodes. Use the
 	// type sub-field to select the encryption mode and tang to provide
 	// Tang server details when using network-bound disk encryption.
+	// These fields are not consumed by the default provided templates
+	// and require custom templates (via templateRefs) to take effect.
 	// +optional
 	DiskEncryption *DiskEncryption `json:"diskEncryption,omitempty"`
 
@@ -461,6 +478,8 @@ type ClusterInstanceSpec struct {
 	// from rendering. Manifests whose rendered Kind matches an entry in this
 	// list are not applied to the cluster and are recorded as "suppressed" in
 	// status. Cluster-level suppression also applies to node-level manifests.
+	// Previously applied resources are not deleted; use pruneManifests to
+	// remove them.
 	// +optional
 	SuppressedManifests []string `json:"suppressedManifests,omitempty"`
 

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1144,7 +1144,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterInstance is the Schema for the clusterinstances API
+    - description: ClusterInstance defines the desired configuration for provisioning
+        an OpenShift cluster. Based on the selected templateRefs and clusterType,
+        the controller renders and applies the Kubernetes resources needed for cluster
+        installation (e.g., ClusterDeployment, ManagedCluster, BareMetalHost, or HostedCluster
+        depending on the installation flow).
       displayName: Cluster Instance
       kind: ClusterInstance
       name: clusterinstances.siteconfig.open-cluster-management.io

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -84,7 +84,7 @@ spec:
                 description: |-
                   caBundleRef is a reference to a ConfigMap containing a bundle of
                   trusted CA certificates. The controller passes this reference to
-                  the downstream CRD (HostedCluster or ImageClusterInstall). Not
+                  the downstream resource (HostedCluster or ImageClusterInstall). Not
                   applicable to the Assisted Installer flow.
                 properties:
                   name:

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -30,7 +30,12 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterInstance is the Schema for the clusterinstances API
+        description: |-
+          ClusterInstance defines the desired configuration for provisioning an
+          OpenShift cluster. Based on the selected templateRefs and clusterType,
+          the controller renders and applies the Kubernetes resources needed for
+          cluster installation (e.g., ClusterDeployment, ManagedCluster,
+          BareMetalHost, or HostedCluster depending on the installation flow).
         properties:
           apiVersion:
             description: |-
@@ -50,7 +55,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterInstanceSpec defines the desired state of ClusterInstance
+            description: |-
+              ClusterInstanceSpec defines the desired state for a cluster, including
+              topology, networking, platform, node roles, and installation settings.
             properties:
               additionalNTPSources:
                 description: |-
@@ -74,8 +81,11 @@ spec:
                   cluster.
                 type: string
               caBundleRef:
-                description: CABundle is a reference to a config map containing the
-                  new bundle of trusted certificates for the host.
+                description: |-
+                  caBundleRef is a reference to a ConfigMap containing a bundle of
+                  trusted CA certificates. The controller passes this reference to
+                  the downstream CRD (HostedCluster or ImageClusterInstall). Not
+                  applicable to the Assisted Installer flow.
                 properties:
                   name:
                     default: ""
@@ -94,7 +104,9 @@ spec:
                   OpenShift version to deploy.
                 type: string
               clusterName:
-                description: ClusterName is the name of the cluster.
+                description: |-
+                  clusterName is the name of the cluster. It is used as the base name
+                  for generated resources and their namespace.
                 type: string
               clusterNetwork:
                 description: ClusterNetwork is the list of IP address pools for pods.
@@ -118,7 +130,15 @@ spec:
                   type: object
                 type: array
               clusterType:
-                description: ClusterType is a string representing the cluster type
+                description: |-
+                  clusterType specifies the topology of the cluster.
+                  One of: SNO (Single Node OpenShift — exactly 1 control-plane node; worker nodes
+                  may also be specified and are provisioned independently of the initial installation),
+                  HighlyAvailable (multiple control-plane and worker nodes),
+                  HostedControlPlane (control plane hosted externally via HyperShift, no control-plane
+                  nodes in this spec),
+                  HighlyAvailableArbiter (at least 2 control-plane nodes with at least 1 arbiter node
+                  for stretched clusters).
                 enum:
                 - SNO
                 - HighlyAvailable
@@ -147,20 +167,35 @@ spec:
                 - AllNodes
                 type: string
               diskEncryption:
-                description: DiskEncryption is the configuration to enable/disable
-                  disk encryption for cluster nodes.
+                description: |-
+                  diskEncryption configures disk encryption for cluster nodes. Use the
+                  type sub-field to select the encryption mode and tang to provide
+                  Tang server details when using network-bound disk encryption.
                 properties:
                   tang:
+                    description: |-
+                      tang is a list of Tang server configurations used for network-bound
+                      disk encryption (NBDE). Each entry specifies a Tang server URL and
+                      its thumbprint.
                     items:
+                      description: |-
+                        TangConfig holds the configuration for a single Tang server used for
+                        network-bound disk encryption (NBDE).
                       properties:
                         thumbprint:
+                          description: thumbprint is the thumbprint of the Tang server's
+                            signing key.
                           type: string
                         url:
+                          description: url is the URL of the Tang server.
                           type: string
                       type: object
                     type: array
                   type:
                     default: none
+                    description: |-
+                      type specifies the disk encryption mode. Valid values depend on the
+                      installation flow. The default is "none" (encryption disabled).
                     type: string
                 type: object
               extraAnnotations:
@@ -168,16 +203,24 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: Additional cluster-wide annotations to be applied to
-                  the rendered templates
+                description: |-
+                  extraAnnotations specifies additional cluster-level annotations keyed by
+                  resource Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind,
+                  the annotations are merged into the matching rendered manifest's metadata.
+                  Annotations already defined in the template take precedence and are not
+                  overwritten by extraAnnotations.
                 type: object
               extraLabels:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: Additional cluster-wide labels to be applied to the rendered
-                  templates
+                description: |-
+                  extraLabels specifies additional cluster-level labels keyed by resource
+                  Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind, the
+                  labels are merged into the matching rendered manifest's metadata.
+                  Labels already defined in the template take precedence and are not
+                  overwritten by extraLabels.
                 type: object
               extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
@@ -202,13 +245,17 @@ spec:
               holdInstallation:
                 default: false
                 description: |-
-                  HoldInstallation will prevent installation from happening when true.
-                  Inspection and validation will proceed as usual, but once the RequirementsMet condition is true,
-                  installation will not begin until this field is set to false.
+                  holdInstallation prevents the Assisted Installer from starting the
+                  installation when set to true. Inspection and validation proceed
+                  normally, but installation is held until this field is set to false.
+                  Can only be enabled at creation time. Defaults to false.
                 type: boolean
               ignitionConfigOverride:
-                description: Json formatted string containing the user overrides for
-                  the initial ignition config
+                description: |-
+                  ignitionConfigOverride is a JSON-formatted string containing overrides
+                  for the discovery-phase Ignition config. Rendered into
+                  InfraEnv.spec.ignitionConfigOverride. Applies to Assisted Installer
+                  and Hosted Control Plane flows.
                 type: string
               ingressVIPs:
                 description: |-
@@ -222,8 +269,11 @@ spec:
                 type: array
               installConfigOverrides:
                 description: |-
-                  InstallConfigOverrides is a Json formatted string that provides a generic way of passing
-                  install-config parameters.
+                  installConfigOverrides is a JSON-formatted string of install-config
+                  parameters. The controller automatically merges networkType and
+                  cpuPartitioningMode into this value. Rendered as the
+                  agent-install.openshift.io/install-config-overrides annotation on
+                  AgentClusterInstall. Applies to the Assisted Installer flow only.
                 type: string
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
@@ -242,16 +292,21 @@ spec:
               networkType:
                 default: OVNKubernetes
                 description: |-
-                  NetworkType is the Container Network Interface (CNI) plug-in to install
-                  The default value is OpenShiftSDN for IPv4, and OVNKubernetes for IPv6 or SNO
+                  networkType specifies the Container Network Interface (CNI) plugin
+                  to install. Defaults to OVNKubernetes.
                 enum:
                 - OpenShiftSDN
                 - OVNKubernetes
                 type: string
               nodes:
-                description: List of node objects
+                description: |-
+                  nodes is the list of nodes to provision for this cluster. The number
+                  and roles of nodes must be compatible with the selected clusterType.
                 items:
-                  description: NodeSpec
+                  description: |-
+                    NodeSpec defines the desired configuration for a single node (host) in
+                    a ClusterInstance, including bare-metal host details, network settings,
+                    and node-level template overrides.
                   properties:
                     automatedCleaningMode:
                       default: disabled
@@ -273,6 +328,9 @@ spec:
                         and "password").
                       properties:
                         name:
+                          description: |-
+                            name is the name of the Secret containing the BMC credentials
+                            (requires keys "username" and "password").
                           type: string
                       required:
                       - name
@@ -285,8 +343,9 @@ spec:
                       type: string
                     bootMode:
                       default: UEFI
-                      description: Provide guidance about how to choose the device
-                        for the image being provisioned.
+                      description: |-
+                        bootMode selects the method of initializing the hardware during boot.
+                        Defaults to UEFI.
                       enum:
                       - UEFI
                       - UEFISecureBoot
@@ -295,7 +354,7 @@ spec:
                     cpuArchitecture:
                       description: |-
                         CPUArchitecture is the software architecture of the node.
-                        If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+                        If it is not defined here then it is inherited from the ClusterInstanceSpec.
                       enum:
                       - x86_64
                       - aarch64
@@ -305,16 +364,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      description: Additional node-level annotations to be applied
-                        to the rendered templates
+                      description: |-
+                        extraAnnotations specifies additional node-level annotations keyed by
+                        resource Kind. If a Kind is present in the node-level map, those
+                        annotations are used for this node instead of any cluster-level
+                        annotations for the same Kind. Kinds not defined at node level fall
+                        back to cluster-level extraAnnotations.
                       type: object
                     extraLabels:
                       additionalProperties:
                         additionalProperties:
                           type: string
                         type: object
-                      description: Additional node-level labels to be applied to the
-                        rendered templates
+                      description: |-
+                        extraLabels specifies additional node-level labels keyed by resource
+                        Kind. If a Kind is present in the node-level map, those labels are
+                        used for this node instead of any cluster-level labels for the same
+                        Kind. Kinds not defined at node level fall back to cluster-level
+                        extraLabels.
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host
@@ -338,19 +405,24 @@ spec:
                       type: object
                     ignitionConfigOverride:
                       description: |-
-                        Json formatted string containing the user overrides for the host's ignition config
-                        IgnitionConfigOverride enables the assignment of partitions for persistent storage.
-                        Adjust disk ID and size to the specific hardware.
+                        ignitionConfigOverride is a JSON-formatted string containing
+                        host-specific Ignition config overrides. Rendered as the
+                        bmac.agent-install.openshift.io/ignition-config-overrides annotation
+                        on the BareMetalHost resource. Must be valid JSON when provided.
                       type: string
                     installerArgs:
-                      description: Json formatted string containing the user overrides
-                        for the host's coreos installer args
+                      description: |-
+                        installerArgs is a JSON-formatted string of arguments passed to the
+                        coreos-installer via the bare metal agent controller. Rendered as the
+                        bmac.agent-install.openshift.io/installer-args annotation on the
+                        BareMetalHost resource. Must be valid JSON when provided.
                       type: string
                     ironicInspect:
                       default: ""
                       description: |-
-                        IronicInspect is used to specify if automatic introspection carried out during registration of BMH is enabled or
-                        disabled
+                        ironicInspect controls automatic hardware introspection performed by
+                        Ironic during BareMetalHost registration. The default empty string
+                        enables inspection. Set to "disabled" to skip hardware inspection.
                       enum:
                       - ""
                       - disabled
@@ -405,8 +477,10 @@ spec:
                       type: object
                     pruneManifests:
                       description: |-
-                        PruneManifests represents a list of Kubernetes resource references that indicates which "node-level" manifests
-                        should be pruned (removed).
+                        pruneManifests is a list of resource references (apiVersion + kind)
+                        identifying node-level manifests that should be skipped during
+                        rendering and deleted from the cluster if previously applied.
+                        Combined with cluster-level pruneManifests.
                       items:
                         description: ResourceRef represents the API version and kind
                           of a Kubernetes resource
@@ -428,6 +502,8 @@ spec:
                       type: array
                     role:
                       default: master
+                      description: role specifies the role of this node in the cluster.
+                        Defaults to "master".
                       enum:
                       - master
                       - worker
@@ -490,8 +566,11 @@ spec:
                           type: string
                       type: object
                     suppressedManifests:
-                      description: SuppressedManifests is a list of node-level manifest
-                        names to be excluded from the template rendering process
+                      description: |-
+                        suppressedManifests is a list of Kubernetes resource Kinds to exclude
+                        from rendering for this node. Combined with cluster-level
+                        suppressedManifests. Matching manifests are not applied and are
+                        recorded as "suppressed" in status.
                       items:
                         type: string
                       type: array
@@ -529,8 +608,11 @@ spec:
                   type: object
                 type: array
               platformType:
-                description: PlatformType is the name for the specific platform upon
-                  which to perform the installation.
+                description: |-
+                  platformType specifies the infrastructure platform for installation.
+                  Only applicable to the Assisted Installer flow. When empty, the field
+                  is omitted from the rendered AgentClusterInstall, allowing the installer
+                  to select a default.
                 enum:
                 - ""
                 - BareMetal
@@ -557,8 +639,11 @@ spec:
                 type: object
               pruneManifests:
                 description: |-
-                  PruneManifests represents a list of Kubernetes resource references that indicates which manifests should be
-                  pruned (removed).
+                  pruneManifests is a list of resource references (apiVersion + kind)
+                  identifying manifests that should be skipped during rendering and
+                  deleted from the cluster if they were previously applied. Unlike
+                  suppressedManifests, pruning actively removes existing resources.
+                  Cluster-level prune entries also apply to node-level manifests.
                 items:
                   description: ResourceRef represents the API version and kind of
                     a Kubernetes resource
@@ -593,7 +678,12 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               reinstall:
-                description: Reinstall specifications
+                description: |-
+                  reinstall triggers a cluster reinstallation workflow when populated.
+                  This is a destructive operation: all rendered resources (except
+                  ManagedCluster) are deleted and reprovisioned. Requires the controller
+                  to be configured with allowReinstalls enabled. Each reinstall must use
+                  a unique generation value.
                 properties:
                   generation:
                     description: |-
@@ -640,8 +730,11 @@ spec:
                   This key will be added to the host to allow ssh access
                 type: string
               suppressedManifests:
-                description: SuppressedManifests is a list of manifest names to be
-                  excluded from the template rendering process
+                description: |-
+                  suppressedManifests is a list of Kubernetes resource Kinds to exclude
+                  from rendering. Manifests whose rendered Kind matches an entry in this
+                  list are not applied to the cluster and are recorded as "suppressed" in
+                  status. Cluster-level suppression also applies to node-level manifests.
                 items:
                   type: string
                 type: array

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -194,8 +194,9 @@ spec:
                   type:
                     default: none
                     description: |-
-                      type specifies the disk encryption mode. Valid values depend on the
-                      installation flow. The default is "none" (encryption disabled).
+                      type specifies the disk encryption mode. The default "none" disables
+                      encryption. Use "tpmv2" for TPM 2.0 or "tang" for network-bound disk
+                      encryption via Tang servers (requires the tang field).
                     type: string
                 type: object
               extraAnnotations:

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -72,6 +72,7 @@ spec:
                   Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
                   most one IP address per IP stack used). The order of stacks should be the same as order
                   of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                  Not applicable to Single Node OpenShift (SNO) clusters.
                 items:
                   type: string
                 maxItems: 2
@@ -106,7 +107,10 @@ spec:
               clusterName:
                 description: |-
                   clusterName is the name of the cluster. It is used as the base name
-                  for generated resources and their namespace.
+                  for generated resources and their namespace. Must be a valid
+                  Kubernetes namespace name: lowercase alphanumeric characters or
+                  hyphens, must start and end with an alphanumeric character, and at
+                  most 63 characters long.
                 type: string
               clusterNetwork:
                 description: ClusterNetwork is the list of IP address pools for pods.
@@ -171,6 +175,8 @@ spec:
                   diskEncryption configures disk encryption for cluster nodes. Use the
                   type sub-field to select the encryption mode and tang to provide
                   Tang server details when using network-bound disk encryption.
+                  These fields are not consumed by the default provided templates
+                  and require custom templates (via templateRefs) to take effect.
                 properties:
                   tang:
                     description: |-
@@ -264,6 +270,7 @@ spec:
                   Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
                   most one IP address per IP stack used). The order of stacks should be the same as order
                   of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                  Not applicable to Single Node OpenShift (SNO) clusters.
                 items:
                   type: string
                 maxItems: 2
@@ -340,6 +347,9 @@ spec:
                       description: |-
                         Which MAC address will PXE boot? This is optional for some
                         types, but required for libvirt VMs driven by vbmc.
+                        This MAC address should correspond to one of the interfaces
+                        defined in nodeNetwork so that the host can be provisioned
+                        on the correct network.
                       pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
                       type: string
                     bootMode:
@@ -367,10 +377,13 @@ spec:
                         type: object
                       description: |-
                         extraAnnotations specifies additional node-level annotations keyed by
-                        resource Kind. If a Kind is present in the node-level map, those
-                        annotations are used for this node instead of any cluster-level
-                        annotations for the same Kind. Kinds not defined at node level fall
-                        back to cluster-level extraAnnotations.
+                        the Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+                        The key is matched against the kind field of each rendered manifest.
+                        If a Kind is present in the node-level map, those annotations are
+                        used for this node instead of any cluster-level annotations for the
+                        same Kind. Kinds not defined at node level fall back to cluster-level
+                        extraAnnotations. Annotations already defined in the template take
+                        precedence and are not overwritten.
                       type: object
                     extraLabels:
                       additionalProperties:
@@ -378,11 +391,14 @@ spec:
                           type: string
                         type: object
                       description: |-
-                        extraLabels specifies additional node-level labels keyed by resource
-                        Kind. If a Kind is present in the node-level map, those labels are
-                        used for this node instead of any cluster-level labels for the same
-                        Kind. Kinds not defined at node level fall back to cluster-level
-                        extraLabels.
+                        extraLabels specifies additional node-level labels keyed by the
+                        Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+                        The key is matched against the kind field of each rendered manifest.
+                        If a Kind is present in the node-level map, those labels are used
+                        for this node instead of any cluster-level labels for the same Kind.
+                        Kinds not defined at node level fall back to cluster-level
+                        extraLabels. Labels already defined in the template take precedence
+                        and are not overwritten.
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host
@@ -571,7 +587,8 @@ spec:
                         suppressedManifests is a list of Kubernetes resource Kinds to exclude
                         from rendering for this node. Combined with cluster-level
                         suppressedManifests. Matching manifests are not applied and are
-                        recorded as "suppressed" in status.
+                        recorded as "suppressed" in status. Previously applied resources
+                        are not deleted; use pruneManifests to remove them.
                       items:
                         type: string
                       type: array
@@ -736,6 +753,8 @@ spec:
                   from rendering. Manifests whose rendered Kind matches an entry in this
                   list are not applied to the cluster and are recorded as "suppressed" in
                   status. Cluster-level suppression also applies to node-level manifests.
+                  Previously applied resources are not deleted; use pruneManifests to
+                  remove them.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -84,7 +84,7 @@ spec:
                 description: |-
                   caBundleRef is a reference to a ConfigMap containing a bundle of
                   trusted CA certificates. The controller passes this reference to
-                  the downstream CRD (HostedCluster or ImageClusterInstall). Not
+                  the downstream resource (HostedCluster or ImageClusterInstall). Not
                   applicable to the Assisted Installer flow.
                 properties:
                   name:

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -30,7 +30,12 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterInstance is the Schema for the clusterinstances API
+        description: |-
+          ClusterInstance defines the desired configuration for provisioning an
+          OpenShift cluster. Based on the selected templateRefs and clusterType,
+          the controller renders and applies the Kubernetes resources needed for
+          cluster installation (e.g., ClusterDeployment, ManagedCluster,
+          BareMetalHost, or HostedCluster depending on the installation flow).
         properties:
           apiVersion:
             description: |-
@@ -50,7 +55,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterInstanceSpec defines the desired state of ClusterInstance
+            description: |-
+              ClusterInstanceSpec defines the desired state for a cluster, including
+              topology, networking, platform, node roles, and installation settings.
             properties:
               additionalNTPSources:
                 description: |-
@@ -74,8 +81,11 @@ spec:
                   cluster.
                 type: string
               caBundleRef:
-                description: CABundle is a reference to a config map containing the
-                  new bundle of trusted certificates for the host.
+                description: |-
+                  caBundleRef is a reference to a ConfigMap containing a bundle of
+                  trusted CA certificates. The controller passes this reference to
+                  the downstream CRD (HostedCluster or ImageClusterInstall). Not
+                  applicable to the Assisted Installer flow.
                 properties:
                   name:
                     default: ""
@@ -94,7 +104,9 @@ spec:
                   OpenShift version to deploy.
                 type: string
               clusterName:
-                description: ClusterName is the name of the cluster.
+                description: |-
+                  clusterName is the name of the cluster. It is used as the base name
+                  for generated resources and their namespace.
                 type: string
               clusterNetwork:
                 description: ClusterNetwork is the list of IP address pools for pods.
@@ -118,7 +130,15 @@ spec:
                   type: object
                 type: array
               clusterType:
-                description: ClusterType is a string representing the cluster type
+                description: |-
+                  clusterType specifies the topology of the cluster.
+                  One of: SNO (Single Node OpenShift — exactly 1 control-plane node; worker nodes
+                  may also be specified and are provisioned independently of the initial installation),
+                  HighlyAvailable (multiple control-plane and worker nodes),
+                  HostedControlPlane (control plane hosted externally via HyperShift, no control-plane
+                  nodes in this spec),
+                  HighlyAvailableArbiter (at least 2 control-plane nodes with at least 1 arbiter node
+                  for stretched clusters).
                 enum:
                 - SNO
                 - HighlyAvailable
@@ -147,20 +167,35 @@ spec:
                 - AllNodes
                 type: string
               diskEncryption:
-                description: DiskEncryption is the configuration to enable/disable
-                  disk encryption for cluster nodes.
+                description: |-
+                  diskEncryption configures disk encryption for cluster nodes. Use the
+                  type sub-field to select the encryption mode and tang to provide
+                  Tang server details when using network-bound disk encryption.
                 properties:
                   tang:
+                    description: |-
+                      tang is a list of Tang server configurations used for network-bound
+                      disk encryption (NBDE). Each entry specifies a Tang server URL and
+                      its thumbprint.
                     items:
+                      description: |-
+                        TangConfig holds the configuration for a single Tang server used for
+                        network-bound disk encryption (NBDE).
                       properties:
                         thumbprint:
+                          description: thumbprint is the thumbprint of the Tang server's
+                            signing key.
                           type: string
                         url:
+                          description: url is the URL of the Tang server.
                           type: string
                       type: object
                     type: array
                   type:
                     default: none
+                    description: |-
+                      type specifies the disk encryption mode. Valid values depend on the
+                      installation flow. The default is "none" (encryption disabled).
                     type: string
                 type: object
               extraAnnotations:
@@ -168,16 +203,24 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: Additional cluster-wide annotations to be applied to
-                  the rendered templates
+                description: |-
+                  extraAnnotations specifies additional cluster-level annotations keyed by
+                  resource Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind,
+                  the annotations are merged into the matching rendered manifest's metadata.
+                  Annotations already defined in the template take precedence and are not
+                  overwritten by extraAnnotations.
                 type: object
               extraLabels:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: Additional cluster-wide labels to be applied to the rendered
-                  templates
+                description: |-
+                  extraLabels specifies additional cluster-level labels keyed by resource
+                  Kind (e.g., "ManagedCluster": {"key": "value"}). For each Kind, the
+                  labels are merged into the matching rendered manifest's metadata.
+                  Labels already defined in the template take precedence and are not
+                  overwritten by extraLabels.
                 type: object
               extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
@@ -202,13 +245,17 @@ spec:
               holdInstallation:
                 default: false
                 description: |-
-                  HoldInstallation will prevent installation from happening when true.
-                  Inspection and validation will proceed as usual, but once the RequirementsMet condition is true,
-                  installation will not begin until this field is set to false.
+                  holdInstallation prevents the Assisted Installer from starting the
+                  installation when set to true. Inspection and validation proceed
+                  normally, but installation is held until this field is set to false.
+                  Can only be enabled at creation time. Defaults to false.
                 type: boolean
               ignitionConfigOverride:
-                description: Json formatted string containing the user overrides for
-                  the initial ignition config
+                description: |-
+                  ignitionConfigOverride is a JSON-formatted string containing overrides
+                  for the discovery-phase Ignition config. Rendered into
+                  InfraEnv.spec.ignitionConfigOverride. Applies to Assisted Installer
+                  and Hosted Control Plane flows.
                 type: string
               ingressVIPs:
                 description: |-
@@ -222,8 +269,11 @@ spec:
                 type: array
               installConfigOverrides:
                 description: |-
-                  InstallConfigOverrides is a Json formatted string that provides a generic way of passing
-                  install-config parameters.
+                  installConfigOverrides is a JSON-formatted string of install-config
+                  parameters. The controller automatically merges networkType and
+                  cpuPartitioningMode into this value. Rendered as the
+                  agent-install.openshift.io/install-config-overrides annotation on
+                  AgentClusterInstall. Applies to the Assisted Installer flow only.
                 type: string
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
@@ -242,16 +292,21 @@ spec:
               networkType:
                 default: OVNKubernetes
                 description: |-
-                  NetworkType is the Container Network Interface (CNI) plug-in to install
-                  The default value is OpenShiftSDN for IPv4, and OVNKubernetes for IPv6 or SNO
+                  networkType specifies the Container Network Interface (CNI) plugin
+                  to install. Defaults to OVNKubernetes.
                 enum:
                 - OpenShiftSDN
                 - OVNKubernetes
                 type: string
               nodes:
-                description: List of node objects
+                description: |-
+                  nodes is the list of nodes to provision for this cluster. The number
+                  and roles of nodes must be compatible with the selected clusterType.
                 items:
-                  description: NodeSpec
+                  description: |-
+                    NodeSpec defines the desired configuration for a single node (host) in
+                    a ClusterInstance, including bare-metal host details, network settings,
+                    and node-level template overrides.
                   properties:
                     automatedCleaningMode:
                       default: disabled
@@ -273,6 +328,9 @@ spec:
                         and "password").
                       properties:
                         name:
+                          description: |-
+                            name is the name of the Secret containing the BMC credentials
+                            (requires keys "username" and "password").
                           type: string
                       required:
                       - name
@@ -285,8 +343,9 @@ spec:
                       type: string
                     bootMode:
                       default: UEFI
-                      description: Provide guidance about how to choose the device
-                        for the image being provisioned.
+                      description: |-
+                        bootMode selects the method of initializing the hardware during boot.
+                        Defaults to UEFI.
                       enum:
                       - UEFI
                       - UEFISecureBoot
@@ -295,7 +354,7 @@ spec:
                     cpuArchitecture:
                       description: |-
                         CPUArchitecture is the software architecture of the node.
-                        If it is not defined here then it is inheirited from the ClusterInstanceSpec.
+                        If it is not defined here then it is inherited from the ClusterInstanceSpec.
                       enum:
                       - x86_64
                       - aarch64
@@ -305,16 +364,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      description: Additional node-level annotations to be applied
-                        to the rendered templates
+                      description: |-
+                        extraAnnotations specifies additional node-level annotations keyed by
+                        resource Kind. If a Kind is present in the node-level map, those
+                        annotations are used for this node instead of any cluster-level
+                        annotations for the same Kind. Kinds not defined at node level fall
+                        back to cluster-level extraAnnotations.
                       type: object
                     extraLabels:
                       additionalProperties:
                         additionalProperties:
                           type: string
                         type: object
-                      description: Additional node-level labels to be applied to the
-                        rendered templates
+                      description: |-
+                        extraLabels specifies additional node-level labels keyed by resource
+                        Kind. If a Kind is present in the node-level map, those labels are
+                        used for this node instead of any cluster-level labels for the same
+                        Kind. Kinds not defined at node level fall back to cluster-level
+                        extraLabels.
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host
@@ -338,19 +405,24 @@ spec:
                       type: object
                     ignitionConfigOverride:
                       description: |-
-                        Json formatted string containing the user overrides for the host's ignition config
-                        IgnitionConfigOverride enables the assignment of partitions for persistent storage.
-                        Adjust disk ID and size to the specific hardware.
+                        ignitionConfigOverride is a JSON-formatted string containing
+                        host-specific Ignition config overrides. Rendered as the
+                        bmac.agent-install.openshift.io/ignition-config-overrides annotation
+                        on the BareMetalHost resource. Must be valid JSON when provided.
                       type: string
                     installerArgs:
-                      description: Json formatted string containing the user overrides
-                        for the host's coreos installer args
+                      description: |-
+                        installerArgs is a JSON-formatted string of arguments passed to the
+                        coreos-installer via the bare metal agent controller. Rendered as the
+                        bmac.agent-install.openshift.io/installer-args annotation on the
+                        BareMetalHost resource. Must be valid JSON when provided.
                       type: string
                     ironicInspect:
                       default: ""
                       description: |-
-                        IronicInspect is used to specify if automatic introspection carried out during registration of BMH is enabled or
-                        disabled
+                        ironicInspect controls automatic hardware introspection performed by
+                        Ironic during BareMetalHost registration. The default empty string
+                        enables inspection. Set to "disabled" to skip hardware inspection.
                       enum:
                       - ""
                       - disabled
@@ -405,8 +477,10 @@ spec:
                       type: object
                     pruneManifests:
                       description: |-
-                        PruneManifests represents a list of Kubernetes resource references that indicates which "node-level" manifests
-                        should be pruned (removed).
+                        pruneManifests is a list of resource references (apiVersion + kind)
+                        identifying node-level manifests that should be skipped during
+                        rendering and deleted from the cluster if previously applied.
+                        Combined with cluster-level pruneManifests.
                       items:
                         description: ResourceRef represents the API version and kind
                           of a Kubernetes resource
@@ -428,6 +502,8 @@ spec:
                       type: array
                     role:
                       default: master
+                      description: role specifies the role of this node in the cluster.
+                        Defaults to "master".
                       enum:
                       - master
                       - worker
@@ -490,8 +566,11 @@ spec:
                           type: string
                       type: object
                     suppressedManifests:
-                      description: SuppressedManifests is a list of node-level manifest
-                        names to be excluded from the template rendering process
+                      description: |-
+                        suppressedManifests is a list of Kubernetes resource Kinds to exclude
+                        from rendering for this node. Combined with cluster-level
+                        suppressedManifests. Matching manifests are not applied and are
+                        recorded as "suppressed" in status.
                       items:
                         type: string
                       type: array
@@ -529,8 +608,11 @@ spec:
                   type: object
                 type: array
               platformType:
-                description: PlatformType is the name for the specific platform upon
-                  which to perform the installation.
+                description: |-
+                  platformType specifies the infrastructure platform for installation.
+                  Only applicable to the Assisted Installer flow. When empty, the field
+                  is omitted from the rendered AgentClusterInstall, allowing the installer
+                  to select a default.
                 enum:
                 - ""
                 - BareMetal
@@ -557,8 +639,11 @@ spec:
                 type: object
               pruneManifests:
                 description: |-
-                  PruneManifests represents a list of Kubernetes resource references that indicates which manifests should be
-                  pruned (removed).
+                  pruneManifests is a list of resource references (apiVersion + kind)
+                  identifying manifests that should be skipped during rendering and
+                  deleted from the cluster if they were previously applied. Unlike
+                  suppressedManifests, pruning actively removes existing resources.
+                  Cluster-level prune entries also apply to node-level manifests.
                 items:
                   description: ResourceRef represents the API version and kind of
                     a Kubernetes resource
@@ -593,7 +678,12 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               reinstall:
-                description: Reinstall specifications
+                description: |-
+                  reinstall triggers a cluster reinstallation workflow when populated.
+                  This is a destructive operation: all rendered resources (except
+                  ManagedCluster) are deleted and reprovisioned. Requires the controller
+                  to be configured with allowReinstalls enabled. Each reinstall must use
+                  a unique generation value.
                 properties:
                   generation:
                     description: |-
@@ -640,8 +730,11 @@ spec:
                   This key will be added to the host to allow ssh access
                 type: string
               suppressedManifests:
-                description: SuppressedManifests is a list of manifest names to be
-                  excluded from the template rendering process
+                description: |-
+                  suppressedManifests is a list of Kubernetes resource Kinds to exclude
+                  from rendering. Manifests whose rendered Kind matches an entry in this
+                  list are not applied to the cluster and are recorded as "suppressed" in
+                  status. Cluster-level suppression also applies to node-level manifests.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -194,8 +194,9 @@ spec:
                   type:
                     default: none
                     description: |-
-                      type specifies the disk encryption mode. Valid values depend on the
-                      installation flow. The default is "none" (encryption disabled).
+                      type specifies the disk encryption mode. The default "none" disables
+                      encryption. Use "tpmv2" for TPM 2.0 or "tang" for network-bound disk
+                      encryption via Tang servers (requires the tang field).
                     type: string
                 type: object
               extraAnnotations:

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -72,6 +72,7 @@ spec:
                   Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
                   most one IP address per IP stack used). The order of stacks should be the same as order
                   of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                  Not applicable to Single Node OpenShift (SNO) clusters.
                 items:
                   type: string
                 maxItems: 2
@@ -106,7 +107,10 @@ spec:
               clusterName:
                 description: |-
                   clusterName is the name of the cluster. It is used as the base name
-                  for generated resources and their namespace.
+                  for generated resources and their namespace. Must be a valid
+                  Kubernetes namespace name: lowercase alphanumeric characters or
+                  hyphens, must start and end with an alphanumeric character, and at
+                  most 63 characters long.
                 type: string
               clusterNetwork:
                 description: ClusterNetwork is the list of IP address pools for pods.
@@ -171,6 +175,8 @@ spec:
                   diskEncryption configures disk encryption for cluster nodes. Use the
                   type sub-field to select the encryption mode and tang to provide
                   Tang server details when using network-bound disk encryption.
+                  These fields are not consumed by the default provided templates
+                  and require custom templates (via templateRefs) to take effect.
                 properties:
                   tang:
                     description: |-
@@ -264,6 +270,7 @@ spec:
                   Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
                   most one IP address per IP stack used). The order of stacks should be the same as order
                   of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                  Not applicable to Single Node OpenShift (SNO) clusters.
                 items:
                   type: string
                 maxItems: 2
@@ -340,6 +347,9 @@ spec:
                       description: |-
                         Which MAC address will PXE boot? This is optional for some
                         types, but required for libvirt VMs driven by vbmc.
+                        This MAC address should correspond to one of the interfaces
+                        defined in nodeNetwork so that the host can be provisioned
+                        on the correct network.
                       pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
                       type: string
                     bootMode:
@@ -367,10 +377,13 @@ spec:
                         type: object
                       description: |-
                         extraAnnotations specifies additional node-level annotations keyed by
-                        resource Kind. If a Kind is present in the node-level map, those
-                        annotations are used for this node instead of any cluster-level
-                        annotations for the same Kind. Kinds not defined at node level fall
-                        back to cluster-level extraAnnotations.
+                        the Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+                        The key is matched against the kind field of each rendered manifest.
+                        If a Kind is present in the node-level map, those annotations are
+                        used for this node instead of any cluster-level annotations for the
+                        same Kind. Kinds not defined at node level fall back to cluster-level
+                        extraAnnotations. Annotations already defined in the template take
+                        precedence and are not overwritten.
                       type: object
                     extraLabels:
                       additionalProperties:
@@ -378,11 +391,14 @@ spec:
                           type: string
                         type: object
                       description: |-
-                        extraLabels specifies additional node-level labels keyed by resource
-                        Kind. If a Kind is present in the node-level map, those labels are
-                        used for this node instead of any cluster-level labels for the same
-                        Kind. Kinds not defined at node level fall back to cluster-level
-                        extraLabels.
+                        extraLabels specifies additional node-level labels keyed by the
+                        Kubernetes resource Kind (e.g., "BareMetalHost", "NMStateConfig").
+                        The key is matched against the kind field of each rendered manifest.
+                        If a Kind is present in the node-level map, those labels are used
+                        for this node instead of any cluster-level labels for the same Kind.
+                        Kinds not defined at node level fall back to cluster-level
+                        extraLabels. Labels already defined in the template take precedence
+                        and are not overwritten.
                       type: object
                     hostName:
                       description: Hostname is the desired hostname for the host
@@ -571,7 +587,8 @@ spec:
                         suppressedManifests is a list of Kubernetes resource Kinds to exclude
                         from rendering for this node. Combined with cluster-level
                         suppressedManifests. Matching manifests are not applied and are
-                        recorded as "suppressed" in status.
+                        recorded as "suppressed" in status. Previously applied resources
+                        are not deleted; use pruneManifests to remove them.
                       items:
                         type: string
                       type: array
@@ -736,6 +753,8 @@ spec:
                   from rendering. Manifests whose rendered Kind matches an entry in this
                   list are not applied to the cluster and are recorded as "suppressed" in
                   status. Cluster-level suppression also applies to node-level manifests.
+                  Previously applied resources are not deleted; use pruneManifests to
+                  remove them.
                 items:
                   type: string
                 type: array

--- a/config/manifests/bases/siteconfig.clusterserviceversion.yaml
+++ b/config/manifests/bases/siteconfig.clusterserviceversion.yaml
@@ -10,7 +10,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterInstance is the Schema for the clusterinstances API
+    - description: ClusterInstance defines the desired configuration for provisioning
+        an OpenShift cluster. Based on the selected templateRefs and clusterType,
+        the controller renders and applies the Kubernetes resources needed for cluster
+        installation (e.g., ClusterDeployment, ManagedCluster, BareMetalHost, or HostedCluster
+        depending on the installation flow).
       displayName: Cluster Instance
       kind: ClusterInstance
       name: clusterinstances.siteconfig.open-cluster-management.io


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The ClusterInstance CRD has multiple fields with vague, missing, or inaccurate descriptions. This degrades the user experience when using `kubectl explain`, reading API docs, or authoring ClusterInstance manifests. A CRD description quality audit identified 8 critical fields with no description at all, 12 fields with insufficient documentation, and 2 fields with factually incorrect descriptions.

## Changes Made

- Improved root `ClusterInstance` and `ClusterInstanceSpec` type descriptions to explain what the CRD does and what resources it generates
- Documented all 4 `clusterType` enum values (SNO, HighlyAvailable, HostedControlPlane, HighlyAvailableArbiter) with code-validated constraints
- Added missing descriptions for `diskEncryption.tang`, `diskEncryption.type`, `role`, `TangConfig` fields, and `BmcCredentialsName.Name`
- Corrected `bootMode` description (was incorrectly describing `rootDeviceHints`)
- Corrected `networkType` default (was "OpenShiftSDN for IPv4", actual default is OVNKubernetes)
- Clarified `extraAnnotations`/`extraLabels` Kind-keyed structure and template precedence behavior
- Distinguished `suppressedManifests` (skip rendering) from `pruneManifests` (skip rendering and delete existing resources)
- Documented `installConfigOverrides` auto-merge behavior and `reinstall` destructive nature
- Improved descriptions for `platformType`, `ironicInspect`, `holdInstallation`, `caBundleRef`, `ignitionConfigOverride`, `installerArgs`, and `NodeSpec`
- Fixed typo: "inheirited" → "inherited" in `cpuArchitecture` description

## Testing

- All unit tests pass (`make unittest`)
- `golangci-lint` passes with no violations
- `make generate manifests` regenerated CRD schema — descriptions appear correctly in OpenAPI spec
- `make bundle` regenerated operator bundle
- Full `make ci-job` passes (excluding `bundle-check` which requires committed files)
- N/A — Comment-only changes, no behavioral code changes, no new code paths

## JIRA

https://issues.redhat.com/browse/ACM-32731

## AI Assistance

- **Model Used**: Claude Opus 4.6 (1M context) via Claude Code CLI
- **Scope**: All description text was AI-drafted based on code analysis, then verified against the actual codebase, upstream component CRDs (Assisted Service, Hive, BMO, HyperShift), and Kubernetes API conventions
- **Level**: Co-development — AI researched code behavior, drafted descriptions, and identified inaccuracies in the original Jira suggestions; human reviewed and approved all changes
- **Human Review**: All AI-generated descriptions were reviewed, cross-referenced against source code, and validated via CI

---

## Pull Request Checklist

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @imiller0 @cwilkers @jnpacker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tang entries added for network-bound disk encryption.
  * New per-node options: CPU architecture, boot mode, node role, inspection controls, installer/ignition overrides, boot MAC, platform hints, and per-node manifest handling.
  * Cluster-level knobs: network type, CA bundle reference, manifest pruning/suppression, hold installation, and reinstall controls.

* **Documentation**
  * Expanded API/CRD descriptions clarifying defaults, validation, precedence, install flows, and manifest/override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->