### PR TITLE
ACM-33708: Bump Go to 1.25.9 for CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.25.3
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The `acm-siteconfig-rhel9` image has 7 Go stdlib CVEs (1 CRITICAL, 6 HIGH) due to using a Go version older than 1.25.9. The CRITICAL CVE (CVE-2026-27143) allows arithmetic overflow in loop induction variables. Other HIGH-severity CVEs affect URL handling, TLS key updates, certificate chain validation, and the compiler's pointer analysis.

Full list: CVE-2026-27143, CVE-2026-25679, CVE-2026-27140, CVE-2026-27144, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283.

## Changes Made

- Bumped `go` directive in `go.mod` from `1.25.3` to `1.25.9`
- Ran `go mod tidy` and `go mod vendor` to update vendored dependencies

## Testing

- `make ci-job` passes without errors (deps, codegen, fmt, vet, lint, tests, shellcheck, bundle-check)
- All existing unit tests pass unchanged (no new tests required for version bump)
- Code coverage for new code: N/A (dependency update only)

## JIRA

https://redhat.atlassian.net/browse/ACM-33708

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Plan creation, branch analysis, PR description drafting
- **Level**: Code assistance
- **Human Review**: All changes reviewed and validated before submission

---

## Pull Request Checklist

- [x] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass (N/A — no new code)
- [ ] Code coverage meets requirements (N/A — dependency update only)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25.3 to 1.25.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->