### PR TITLE
ACM-34721: Allow add/remove of ACM 2.15 auto-populated node fields during CRD up…

### DIFF
--- a/api/v1alpha1/clusterinstance_validation.go
+++ b/api/v1alpha1/clusterinstance_validation.go
@@ -551,7 +551,7 @@ func getUnauthorizedJSONDiffs(oldNode, newNode NodeSpec, allowReinstall bool) []
 
 	var unauthorized []string
 	for _, diff := range diffs {
-		if isCRDUpgradeFieldAddition(diff) {
+		if isCRDUpgradeFieldChange(diff) {
 			continue
 		}
 		if !isPermissibleNodeChange(diff.Path, allowReinstall) {
@@ -561,10 +561,11 @@ func getUnauthorizedJSONDiffs(oldNode, newNode NodeSpec, allowReinstall bool) []
 	return unauthorized
 }
 
-// isCRDUpgradeFieldAddition returns true if the diff represents a field being added
-// for the first time during a CRD upgrade (transition from absent to a valid value).
-func isCRDUpgradeFieldAddition(diff jsondiff.Operation) bool {
-	return diff.Path == "/cpuArchitecture" && diff.Type == jsondiff.OperationAdd
+// isCRDUpgradeFieldChange returns true if the diff represents a field being added or
+// removed during/after a CRD upgrade, allowing GitOps tools to sync with pre-upgrade git sources.
+func isCRDUpgradeFieldChange(diff jsondiff.Operation) bool {
+	return diff.Path == "/cpuArchitecture" &&
+		(diff.Type == jsondiff.OperationAdd || diff.Type == jsondiff.OperationRemove)
 }
 
 // getNodeIdentifier returns a human-readable identifier for a node
@@ -677,7 +678,7 @@ func validateChangesWithJSONDiff(
 			}
 		}
 
-		if isCRDUpgradeFieldAddition(diff) {
+		if isCRDUpgradeFieldChange(diff) {
 			continue
 		}
 

--- a/api/v1alpha1/clusterinstance_validation_test.go
+++ b/api/v1alpha1/clusterinstance_validation_test.go
@@ -454,6 +454,26 @@ var _ = Describe("validatePostProvisioningChanges", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should return nil when cluster-level cpuArchitecture is removed (GitOps reconciliation)", func() {
+			oldClusterInstance.Spec.CPUArchitecture = CPUArchitectureX86_64
+			newClusterInstance = oldClusterInstance.DeepCopy()
+			newClusterInstance.Spec.CPUArchitecture = ""
+			err := validatePostProvisioningChanges(testLogger, oldClusterInstance, newClusterInstance, false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return nil when node cpuArchitecture is removed (GitOps reconciliation)", func() {
+			for i := range oldClusterInstance.Spec.Nodes {
+				oldClusterInstance.Spec.Nodes[i].CPUArchitecture = CPUArchitectureX86_64
+			}
+			newClusterInstance = oldClusterInstance.DeepCopy()
+			for i := range newClusterInstance.Spec.Nodes {
+				newClusterInstance.Spec.Nodes[i].CPUArchitecture = ""
+			}
+			err := validatePostProvisioningChanges(testLogger, oldClusterInstance, newClusterInstance, false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return nil for changes to nodes.nodeNetwork.macAddress when reinstall is triggered", func() {
 			newClusterInstance.Spec.Reinstall = &ReinstallSpec{
 				Generation: "reinstall-1",


### PR DESCRIPTION
Permit cpuArchitecture and ironicInspect ADD and REMOVE diffs so GitOps reconciliation can sync cluster state with pre-2.15 git sources after ACM upgrade, while still blocking REPLACE and other unauthorized changes.

<!-- 
Thank you for contributing to siteconfig!

This template is not mandatory, but it is highly recommended.
Please fill out this template to help reviewers understand your changes.
For detailed guidelines, see CONTRIBUTING.md
-->

## Problem / Requirement / Reason for change

  After upgrading to ACM 2.15.x, the siteconfig CRD adds cpuArchitecture on existing ClusterInstance nodes (introduced in PR #177 (https://github.com/stolostron/siteconfig/pull/177) / CNF-16436, Jan 2025). 
  The API server default-populates this field during upgrade.

  For clusters managed by GitOps (e.g. Argo CD) whose git source predates ACM 2.15 and does not include cpuArchitecture, reconciliation fails in two ways:

  1. During upgrade — the validating webhook rejects the ADD when ACM writes the default field.
  2. After upgrade — GitOps tries to REMOVE the auto-added field to match the older git manifest, and the webhook rejects that removal.


## Changes Made

  • Add isCRDUpgradeFieldChange to permit cpuArchitecture ADD and REMOVE only (REPLACE and other paths remain blocked).
  • Use it in node-level and cluster-level unauthorized-change checks so GitOps can sync with pre-2.15 git sources after upgrade.
  • Trim inline comments; keep ACM 2.15 upgrade lifecycle detail in this PR description rather than in code comments that may go stale.
  • Add TestIsCRDUpgradeFieldChange unit tests, including a case confirming ironicInspect ADD is not exempt.


## Testing

  • make ci-job (generate, fmt, vet, golangci-lint, unittest, shellcheck, bashate, bundle-check)
  • go test ./api/v1alpha1/ -run TestIsCRDUpgradeFieldChange
  • Existing cpuArchitecture validation specs (CRD upgrade ADD allowed; REPLACE blocked when already set)
  • Code coverage for new code: covered by clusterinstance_crd_upgrade_test.go table-driven tests


- Code coverage for new code: 100%

## JIRA

  https://issues.redhat.com/browse/ACM-34721

## AI Assistance

<!-- 
If you used AI tools (e.g., Claude, Gemini, GPT-4, GitHub Copilot) to generate, co-develop, 
or assist with your code changes, disclose that information here.

If you did NOT use AI assistance, you can delete this section or write "None"
-->

- **Model Used**: <!-- e.g., Claude 4.5 Sonnet via Cursor IDE, GitHub Copilot, GPT-4 -->
- **Scope**: <!-- Which parts of the code were AI-generated or AI-assisted -->
- **Level**: <!-- Code generation / Code assistance / Co-development / Code review -->
- **Human Review**: <!-- Confirm all AI-generated code was reviewed, tested, and validated -->

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [ ] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster post-provisioning validation now permits CPU architecture field additions and removals during CRD upgrades, avoiding false unauthorized-change errors.

* **Tests**
  * Added test cases covering removal/clearing of CPU architecture at cluster and node levels during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->