### PR TITLE
Experiment: Test Red Hat Hardened core-runtime Image (release-acm-212)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on \
 
 #####################################################################################################
 # Build the controller image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
 
 ENV SUMMARY="SiteConfig Operator is a template-driven cluster provisioning solution" \
     DESCRIPTION="SiteConfig operator as a template-driven cluster provisioning solution, which allows you to \


### PR DESCRIPTION
## Purpose
This is an **experimental PR** against the inactive **release-acm-212** application to test Red Hat's hardened images.

## Changes
- Switch runtime base image from `registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705`
- To: `registry.access.redhat.com/hi/core-runtime:latest-openssl-fips` (Red Hat Hardened Image with FIPS OpenSSL)
- Modified file: `Dockerfile` (line 26 only)

## Details
**Component:** siteconfig  
**Target Release:** release-2.12 (inactive)  
**Hardened Image:** core-runtime with FIPS-enabled OpenSSL

### Why This Component?
- Clean Dockerfile - only copies binaries
- No package manager usage (no microdnf/dnf/yum)
- Good candidate for hardened image compatibility testing

### Diff
```diff
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
```

## Testing
- Target: Inactive release-acm-212 Konflux application
- Goal: Validate Konflux build success with hardened images
- Focus: FIPS compliance, runtime compatibility
- Reference: https://images.redhat.com/

## Notes
- This is for experimentation only
- Not intended for merge to active releases
- Monitoring Konflux build pipeline for compatibility
- Part of batch testing across multiple ACM 2.12 components
- Only changes the runtime base image, no other modifications

/hold
/cc @gparvin
