### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,55 @@
+# Build the siteconfig-manager binary
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /opt/app-root/src
+
+# Bring in the go dependencies before anything else so we can take
+# advantage of caching these layers in future builds.
+COPY vendor/ vendor/
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+
+# Build the binaries
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on \
+  GOEXPERIMENT=strictfipsruntime go build -mod=vendor -a -o build/siteconfig-manager cmd/main.go
+
+#####################################################################################################
+# Build the controller image
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ENV SUMMARY="SiteConfig Operator is a template-driven cluster provisioning solution" \
+    DESCRIPTION="SiteConfig operator as a template-driven cluster provisioning solution, which allows you to \
+provision clusters with all available installation methods."
+
+LABEL name="rhacm2/acm-siteconfig-rhel9" \
+      url="https://github.com/stolostron/siteconfig" \
+      cpe="cpe:/a:redhat:acm:2.16::el9" \
+      summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      com.redhat.component="siteconfig-operator" \
+      io.k8s.display-name="SiteConfig Operator" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.openshift.tags="siteconfig,template-driven,cluster,provisioning,lifecycle"
+
+COPY --from=builder \
+    /opt/app-root/src/build/siteconfig-manager \
+    /usr/local/bin/
+
+# Copy the licence
+COPY LICENSE /licenses/LICENSE
+
+ENV USER_UID=65532
+
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/siteconfig-manager"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)