### PR TITLE
[release-2.15] ACM-33708: Bump Go to 1.25.9 for CVE fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,164 +1,145 @@
----
+version: "2"
 run:
   concurrency: 6
-  deadline: 5m
-  skip-files:
-    - ".*_test\\.go"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - lll
     - depguard
+    - errorlint
     - goconst
     - gocritic
-    - revive
-    - gofmt
-    - goimports
+    - gocyclo
+    - gosec
     - govet
     - ineffassign
+    - lll
+    - loggercheck
     - misspell
+    - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
-    - gocyclo
     - unused
-    - errorlint
-    - loggercheck
-    - gosec
     - wrapcheck
-linters-settings:
-  lll:
-    line-length: 120
-  revive:
-    rules:
-      - name: if-return
-        severity: warning
-        disabled: true
-      - name: string-format
-        severity: warning
-        disabled: false
-        arguments:
-          - - 'core.WriteError[1].Message'
-            - '/^([^A-Z]|$)/'
-            - must not start with a capital letter
-          - - 'fmt.Errorf[0]'
-            - '/^([^A-Z]|$)/'
-            - must not start with a capital letter
-          - - 'fmt.Errorf[0]'
-            - '/(^|[^\.!?])$/'
-            - must not end in punctuation
-          - - panic
-            - '/^[^\n]*$/'
-            - must not contain line breaks
-  gocritic:
-    enabled-checks:
-      # Diagnostic
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - offBy1
-      - weakCond
-      - octalLiteral
-      - sloppyReassign
-
-      # Performance
-      - equalFold
-      - indexAlloc
-      - rangeExprCopy
-      - appendCombine
-
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
-      - elseif
-      - emptyFallthrough
-      - emptyStringTest
-      - hexLiteral
-      - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - stringXbytes
-      - switchTrue
-      - typeAssertChain
-      - typeSwitchVar
-      - underef
-      - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - yodaStyleExpr
-      - wrapperFunc
-
-      # Opinionated
-      - initClause
-      - nestingReduce
-      - ptrToRefParam
-      - typeUnparen
-      - unnecessaryBlock
-      - paramTypeCombine
-  depguard:
-    # Rules to apply.
-    #
-    # Variables:
-    # - File Variables
-    #   you can still use and exclamation mark ! in front of a variable to say not to use it.
-    #   Example !$test will match any file that is not a go test file.
-    #
-    #   `$all` - matches all go files
-    #   `$test` - matches all go test files
-    #
-    # - Package Variables
-    #
-    #  `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
-    #
-    # Default: Only allow $gostd in all files.
-    rules:
-      # Name of a rule.
-      main:
-        # Used to determine the package matching priority.
-        # There are three different modes: `original`, `strict`, and `lax`.
-        # Default: "original"
-        list-mode: lax
-        # List of file globs that will match this list of settings to compare against.
-        # Default: $all
-        files:
-          - $all
-        # List of allowed packages.
-        #allow:
-        #  - $gostd
-        # Packages that are not allowed where the value is a suggestion.
-        deny:
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package
-  wrapcheck:
-    ignoreSigs:
-      # defaults
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-      # from kyaml's errors package
-      - .WrapPrefixf(
-
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - $all
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+    gocritic:
+      enabled-checks:
+        - argOrder
+        - badCond
+        - caseOrder
+        - codegenComment
+        - commentedOutCode
+        - deprecatedComment
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - exitAfterDefer
+        - flagDeref
+        - flagName
+        - nilValReturn
+        - offBy1
+        - weakCond
+        - octalLiteral
+        - sloppyReassign
+        - equalFold
+        - indexAlloc
+        - rangeExprCopy
+        - appendCombine
+        - assignOp
+        - boolExprSimplify
+        - captLocal
+        - commentFormatting
+        - commentedOutImport
+        - defaultCaseOrder
+        - docStub
+        - elseif
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - methodExprCall
+        - regexpMust
+        - singleCaseSwitch
+        - sloppyLen
+        - stringXbytes
+        - switchTrue
+        - typeAssertChain
+        - typeSwitchVar
+        - underef
+        - unlabelStmt
+        - unlambda
+        - unslice
+        - valSwap
+        - yodaStyleExpr
+        - wrapperFunc
+        - initClause
+        - nestingReduce
+        - ptrToRefParam
+        - typeUnparen
+        - unnecessaryBlock
+        - paramTypeCombine
+    lll:
+      line-length: 120
+    revive:
+      rules:
+        - name: if-return
+          severity: warning
+          disabled: true
+        - name: string-format
+          arguments:
+            - - core.WriteError[1].Message
+              - /^([^A-Z]|$)/
+              - must not start with a capital letter
+            - - fmt.Errorf[0]
+              - /^([^A-Z]|$)/
+              - must not start with a capital letter
+            - - fmt.Errorf[0]
+              - /(^|[^\.!?])$/
+              - must not end in punctuation
+            - - panic
+              - /^[^\n]*$/
+              - must not contain line breaks
+          severity: warning
+          disabled: false
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+        - .WrapPrefixf(
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - _test\.go$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ MOCKGEN ?= $(LOCALBIN)/mockgen
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
-CONTROLLER_TOOLS_VERSION ?= v0.16.2
+CONTROLLER_TOOLS_VERSION ?= v0.20.0
 MOCKGEN_VERSION ?= v0.6.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/api/v1alpha1/clusterinstance_utils.go
+++ b/api/v1alpha1/clusterinstance_utils.go
@@ -108,7 +108,7 @@ func IndexOfManifestByIdentity(target *ManifestReference, manifestRefs []Manifes
 
 // IsPaused checks if the ClusterInstance has the paused annotation.
 func (ci *ClusterInstance) IsPaused() bool {
-	annotations := ci.ObjectMeta.Annotations
+	annotations := ci.Annotations
 	if annotations == nil {
 		return false
 	}

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   name: clusterinstances.siteconfig.open-cluster-management.io
 spec:

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: clusterinstances.siteconfig.open-cluster-management.io
 spec:
   group: siteconfig.open-cluster-management.io

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.64.6"
+VERSION="2.8.0"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then
@@ -41,4 +41,4 @@ fi
 
 export GOCACHE=/tmp/
 export GOLANGCI_LINT_CACHE=/tmp/.cache
-"${golangci_lint}" run --verbose --print-resources-usage --modules-download-mode=vendor --timeout=5m0s
+"${golangci_lint}" run --verbose --modules-download-mode=vendor

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -60,7 +60,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Get the ClusterDeployment CR
 	clusterDeployment := &hivev1.ClusterDeployment{}
-	if err := r.Client.Get(ctx, req.NamespacedName, clusterDeployment); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, clusterDeployment); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("ClusterDeployment not found")
 			return doNotRequeue(), nil
@@ -276,7 +276,7 @@ func (r *ClusterDeploymentReconciler) getClusterInstance(
 	}
 
 	clusterInstance := &v1alpha1.ClusterInstance{}
-	if err := r.Client.Get(ctx, clusterInstanceRef,
+	if err := r.Get(ctx, clusterInstanceRef,
 		clusterInstance); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("ClusterInstance not found", zap.String("name", clusterInstanceRef.String()))
@@ -293,7 +293,7 @@ func (r *ClusterDeploymentReconciler) mapClusterInstanceToCD(
 	obj *v1alpha1.ClusterInstance,
 ) []reconcile.Request {
 	clusterInstance := &v1alpha1.ClusterInstance{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()},
+	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()},
 		clusterInstance); err != nil {
 		return []reconcile.Request{}
 	}

--- a/internal/controller/mocks/client_mock_generated.go
+++ b/internal/controller/mocks/client_mock_generated.go
@@ -44,6 +44,25 @@ func (m *GeneratedMockClient) EXPECT() *GeneratedMockClientMockRecorder {
 	return m.recorder
 }
 
+// Apply mocks base method.
+func (m *GeneratedMockClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Apply", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Apply indicates an expected call of Apply.
+func (mr *GeneratedMockClientMockRecorder) Apply(ctx, obj any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*GeneratedMockClient)(nil).Apply), varargs...)
+}
+
 // Create mocks base method.
 func (m *GeneratedMockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	m.ctrl.T.Helper()

--- a/internal/controller/reinstall/reinstall.go
+++ b/internal/controller/reinstall/reinstall.go
@@ -306,7 +306,7 @@ func (r *ReinstallHandler) ensureRenderedManifestsAreDeleted(ctx context.Context
 					return
 				}
 				if changed && err == nil {
-					result.Requeue = true
+					result.RequeueAfter = requeueWithShortInterval
 				}
 			}
 		}
@@ -357,7 +357,7 @@ func (r *ReinstallHandler) ensureRenderedManifestsAreDeleted(ctx context.Context
 
 	if !deletionCompleted {
 		log.Info("Waiting for rendered manifests to be deleted")
-		result = reconcile.Result{Requeue: true, RequeueAfter: deletionRequeueWithMediumInterval}
+		result = reconcile.Result{RequeueAfter: deletionRequeueWithMediumInterval}
 		return
 	}
 
@@ -521,7 +521,7 @@ func (r *ReinstallHandler) ensureDataIsPreserved(
 		}
 
 		if updateRequired {
-			result.Requeue = true
+			result.RequeueAfter = requeueWithShortInterval
 			updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch)
 			if updateErr != nil {
 				result.RequeueAfter = requeueWithShortInterval
@@ -579,7 +579,7 @@ func (r *ReinstallHandler) ensurePreservedDataIsRestored(
 			patch := client.MergeFrom(clusterInstance.DeepCopy())
 
 			if changed := setReinstallStatusCondition(clusterInstance, *preservationDataRestoredCondition); changed {
-				result.Requeue = true
+				result.RequeueAfter = requeueWithShortInterval
 				updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch)
 				if updateErr != nil {
 					result.RequeueAfter = requeueWithShortInterval

--- a/internal/controller/reinstall/reinstall_test.go
+++ b/internal/controller/reinstall/reinstall_test.go
@@ -585,7 +585,7 @@ var _ = Describe("ensureRenderedManifestsAreDeleted", func() {
 
 		result, err := handler.ensureRenderedManifestsAreDeleted(ctx, testLogger, clusterInstance)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result.Requeue).To(BeTrue())
+		Expect(result.RequeueAfter).To(Equal(requeueWithShortInterval))
 
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallRenderedManifestsDeleted)
 		Expect(cond).NotTo(BeNil())
@@ -704,7 +704,6 @@ var _ = Describe("ensureRenderedManifestsAreDeleted", func() {
 		// Invoke deletion first time - to delete the resource, which triggers a requeue
 		result, err := handler.ensureRenderedManifestsAreDeleted(ctx, testLogger, clusterInstance)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result.Requeue).To(BeTrue())
 		Expect(result.RequeueAfter).To(Equal(deletionRequeueWithMediumInterval))
 
 		// Invoke deletion second time - to ensure that deletion was successful and that the status condition is correctly set
@@ -712,7 +711,7 @@ var _ = Describe("ensureRenderedManifestsAreDeleted", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify that requeue is set to reflect the update in ReinstallRenderedManifestsDeleted status condition
-		Expect(result.Requeue).To(BeTrue())
+		Expect(result.RequeueAfter).To(Equal(requeueWithShortInterval))
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallRenderedManifestsDeleted)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
@@ -1131,7 +1130,7 @@ var _ = Describe("ensureDataIsPreserved", func() {
 
 		result, err := handler.ensureDataIsPreserved(ctx, testLogger, clusterInstance)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: requeueWithShortInterval}))
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallPreservationDataBackedup)
 		Expect(cond).ToNot(BeNil())
 		Expect(cond.Reason).To(Equal(string(v1alpha1.PreservationNotRequired)))
@@ -1248,7 +1247,7 @@ var _ = Describe("ensureDataIsPreserved", func() {
 
 		result, err := handler.ensureDataIsPreserved(ctx, testLogger, clusterInstance)
 		Expect(err).To(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: requeueWithShortInterval}))
 
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallPreservationDataBackedup)
 		Expect(cond).ToNot(BeNil())
@@ -1321,7 +1320,7 @@ var _ = Describe("ensurePreservedDataIsRestored", func() {
 
 		result, err := handler.ensurePreservedDataIsRestored(ctx, testLogger, clusterInstance)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: requeueWithShortInterval}))
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallPreservationDataRestored)
 		Expect(cond.Reason).To(Equal(string(v1alpha1.PreservationNotRequired)))
 	})
@@ -1398,7 +1397,7 @@ var _ = Describe("ensurePreservedDataIsRestored", func() {
 
 		result, err := handler.ensurePreservedDataIsRestored(ctx, testLogger, clusterInstance)
 		Expect(err).To(HaveOccurred())
-		Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(result).To(Equal(reconcile.Result{RequeueAfter: requeueWithShortInterval}))
 
 		cond := findReinstallStatusCondition(clusterInstance, v1alpha1.ReinstallPreservationDataRestored)
 		Expect(cond).NotTo(BeNil())


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The `acm-siteconfig-rhel9` image has 7 Go stdlib CVEs (1 CRITICAL, 6 HIGH) due to using a Go version older than 1.25.9. The CRITICAL CVE (CVE-2026-27143) allows arithmetic overflow in loop induction variables. Other HIGH-severity CVEs affect URL handling, TLS key updates, certificate chain validation, and the compiler's pointer analysis.

Full list: CVE-2026-27143, CVE-2026-25679, CVE-2026-27140, CVE-2026-27144, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283.

## Changes Made

- Bumped `go` directive in `go.mod` from `1.25.0` to `1.25.9`
- Upgraded golangci-lint from v1.64.6 to v2.8.0 (required for Go 1.25 support)
- Migrated `.golangci.yml` to v2 format with test file exclusions
- Upgraded controller-tools from v0.16.2 to v0.20.0 for Go 1.25 compatibility
- Simplified embedded field selectors to satisfy new staticcheck rules
- Replaced deprecated `result.Requeue` with `result.RequeueAfter` (SA1019)
- Updated corresponding unit tests for the requeue changes

Cherry-picked from f7762873a (main branch Go 1.25 upgrade) with additional fixes for release-2.15 compatibility.

**Note:** The preservation package has 6 pre-existing test failures on the `release-2.15` base branch (unrelated to this change). All other tests pass.

## Testing

- All lint checks pass (golangci-lint v2.8.0, 0 issues)
- All unit tests pass except pre-existing preservation test failures on `release-2.15` base
- Code coverage for new code: N/A (dependency update only)

## JIRA

https://redhat.atlassian.net/browse/ACM-33708

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Plan creation, branch analysis, PR description drafting
- **Level**: Code assistance
- **Human Review**: All changes reviewed and validated before submission

---

## Pull Request Checklist

- [x] Lint checks pass without errors
- [x] Unit tests pass (except pre-existing failures on base branch)
- [x] Code coverage meets requirements (N/A — dependency update only)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin