### PR TITLE
[release-2.14] ACM-34001: Update Go builder images from 1.24 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Resolves: [ACM-34001](https://redhat.atlassian.net/browse/ACM-34001)

/cc @gparvin

[ACM-34001]: https://redhat.atlassian.net/browse/ACM-34001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ