### PR TITLE
ACM-36263: Add NetworkPolicy for siteconfig-controller-manager

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - manager.yaml
+- siteconfig-controller-networkpolicy.yaml
 
 images:
 - name: controller

--- a/config/manager/siteconfig-controller-networkpolicy.yaml
+++ b/config/manager/siteconfig-controller-networkpolicy.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: siteconfig-controller-manager
+  namespace: system
+  labels:
+    app.kubernetes.io/name: siteconfig-controller
+    app.kubernetes.io/component: siteconfig
+    control-plane: siteconfig-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: siteconfig-controller
+      app.kubernetes.io/component: siteconfig
+      control-plane: siteconfig-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic (operator components, leader election, etc.)
+    - from:
+        - podSelector: {}
+
+    # Webhook port (9443) — kube-apiserver calls admission webhooks from host network
+    - ports:
+        - protocol: TCP
+          port: 9443
+
+    # Health probe port (8081) — kubelet liveness/readiness probes from host network
+    - ports:
+        - protocol: TCP
+          port: 8081
+
+    # Metrics port (8443) — OpenShift monitoring / Prometheus scraping
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8443
+
+  egress:
+    # DNS — both UDP and TCP (TCP needed for responses > 512 bytes)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+
+    # Hub Kubernetes API server — all controller-runtime RBAC operations
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+
+    # Spoke cluster API servers — reinstall reimport via kubeconfig secrets (dynamic IPs)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 6443
+
+    # External HTTPS — OIDC/OAuth auth plugin for cloud provider authentication
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION

<!-- 
Thank you for contributing to siteconfig!

This template is not mandatory, but it is highly recommended.
Please fill out this template to help reviewers understand your changes.
For detailed guidelines, see CONTRIBUTING.md
-->

## Problem / Requirement / Reason for change
The change is to add network policies for siteconfig operator. 

<!-- 
Clearly describe the problem being solved or feature being added.
What is the current behavior? Why does it need to change?
-->

## Changes Made

<!-- 
Summarize the key changes in your implementation.
Use bullet points for clarity.
-->

- Adds a network policy for siteconfig-operator in the ACM namespace
- Restrict ingress/egress traffic to only what the operator requires: webhook (9443), health probes (8081), metrics from monitoring (8443), hub API (6443), spoke cluster APIs (6443), DNS (5353), and external HTTPS for auth plugins (443).


## Testing

<!-- 
Describe how you tested the changes.
Include test cases, manual testing steps, or validation performed.
For documentation-only changes, you may write "N/A - Documentation only"
-->

- Code coverage for new code: ___%

## JIRA
https://issues.redhat.com/browse/ACM-36263
<!-- 
Link to the JIRA issue (if applicable).
Format: https://issues.redhat.com/browse/ACM-36263
Or write "NO-ISSUE" if this is a minor change (docs, typos, minor up-versioning)
-->

## AI Assistance
Used multiple tools for researching, testing and writing code including claude code with opus-4.6 and sonnet-5, cursor with gpt-5.4. 
<!-- 
If you used AI tools (e.g., Claude, Gemini, GPT-4, GitHub Copilot) to generate, co-develop, 
or assist with your code changes, disclose that information here.

If you did NOT use AI assistance, you can delete this section or write "None"
-->

- **Model Used**: Opus-4.6, Sonnet-5, GPT-5.4
- **Scope**: <!-- Which parts of the code were AI-generated or AI-assisted -->
- **Level**: <!-- Code generation / Code assistance / Co-development / Code review -->
- **Human Review**: <!-- Confirm all AI-generated code was reviewed, tested, and validated -->

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [ ] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added network traffic restrictions for the SiteConfig controller.
  * Limited inbound access to required webhook, health probe, and monitoring connections.
  * Restricted outbound access to DNS, Kubernetes APIs, and approved HTTPS destinations while blocking metadata service access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->