### PR TITLE
ACM-33699: Update Go builder images from 1.24 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Problem / Requirement / Reason for change

Konflux builds on `release-2.15` fail because `go.mod` requires Go 1.25.0 but both Dockerfiles reference Go 1.24 builder images (`ACM-33699`).

## Changes Made

- Updated `Dockerfile` builder image from `go1.24-linux` to `go1.25-linux`
- Updated `build/Dockerfile.rhtap` builder image from `rhel_9_1.24` to `rhel_9_1.25`

## Testing

- Verified `go1.25-linux` image exists and pulls successfully
- Confirmed `go mod verify` passes — vendor directory is consistent
- N/A for code coverage — no code changes

## JIRA

https://issues.redhat.com/browse/ACM-33699

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Log analysis, root cause triage, Dockerfile edits
- **Level**: Co-development
- **Human Review**: All changes reviewed and validated

---

## Pull Request Checklist

- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass

/cc @gparvin 