### PR TITLE
ACM-34659: Bump Go toolchain to 1.25 on release-2.13 branch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,164 +1,145 @@
----
+version: "2"
 run:
   concurrency: 6
-  deadline: 5m
-  skip-files:
-    - ".*_test\\.go"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - lll
     - depguard
+    - errorlint
     - goconst
     - gocritic
-    - revive
-    - gofmt
-    - goimports
+    - gocyclo
+    - gosec
     - govet
     - ineffassign
+    - lll
+    - loggercheck
     - misspell
+    - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
-    - gocyclo
     - unused
-    - errorlint
-    - loggercheck
-    - gosec
     - wrapcheck
-linters-settings:
-  lll:
-    line-length: 120
-  revive:
-    rules:
-      - name: if-return
-        severity: warning
-        disabled: true
-      - name: string-format
-        severity: warning
-        disabled: false
-        arguments:
-          - - 'core.WriteError[1].Message'
-            - '/^([^A-Z]|$)/'
-            - must not start with a capital letter
-          - - 'fmt.Errorf[0]'
-            - '/^([^A-Z]|$)/'
-            - must not start with a capital letter
-          - - 'fmt.Errorf[0]'
-            - '/(^|[^\.!?])$/'
-            - must not end in punctuation
-          - - panic
-            - '/^[^\n]*$/'
-            - must not contain line breaks
-  gocritic:
-    enabled-checks:
-      # Diagnostic
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - offBy1
-      - weakCond
-      - octalLiteral
-      - sloppyReassign
-
-      # Performance
-      - equalFold
-      - indexAlloc
-      - rangeExprCopy
-      - appendCombine
-
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
-      - elseif
-      - emptyFallthrough
-      - emptyStringTest
-      - hexLiteral
-      - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - stringXbytes
-      - switchTrue
-      - typeAssertChain
-      - typeSwitchVar
-      - underef
-      - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - yodaStyleExpr
-      - wrapperFunc
-
-      # Opinionated
-      - initClause
-      - nestingReduce
-      - ptrToRefParam
-      - typeUnparen
-      - unnecessaryBlock
-      - paramTypeCombine
-  depguard:
-    # Rules to apply.
-    #
-    # Variables:
-    # - File Variables
-    #   you can still use and exclamation mark ! in front of a variable to say not to use it.
-    #   Example !$test will match any file that is not a go test file.
-    #
-    #   `$all` - matches all go files
-    #   `$test` - matches all go test files
-    #
-    # - Package Variables
-    #
-    #  `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
-    #
-    # Default: Only allow $gostd in all files.
-    rules:
-      # Name of a rule.
-      main:
-        # Used to determine the package matching priority.
-        # There are three different modes: `original`, `strict`, and `lax`.
-        # Default: "original"
-        list-mode: lax
-        # List of file globs that will match this list of settings to compare against.
-        # Default: $all
-        files:
-          - $all
-        # List of allowed packages.
-        #allow:
-        #  - $gostd
-        # Packages that are not allowed where the value is a suggestion.
-        deny:
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package
-  wrapcheck:
-    ignoreSigs:
-      # defaults
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-      # from kyaml's errors package
-      - .WrapPrefixf(
-
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - $all
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+    gocritic:
+      enabled-checks:
+        - argOrder
+        - badCond
+        - caseOrder
+        - codegenComment
+        - commentedOutCode
+        - deprecatedComment
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - exitAfterDefer
+        - flagDeref
+        - flagName
+        - nilValReturn
+        - offBy1
+        - weakCond
+        - octalLiteral
+        - sloppyReassign
+        - equalFold
+        - indexAlloc
+        - rangeExprCopy
+        - appendCombine
+        - assignOp
+        - boolExprSimplify
+        - captLocal
+        - commentFormatting
+        - commentedOutImport
+        - defaultCaseOrder
+        - docStub
+        - elseif
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - methodExprCall
+        - regexpMust
+        - singleCaseSwitch
+        - sloppyLen
+        - stringXbytes
+        - switchTrue
+        - typeAssertChain
+        - typeSwitchVar
+        - underef
+        - unlabelStmt
+        - unlambda
+        - unslice
+        - valSwap
+        - yodaStyleExpr
+        - wrapperFunc
+        - initClause
+        - nestingReduce
+        - ptrToRefParam
+        - typeUnparen
+        - unnecessaryBlock
+        - paramTypeCombine
+    lll:
+      line-length: 120
+    revive:
+      rules:
+        - name: if-return
+          severity: warning
+          disabled: true
+        - name: string-format
+          arguments:
+            - - core.WriteError[1].Message
+              - /^([^A-Z]|$)/
+              - must not start with a capital letter
+            - - fmt.Errorf[0]
+              - /^([^A-Z]|$)/
+              - must not start with a capital letter
+            - - fmt.Errorf[0]
+              - /(^|[^\.!?])$/
+              - must not end in punctuation
+            - - panic
+              - /^[^\n]*$/
+              - must not contain line breaks
+          severity: warning
+          disabled: false
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+        - .WrapPrefixf(
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - _test\.go$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM registry.redhat.io/ubi9/go-toolset:1.24 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/api/v1alpha1/clusterinstance_utils.go
+++ b/api/v1alpha1/clusterinstance_utils.go
@@ -108,7 +108,7 @@ func IndexOfManifestByIdentity(target *ManifestReference, manifestRefs []Manifes
 
 // IsPaused checks if the ClusterInstance has the paused annotation.
 func (ci *ClusterInstance) IsPaused() bool {
-	annotations := ci.ObjectMeta.Annotations
+	annotations := ci.Annotations
 	if annotations == nil {
 		return false
 	}

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   name: clusterinstances.siteconfig.open-cluster-management.io
 spec:

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: clusterinstances.siteconfig.open-cluster-management.io
 spec:
   group: siteconfig.open-cluster-management.io

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.24.0
-
-toolchain go1.24.12
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.64.6"
+VERSION="2.8.0"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then
@@ -41,4 +41,4 @@ fi
 
 export GOCACHE=/tmp/
 export GOLANGCI_LINT_CACHE=/tmp/.cache
-"${golangci_lint}" run --verbose --print-resources-usage --modules-download-mode=vendor --timeout=5m0s
+"${golangci_lint}" run --verbose --modules-download-mode=vendor

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -59,7 +59,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Get the ClusterDeployment CR
 	clusterDeployment := &hivev1.ClusterDeployment{}
-	if err := r.Client.Get(ctx, req.NamespacedName, clusterDeployment); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, clusterDeployment); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("ClusterDeployment not found")
 			return doNotRequeue(), nil
@@ -269,7 +269,7 @@ func (r *ClusterDeploymentReconciler) getClusterInstance(
 	}
 
 	clusterInstance := &v1alpha1.ClusterInstance{}
-	if err := r.Client.Get(ctx, clusterInstanceRef,
+	if err := r.Get(ctx, clusterInstanceRef,
 		clusterInstance); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("ClusterInstance not found", zap.String("name", clusterInstanceRef.String()))
@@ -286,7 +286,7 @@ func (r *ClusterDeploymentReconciler) mapClusterInstanceToCD(
 	obj *v1alpha1.ClusterInstance,
 ) []reconcile.Request {
 	clusterInstance := &v1alpha1.ClusterInstance{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()},
+	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()},
 		clusterInstance); err != nil {
 		return []reconcile.Request{}
 	}

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -153,7 +153,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Get the ClusterInstance CR
 	clusterInstance := &v1alpha1.ClusterInstance{}
-	if err := r.Client.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Error("ClusterInstance not found")
 			return doNotRequeue(), nil
@@ -186,7 +186,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if clusterInstance.Status.Paused != nil {
 		patch := client.MergeFrom(clusterInstance.DeepCopy())
 		clusterInstance.Status.Paused = nil
-		if err := r.Client.Status().Patch(ctx, clusterInstance, patch); err != nil {
+		if err := r.Status().Patch(ctx, clusterInstance, patch); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to clear Paused status, error: %w", err)
 		}
 		return ctrl.Result{Requeue: true}, nil
@@ -200,7 +200,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Pre-empt the reconcile-loop when the ObservedGeneration is the same as the ObjectMeta.Generation
-	if clusterInstance.Status.ObservedGeneration == clusterInstance.ObjectMeta.Generation {
+	if clusterInstance.Status.ObservedGeneration == clusterInstance.Generation {
 		log.Info("ObservedGeneration and ObjectMeta.Generation are the same, pre-empting reconcile")
 		return doNotRequeue(), nil
 	}
@@ -244,7 +244,7 @@ func (r *ClusterInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	log.Info("Finished rendering templates")
 
 	// Only update the ObservedGeneration when all the above processes have been successfully executed
-	if clusterInstance.Status.ObservedGeneration != clusterInstance.ObjectMeta.Generation {
+	if clusterInstance.Status.ObservedGeneration != clusterInstance.Generation {
 		if err := r.updateObservedStatus(ctx, log, clusterInstance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("encountered an error updating observed ClusterInstance status: %w", err)
 		}
@@ -278,25 +278,25 @@ func (r *ClusterInstanceReconciler) updateObservedStatus(
 		patch := client.MergeFrom(clusterInstance.DeepCopy())
 		metav1.SetMetaDataAnnotation(&clusterInstance.ObjectMeta, v1alpha1.LastClusterInstanceSpecAnnotation,
 			string(currentSpecJSON))
-		if err := r.Client.Patch(ctx, clusterInstance, patch); err != nil {
+		if err := r.Patch(ctx, clusterInstance, patch); err != nil {
 			return fmt.Errorf("failed to update %s annotation: %w",
 				v1alpha1.LastClusterInstanceSpecAnnotation, err)
 		}
 
 		// Re-fetch updated ClusterInstance
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance); err != nil {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(clusterInstance), clusterInstance); err != nil {
 			log.Error("Failed to get ClusterInstance", zap.Error(err))
 			return fmt.Errorf("failed to re-fetch ClusterInstance: %w", err)
 		}
 	}
 
-	log.Sugar().Infof("Updating ObservedGeneration to %d", clusterInstance.ObjectMeta.Generation)
+	log.Sugar().Infof("Updating ObservedGeneration to %d", clusterInstance.Generation)
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
-	clusterInstance.Status.ObservedGeneration = clusterInstance.ObjectMeta.Generation
+	clusterInstance.Status.ObservedGeneration = clusterInstance.Generation
 
 	if err := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); err != nil {
 		return fmt.Errorf("failed to patch ClusterInstance status for ObservedGeneration update to %d: %w",
-			clusterInstance.ObjectMeta.Generation, err)
+			clusterInstance.Generation, err)
 	}
 
 	return nil
@@ -335,7 +335,7 @@ func (r *ClusterInstanceReconciler) applyACMBackupLabelToInstallTemplates(
 		}
 
 		cm := &corev1.ConfigMap{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}, cm); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}, cm); err != nil {
 			return fmt.Errorf("failed to get ConfigMap %s/%s: %w", ref.Namespace, ref.Name, err)
 		}
 
@@ -351,7 +351,7 @@ func (r *ClusterInstanceReconciler) applyACMBackupLabelToInstallTemplates(
 		labels[acmBackupLabel] = acmBackupLabelValue
 		cm.SetLabels(labels)
 
-		if err := r.Client.Patch(ctx, cm, patch); err != nil {
+		if err := r.Patch(ctx, cm, patch); err != nil {
 			return fmt.Errorf("failed to patch ConfigMap %s/%s: %w", cm.GetNamespace(), cm.GetName(), err)
 		}
 
@@ -436,7 +436,7 @@ func (r *ClusterInstanceReconciler) handleFinalizer(
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
 	controllerutil.RemoveFinalizer(clusterInstance, clusterInstanceFinalizer)
 
-	if err := r.Client.Patch(ctx, clusterInstance, patch); err != nil {
+	if err := r.Patch(ctx, clusterInstance, patch); err != nil {
 		log.Error("Failed to remove finalizer", zap.Error(err))
 		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer for ClusterInstance %s/%s: %w",
 			clusterInstance.Namespace, clusterInstance.Name, err)
@@ -461,7 +461,7 @@ func (r *ClusterInstanceReconciler) ensureFinalizer(
 	controllerutil.AddFinalizer(clusterInstance, clusterInstanceFinalizer)
 
 	// Persist the finalizer addition
-	if err := r.Client.Patch(ctx, clusterInstance, patch); err != nil {
+	if err := r.Patch(ctx, clusterInstance, patch); err != nil {
 		log.Error("Failed to add finalizer", zap.Error(err))
 		return ctrl.Result{}, fmt.Errorf("failed to add finalizer to ClusterInstance %s/%s: %w",
 			clusterInstance.Namespace, clusterInstance.Name, err)


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The release-2.13 branch uses Go 1.24 (go.mod: `go 1.24.0`, Dockerfile: `ubi9/go-toolset:1.24`).
Upstream `golang.org/x` modules now require Go 1.25 as their minimum version, which causes all
Renovate dependency update PRs to fail CI with:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)
```

This blocks five open PRs, including three security fixes (golang.org/x/crypto, net, sys).
The same issue was already resolved on main in PR #1105 (ACM-33708).

## Changes Made

- Bumped `go.mod` from `go 1.24.0` / `toolchain go1.24.12` to `go 1.25.0`
- Updated Dockerfile builder image from `ubi9/go-toolset:1.24` to `ubi9/go-toolset:1.25`
- Upgraded golangci-lint from v1.64.6 to v2.8.0 with v2 config format for Go 1.25 compatibility
- Fixed embedded field selector lint warnings (`r.Client.Get` → `r.Get`, `ci.ObjectMeta.Annotations` → `ci.Annotations`, etc.) surfaced by the new linter version
- Regenerated CRD manifests (controller-gen version annotation bump v0.16.2 → v0.20.0)

## Testing

- `make ci-job` passes (lint, vet, fmt, unit tests, shellcheck, bashate)
- All 402 unit tests pass with 0 failures
- golangci-lint v2.8.0 reports 0 issues
- Code coverage for new code: N/A — no new code, only toolchain and lint fixes

## JIRA

https://issues.redhat.com/browse/ACM-34659

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Investigation of failing PRs, code edits for lint fixes, commit and PR message drafting
- **Level**: Co-development
- **Human Review**: All changes reviewed and validated by the author

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin