### PR TITLE
ACM-36262: Enforce cluster TLS security profile on webhook and metrics servers

### DIFF
--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1226,6 +1226,14 @@ spec:
           verbs:
           - create
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - extensions.hive.openshift.io
           resources:
           - agentclusterinstalls

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -145,7 +146,10 @@ func run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir, probeAddr s
 		return fmt.Errorf("failed to create pre-manager client: %w", err)
 	}
 
-	tlsProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, preMgrClient)
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer fetchCancel()
+
+	tlsProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(fetchCtx, preMgrClient)
 	if err != nil {
 		return fmt.Errorf("failed to fetch cluster TLS security profile: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,12 +109,23 @@ func main() {
 
 	ctrl.SetLogger(ctrlruntimezap.New(ctrlruntimezap.UseFlagOptions(&opts)))
 
+	if err := run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir,
+		probeAddr, enableLeaderElection, enableHTTP2); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir, probeAddr string,
+	enableLeaderElection, enableHTTP2 bool,
+) error {
 	siteconfigLogger := zap.Must(zap.NewDevelopment())
 	defer siteconfigLogger.Sync() //nolint:errcheck
 
 	setupLog := siteconfigLogger.Named("SiteConfigSetup")
 
 	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -131,14 +142,12 @@ func main() {
 
 	preMgrClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		setupLog.Error("failed to create pre-manager client", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to create pre-manager client: %w", err)
 	}
 
 	tlsProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, preMgrClient)
 	if err != nil {
-		setupLog.Error("failed to fetch cluster TLS security profile", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to fetch cluster TLS security profile: %w", err)
 	}
 
 	profileTLSOpt, unsupportedCiphers := openshifttls.NewTLSConfigFromProfile(tlsProfileSpec)
@@ -180,8 +189,7 @@ func main() {
 		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
-		setupLog.Error("Unable to start manager", zap.Error(err))
-		os.Exit(1) // nolint:gocritic
+		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
 	if err := (&openshifttls.SecurityProfileWatcher{
@@ -192,38 +200,30 @@ func main() {
 			cancel()
 		},
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error("unable to create controller",
-			zap.String("controller", "SecurityProfileWatcher"),
-			zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to create controller SecurityProfileWatcher: %w", err)
 	}
 
 	// Check that the SiteConfig namespace value is defined
 	siteConfigNamespace := getSiteConfigNamespace(setupLog)
 	if siteConfigNamespace == "" {
-		setupLog.Error("Unable to retrieve the SiteConfig Operator namespace")
-		os.Exit(1)
+		return fmt.Errorf("unable to retrieve the SiteConfig Operator namespace")
 	}
 
 	// Create an uncached client to initialize ConfigMaps
 	tmpClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		setupLog.Error("Failed to create temporary client", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to create temporary client: %w", err)
 	}
 
 	// Initialize the default install template ConfigMaps
 	if err := initConfigMapTemplates(context.TODO(), tmpClient, siteConfigNamespace, setupLog); err != nil {
-		setupLog.Error("Unable to initialize the default reference installation template ConfigMaps",
-			zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to initialize the default reference installation template ConfigMaps: %w", err)
 	}
 
 	// Initialize the SiteConfig Operator configuration store
 	sharedConfigStore, err := createConfigurationStore(context.TODO(), tmpClient, siteConfigNamespace, setupLog)
 	if err != nil {
-		setupLog.Error("Failed to initialize the ConfigurationStore for the SiteConfig Operator")
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize the ConfigurationStore for the SiteConfig Operator: %w", err)
 	}
 
 	// Create configuration monitor controller to track SiteConfig Operator configuration change(s)
@@ -234,10 +234,7 @@ func main() {
 		Namespace:   siteConfigNamespace,
 		ConfigStore: sharedConfigStore,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error("Unable to create controller",
-			zap.String("controller", "ConfigurationMonitor"),
-			zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to create controller ConfigurationMonitor: %w", err)
 	}
 
 	// Create DeletionHandler for graceful deletion of rendered objects
@@ -267,11 +264,7 @@ func main() {
 		DeletionHandler:  deletionHandler,
 		ReinstallHandler: reinstallHandler,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error("Unable to create controller",
-			zap.String("controller", "ClusterInstance"),
-			zap.Error(err),
-		)
-		os.Exit(1)
+		return fmt.Errorf("unable to create controller ClusterInstance: %w", err)
 	}
 
 	// Create ClusterDeployment controller for monitoring cluster provisioning progress
@@ -280,34 +273,27 @@ func main() {
 		Log:    siteconfigLogger.Named("ClusterDeploymentReconciler"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error("Unable to create controller",
-			zap.String("controller", "ClusterDeploymentReconciler"),
-			zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to create controller ClusterDeploymentReconciler: %w", err)
 	}
 
 	// Create ClusterInstance validating admission webhook
 	if err = (&v1alpha1.ClusterInstance{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error("Unable to create webhook", zap.String("webhook", "ClusterInstance"), zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to create webhook ClusterInstance: %w", err)
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error("Unable to set up health check", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to set up health check: %w", err)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error("Unable to set up ready check", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
 	setupLog.Info("Starting SiteConfig manager")
-	defer cancel()
 	if err := mgr.Start(ctx); err != nil {
-		setupLog.Error("Encountered an error starting SiteConfig manager", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("encountered an error starting SiteConfig manager: %w", err)
 	}
+	return nil
 }
 
 // getSiteConfigNamespace retrieves the namespace where the SiteConfig Operator is running.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -230,61 +230,9 @@ func run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir, probeAddr s
 		return fmt.Errorf("failed to initialize the ConfigurationStore for the SiteConfig Operator: %w", err)
 	}
 
-	// Create configuration monitor controller to track SiteConfig Operator configuration change(s)
-	if err := (&controller.ConfigurationMonitor{
-		Client:      mgr.GetClient(),
-		Log:         siteconfigLogger.Named("ConfigurationMonitor"),
-		Scheme:      mgr.GetScheme(),
-		Namespace:   siteConfigNamespace,
-		ConfigStore: sharedConfigStore,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller ConfigurationMonitor: %w", err)
+	if err := setupControllers(mgr, siteconfigLogger, sharedConfigStore, siteConfigNamespace); err != nil {
+		return err
 	}
-
-	// Create DeletionHandler for graceful deletion of rendered objects
-	deletionHandler := &deletion.DeletionHandler{
-		Client: mgr.GetClient(),
-		Logger: siteconfigLogger.Named("DeletionHandler"),
-	}
-
-	// Create ReinstallHandler
-	reinstallHandler := &reinstall.ReinstallHandler{
-		Client:             mgr.GetClient(),
-		Logger:             siteconfigLogger.Named("ReinstallHandler"),
-		ConfigStore:        sharedConfigStore,
-		DeletionHandler:    deletionHandler,
-		SpokeClientFactory: &reinstall.DefaultSpokeClientFactory{},
-	}
-
-	// Create ClusterInstance controller for reconciling ClusterInstance CRs
-	clusterInstanceLogger := siteconfigLogger.Named("ClusterInstanceController")
-	if err := (&controller.ClusterInstanceReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Recorder:         mgr.GetEventRecorderFor("ClusterInstanceController"),
-		Log:              clusterInstanceLogger,
-		TmplEngine:       ci.NewTemplateEngine(),
-		ConfigStore:      sharedConfigStore,
-		DeletionHandler:  deletionHandler,
-		ReinstallHandler: reinstallHandler,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller ClusterInstance: %w", err)
-	}
-
-	// Create ClusterDeployment controller for monitoring cluster provisioning progress
-	if err := (&controller.ClusterDeploymentReconciler{
-		Client: mgr.GetClient(),
-		Log:    siteconfigLogger.Named("ClusterDeploymentReconciler"),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller ClusterDeploymentReconciler: %w", err)
-	}
-
-	// Create ClusterInstance validating admission webhook
-	if err = (&v1alpha1.ClusterInstance{}).SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create webhook ClusterInstance: %w", err)
-	}
-	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check: %w", err)
@@ -297,6 +245,69 @@ func run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir, probeAddr s
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("encountered an error starting SiteConfig manager: %w", err)
 	}
+	return nil
+}
+
+func setupControllers(
+	mgr ctrl.Manager, logger *zap.Logger,
+	configStore *configuration.ConfigurationStore, namespace string,
+) error {
+	// Create configuration monitor controller to track SiteConfig Operator configuration change(s)
+	if err := (&controller.ConfigurationMonitor{
+		Client:      mgr.GetClient(),
+		Log:         logger.Named("ConfigurationMonitor"),
+		Scheme:      mgr.GetScheme(),
+		Namespace:   namespace,
+		ConfigStore: configStore,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller ConfigurationMonitor: %w", err)
+	}
+
+	// Create DeletionHandler for graceful deletion of rendered objects
+	deletionHandler := &deletion.DeletionHandler{
+		Client: mgr.GetClient(),
+		Logger: logger.Named("DeletionHandler"),
+	}
+
+	// Create ReinstallHandler
+	reinstallHandler := &reinstall.ReinstallHandler{
+		Client:             mgr.GetClient(),
+		Logger:             logger.Named("ReinstallHandler"),
+		ConfigStore:        configStore,
+		DeletionHandler:    deletionHandler,
+		SpokeClientFactory: &reinstall.DefaultSpokeClientFactory{},
+	}
+
+	// Create ClusterInstance controller for reconciling ClusterInstance CRs
+	clusterInstanceLogger := logger.Named("ClusterInstanceController")
+	if err := (&controller.ClusterInstanceReconciler{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("ClusterInstanceController"),
+		Log:              clusterInstanceLogger,
+		TmplEngine:       ci.NewTemplateEngine(),
+		ConfigStore:      configStore,
+		DeletionHandler:  deletionHandler,
+		ReinstallHandler: reinstallHandler,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller ClusterInstance: %w", err)
+	}
+
+	// Create ClusterDeployment controller for monitoring cluster provisioning progress
+	if err := (&controller.ClusterDeploymentReconciler{
+		Client: mgr.GetClient(),
+		Log:    logger.Named("ClusterDeploymentReconciler"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller ClusterDeploymentReconciler: %w", err)
+	}
+
+	// Create ClusterInstance validating admission webhook
+	if err := (&v1alpha1.ClusterInstance{}).SetupWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create webhook ClusterInstance: %w", err)
+	}
+	//+kubebuilder:scaffold:builder
+
 	return nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,7 +45,9 @@ import (
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-service/api/v1beta1"
+	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 
@@ -76,6 +78,7 @@ func init() {
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.Install(scheme))
 	utilruntime.Must(bmh_v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -111,6 +114,8 @@ func main() {
 
 	setupLog := siteconfigLogger.Named("SiteConfigSetup")
 
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
@@ -122,12 +127,29 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	tlsOpts := []func(*tls.Config){}
+	cfg := ctrl.GetConfigOrDie()
+
+	preMgrClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error("failed to create pre-manager client", zap.Error(err))
+		os.Exit(1)
+	}
+
+	tlsProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, preMgrClient)
+	if err != nil {
+		setupLog.Error("failed to fetch cluster TLS security profile", zap.Error(err))
+		os.Exit(1)
+	}
+
+	profileTLSOpt, unsupportedCiphers := openshifttls.NewTLSConfigFromProfile(tlsProfileSpec)
+	if len(unsupportedCiphers) > 0 {
+		setupLog.Warn("TLS profile contains unrecognised cipher suites", zap.Strings("ciphers", unsupportedCiphers))
+	}
+
+	tlsOpts := []func(*tls.Config){profileTLSOpt}
 	if !enableHTTP2 {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
-
-	cfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -160,6 +182,20 @@ func main() {
 	if err != nil {
 		setupLog.Error("Unable to start manager", zap.Error(err))
 		os.Exit(1) // nolint:gocritic
+	}
+
+	if err := (&openshifttls.SecurityProfileWatcher{
+		Client:                mgr.GetClient(),
+		InitialTLSProfileSpec: tlsProfileSpec,
+		OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
+			setupLog.Info("cluster TLS security profile changed, restarting to apply new settings")
+			cancel()
+		},
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error("unable to create controller",
+			zap.String("controller", "SecurityProfileWatcher"),
+			zap.Error(err))
+		os.Exit(1)
 	}
 
 	// Check that the SiteConfig namespace value is defined
@@ -267,7 +303,8 @@ func main() {
 	}
 
 	setupLog.Info("Starting SiteConfig manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	defer cancel()
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error("Encountered an error starting SiteConfig manager", zap.Error(err))
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -216,12 +216,12 @@ func run(metricsAddr, metricsCertDir, clusterInstanceWebhookCertDir, probeAddr s
 	}
 
 	// Initialize the default install template ConfigMaps
-	if err := initConfigMapTemplates(context.TODO(), tmpClient, siteConfigNamespace, setupLog); err != nil {
+	if err := initConfigMapTemplates(ctx, tmpClient, siteConfigNamespace, setupLog); err != nil {
 		return fmt.Errorf("unable to initialize the default reference installation template ConfigMaps: %w", err)
 	}
 
 	// Initialize the SiteConfig Operator configuration store
-	sharedConfigStore, err := createConfigurationStore(context.TODO(), tmpClient, siteConfigNamespace, setupLog)
+	sharedConfigStore, err := createConfigurationStore(ctx, tmpClient, siteConfigNamespace, setupLog)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the ConfigurationStore for the SiteConfig Operator: %w", err)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions.hive.openshift.io
   resources:
   - agentclusterinstalls

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 )
 
 require (
-	github.com/openshift/api v0.0.0-20260304122341-cf5d8996109f // indirect
+	github.com/openshift/api v0.0.0-20260304122341-cf5d8996109f
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/assisted-service/models v0.0.0 // indirect
 )
@@ -24,12 +24,13 @@ require (
 require (
 	github.com/go-task/slim-sprig v2.20.0+incompatible
 	github.com/metal3-io/baremetal-operator/apis v0.12.4
+	github.com/openshift/controller-runtime-common v0.0.0-20260305203102-d1c60045a455
 	github.com/stretchr/testify v1.11.1
 	github.com/wI2L/jsondiff v0.7.1
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
+	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	open-cluster-management.io/api v1.2.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -96,6 +97,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
+	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -273,10 +273,14 @@ github.com/openshift/assisted-service/api v0.0.0-20251026193953-3266b6d73526 h1:
 github.com/openshift/assisted-service/api v0.0.0-20251026193953-3266b6d73526/go.mod h1:wA7MaLcf/KoUl7fhB1bHBdhRBLjWPih90sHpxOV6ZLE=
 github.com/openshift/assisted-service/models v0.0.0-20251026193953-3266b6d73526 h1:q2kwkDj0ASPDzKtkBpemCXzHoO/VtVrVH+fkg7k72/M=
 github.com/openshift/assisted-service/models v0.0.0-20251026193953-3266b6d73526/go.mod h1:5EkIueBSaLnt64HR8drgSewdm+GeuE7W5mr9pa2JXXk=
+github.com/openshift/controller-runtime-common v0.0.0-20260305203102-d1c60045a455 h1:ZpquGa7pP0vz1Mv0Fo8ATOXHQuniVy77+Z7aMlCNKZs=
+github.com/openshift/controller-runtime-common v0.0.0-20260305203102-d1c60045a455/go.mod h1:59nLF3/IfhAtoQZfUzlCyidTAdlVT6KiVeTicUi2wuA=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20251117181851-acea5e9196a2 h1:xxJHYC6iqSuIXxAhGreMPihNYpPREwskYfn+n1t0bf4=
 github.com/openshift/hive/apis v0.0.0-20251117181851-acea5e9196a2/go.mod h1:B8r0x5pxVdoVmZNIiiTIonvarlstfasBleqXqpw2nP8=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 h1:9Pe6iVOMjt9CdA/vaKBNUSoEIjIe1po5Ha3ABRYXLJI=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -563,8 +567,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
-k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKWdRm+BC+xt33FOY=
+k8s.io/utils v0.0.0-20260108192941-914a6e750570/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 open-cluster-management.io/api v1.2.0 h1:+yeQgJiErrur5S4s205UM37EcZ2XbC9pFSm0xgV5/hU=
 open-cluster-management.io/api v1.2.0/go.mod h1:YcmA6SpGEekIMxdoeVIIyOaBhMA6ImWRLXP4g8n8T+4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=

--- a/internal/controller/clusterinstance_controller.go
+++ b/internal/controller/clusterinstance_controller.go
@@ -140,6 +140,7 @@ func requeueForDeletion() ctrl.Result {
 //+kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;create;update;patch;delete
 //+kubebuilder:rbac:groups=hypershift.openshift.io,resources=nodepools,verbs=get;create;update;patch;delete
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/vendor/github.com/openshift/controller-runtime-common/LICENSE
+++ b/vendor/github.com/openshift/controller-runtime-common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecurityProfileWatcher watches the APIServer object for TLS profile changes
+// and triggers a graceful shutdown when the profile changes.
+type SecurityProfileWatcher struct {
+	client.Client
+
+	// InitialTLSProfileSpec is the TLS profile spec that was configured when the operator started.
+	InitialTLSProfileSpec configv1.TLSProfileSpec
+
+	// OnProfileChange is a function that will be called when the TLS profile changes.
+	// It receives the reconcile context, old and new TLS profile specs.
+	// This allows the caller to make decisions based on the actual profile changes.
+	//
+	// The most common use case for this callback is
+	// to trigger a graceful shutdown of the operator
+	// to make it pick up the new configuration.
+	//
+	// Example:
+	//
+	// 	// Create a context that can be cancelled when there is a need to shut down the manager.
+	//  ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	//  defer cancel()
+	//
+	//  watcher := &SecurityProfileWatcher{
+	// 	  OnProfileChange: func(ctx context.Context, old, new configv1.TLSProfileSpec) {
+	//      logger.Infof("TLS profile has changed, initiating a shutdown to reload it. %q: %+v, %q: %+v",
+	//        "old profile", old,
+	//        "new profile", new,
+	//      )
+	//      // Cancel the outer context to trigger a graceful shutdown of the manager.
+	//      cancel()
+	//    },
+	//  }
+	OnProfileChange func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec configv1.TLSProfileSpec)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecurityProfileWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("tlssecurityprofilewatcher").
+		For(&configv1.APIServer{}, builder.WithPredicates(
+			predicate.Funcs{
+				// Only watch the "cluster" APIServer object.
+				CreateFunc: func(e event.CreateEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return e.ObjectNew.GetName() == APIServerName
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+			},
+		)).
+		// Override the default log constructor as it makes the logs very chatty.
+		WithLogConstructor(func(_ *reconcile.Request) logr.Logger {
+			return mgr.GetLogger().WithValues(
+				"controller", "tlssecurityprofilewatcher",
+			)
+		}).
+		Complete(r); err != nil {
+		return fmt.Errorf("could not set up controller for TLS security profile watcher: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile watches for changes to the APIServer TLS profile and triggers a shutdown
+// when the profile changes from the initial configuration.
+func (r *SecurityProfileWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx, "name", req.Name)
+
+	logger.V(1).Info("Reconciling APIServer TLS profile")
+	defer logger.V(1).Info("Finished reconciling APIServer TLS profile")
+
+	// Fetch the APIServer object.
+	apiServer := &configv1.APIServer{}
+	if err := r.Get(ctx, req.NamespacedName, apiServer); err != nil {
+		if apierrors.IsNotFound(err) {
+			// If the APIServer object is not found, we don't need to do anything.
+			// This could happen if the object was deleted.
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Get the current TLS profile spec.
+	currentTLSProfileSpec, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get TLS profile from APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Compare the current TLS profile spec with the initial one.
+	if tlsProfileChanged := !reflect.DeepEqual(r.InitialTLSProfileSpec, currentTLSProfileSpec); tlsProfileChanged {
+		// TLS profile has changed, invoke the callback if it is set.
+		if r.OnProfileChange != nil {
+			r.OnProfileChange(ctx, r.InitialTLSProfileSpec, currentTLSProfileSpec)
+		}
+
+		// Persist the new profile for future change detection.
+		r.InitialTLSProfileSpec = currentTLSProfileSpec
+	}
+
+	// No need to requeue, as the callback will handle further actions.
+	return ctrl.Result{}, nil
+}

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tls provides utilities for working with OpenShift TLS profiles.
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// APIServerName is the name of the APIServer resource in the cluster.
+	APIServerName = "cluster"
+)
+
+var (
+	// ErrCustomProfileNil is returned when a custom TLS profile is specified but the Custom field is nil.
+	ErrCustomProfileNil = errors.New("custom TLS profile specified but Custom field is nil")
+
+	// DefaultTLSCiphers are the default TLS ciphers for API servers.
+	DefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers //nolint:gochecknoglobals
+	// DefaultMinTLSVersion is the default minimum TLS version for API servers.
+	DefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion //nolint:gochecknoglobals
+)
+
+// FetchAPIServerTLSProfile fetches the TLS profile spec configured in APIServer.
+// If no profile is configured, the default profile is returned.
+func FetchAPIServerTLSProfile(ctx context.Context, k8sClient client.Client) (configv1.TLSProfileSpec, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+
+	if err := k8sClient.Get(ctx, key, apiServer); err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+	}
+
+	profile, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get TLS profile from APIServer %q: %w", key.String(), err)
+	}
+
+	return profile, nil
+}
+
+// GetTLSProfileSpec returns TLSProfileSpec for the given profile.
+// If no profile is configured, the default profile is returned.
+func GetTLSProfileSpec(profile *configv1.TLSSecurityProfile) (configv1.TLSProfileSpec, error) {
+	// Define the default profile (at the time of writing, this is the intermediate profile).
+	defaultProfile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	// If the profile is nil or the type is empty, return the default profile.
+	if profile == nil || profile.Type == "" {
+		return defaultProfile, nil
+	}
+
+	// Get the profile type.
+	profileType := profile.Type
+
+	// If the profile type is not custom, return the profile from the map.
+	if profileType != configv1.TLSProfileCustomType {
+		if tlsConfig, ok := configv1.TLSProfiles[profileType]; ok {
+			return *tlsConfig, nil
+		}
+
+		// If the profile type is not found, return the default profile.
+		return defaultProfile, nil
+	}
+
+	if profile.Custom == nil {
+		// If the custom profile is nil, return an error.
+		return configv1.TLSProfileSpec{}, ErrCustomProfileNil
+	}
+
+	// Return the custom profile spec.
+	return profile.Custom.TLSProfileSpec, nil
+}
+
+// NewTLSConfigFromProfile returns a function that configures a tls.Config based on the provided TLSProfileSpec,
+// along with any cipher names from the profile that are not supported by the library-go crypto package.
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Note: CipherSuites are only set when MinVersion is below TLS 1.3, as Go's TLS 1.3 implementation
+// does not allow configuring cipher suites - all TLS 1.3 ciphers are always enabled.
+// See: https://github.com/golang/go/issues/29349
+func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*tls.Config), unsupportedCiphers []string) {
+	minVersion := libgocrypto.TLSVersionOrDie(string(profile.MinTLSVersion))
+	cipherSuites, unsupportedCiphers := cipherCodes(profile.Ciphers)
+
+	return func(tlsConf *tls.Config) {
+		tlsConf.MinVersion = minVersion
+		// TODO: add curve preferences from profile once https://github.com/openshift/api/pull/2583 merges.
+		// tlsConf.CurvePreferences <<<<<< profile.Curves
+
+		// TLS 1.3 cipher suites are not configurable in Go (https://github.com/golang/go/issues/29349), so only set CipherSuites accordingly.
+		// TODO: revisit this once we get an answer on the best way to handle this here:
+		// https://docs.google.com/document/d/1cMc9E8psHfnoK06ntR8kHSWB8d3rMtmldhnmM4nImjs/edit?disco=AAABu_nPcYg
+		if minVersion != tls.VersionTLS13 {
+			tlsConf.CipherSuites = cipherSuites
+		}
+	}, unsupportedCiphers
+}
+
+// cipherCode returns the TLS cipher code for an OpenSSL or IANA cipher name.
+// Returns 0 if the cipher is not supported.
+func cipherCode(cipher string) uint16 {
+	// First try as IANA name directly.
+	if code, err := libgocrypto.CipherSuite(cipher); err == nil {
+		return code
+	}
+
+	// Try converting from OpenSSL name to IANA name.
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites([]string{cipher})
+	if len(ianaCiphers) == 1 {
+		if code, err := libgocrypto.CipherSuite(ianaCiphers[0]); err == nil {
+			return code
+		}
+	}
+
+	// Return 0 if the cipher is not supported.
+	return 0
+}
+
+// cipherCodes converts a list of cipher names (OpenSSL or IANA format) to their uint16 codes.
+// Returns the converted codes and a list of any unsupported cipher names.
+func cipherCodes(ciphers []string) (codes []uint16, unsupportedCiphers []string) {
+	for _, cipher := range ciphers {
+		code := cipherCode(cipher)
+		if code == 0 {
+			unsupportedCiphers = append(unsupportedCiphers, cipher)
+			continue
+		}
+
+		codes = append(codes, code)
+	}
+
+	return codes, unsupportedCiphers
+}

--- a/vendor/github.com/openshift/library-go/LICENSE
+++ b/vendor/github.com/openshift/library-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stlaz
+approvers:
+  - stlaz

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -1,0 +1,1239 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	mathrand "math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/util/cert"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TLS versions that are known to golang. Go 1.13 adds support for
+// TLS 1.3 that's opt-out with a build flag.
+var versions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLS versions that are enabled.
+var supportedVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLSVersionToNameOrDie given a tls version as an int, return its readable name
+func TLSVersionToNameOrDie(intVal uint16) string {
+	matches := []string{}
+	for key, version := range versions {
+		if version == intVal {
+			matches = append(matches, key)
+		}
+	}
+
+	if len(matches) == 0 {
+		panic(fmt.Sprintf("no name found for %d", intVal))
+	}
+	if len(matches) > 1 {
+		panic(fmt.Sprintf("multiple names found for %d: %v", intVal, matches))
+	}
+	return matches[0]
+}
+
+func TLSVersion(versionName string) (uint16, error) {
+	if len(versionName) == 0 {
+		return DefaultTLSVersion(), nil
+	}
+	if version, ok := versions[versionName]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+func TLSVersionOrDie(versionName string) uint16 {
+	version, err := TLSVersion(versionName)
+	if err != nil {
+		panic(err)
+	}
+	return version
+}
+
+// TLS versions that are known to golang, but may not necessarily be enabled.
+func GolangTLSVersions() []string {
+	supported := []string{}
+	for k := range versions {
+		supported = append(supported, k)
+	}
+	sort.Strings(supported)
+	return supported
+}
+
+// Returns the build enabled TLS versions.
+func ValidTLSVersions() []string {
+	validVersions := []string{}
+	for k := range supportedVersions {
+		validVersions = append(validVersions, k)
+	}
+	sort.Strings(validVersions)
+	return validVersions
+}
+func DefaultTLSVersion() uint16 {
+	// Can't use SSLv3 because of POODLE and BEAST
+	// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+	// Can't use TLSv1.1 because of RC4 cipher usage
+	return tls.VersionTLS12
+}
+
+var ciphers = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
+}
+
+// openSSLToIANACiphersMap maps OpenSSL cipher suite names to IANA names
+// Ref: https://www.iana.org/assignments/tls-parameters/tls-parameters.xml
+// This must hold a 1:1 mapping for each OpenSSL cipher defined in openshift/api TLSSecurityProfiles,
+// so it can be used to translate OpenSSL ciphers to IANA ciphers, which is what go's crypto/tls understands.
+// Ciphers in this map must also be compatible with go's crypto/tls ciphers:
+// https://github.com/golang/go/blob/d4febb45179fa99ee1d5783bcb693ed7ba14115c/src/crypto/tls/cipher_suites.go#L682-L724
+var openSSLToIANACiphersMap = map[string]string{
+	// TLS 1.3 ciphers - not configurable in go 1.13, all of them are used in TLSv1.3 flows
+	"TLS_AES_128_GCM_SHA256":       "TLS_AES_128_GCM_SHA256",       // 0x13,0x01
+	"TLS_AES_256_GCM_SHA384":       "TLS_AES_256_GCM_SHA384",       // 0x13,0x02
+	"TLS_CHACHA20_POLY1305_SHA256": "TLS_CHACHA20_POLY1305_SHA256", // 0x13,0x03
+
+	// TLS 1.2
+	"ECDHE-ECDSA-AES128-GCM-SHA256": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",       // 0xC0,0x2B
+	"ECDHE-RSA-AES128-GCM-SHA256":   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",         // 0xC0,0x2F
+	"ECDHE-ECDSA-AES256-GCM-SHA384": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",       // 0xC0,0x2C
+	"ECDHE-RSA-AES256-GCM-SHA384":   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",         // 0xC0,0x30
+	"ECDHE-ECDSA-CHACHA20-POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", // 0xCC,0xA9
+	"ECDHE-RSA-CHACHA20-POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",   // 0xCC,0xA8
+	"ECDHE-ECDSA-AES128-SHA256":     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",       // 0xC0,0x23
+	"ECDHE-RSA-AES128-SHA256":       "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",         // 0xC0,0x27
+	"AES128-GCM-SHA256":             "TLS_RSA_WITH_AES_128_GCM_SHA256",               // 0x00,0x9C
+	"AES256-GCM-SHA384":             "TLS_RSA_WITH_AES_256_GCM_SHA384",               // 0x00,0x9D
+	"AES128-SHA256":                 "TLS_RSA_WITH_AES_128_CBC_SHA256",               // 0x00,0x3C
+
+	// Go's crypto/tls does not support CBC mode and DHE ciphers, so we don't want to include them here.
+	// See:
+	//   - https://github.com/golang/go/issues/26652
+	//   - https://github.com/golang/go/issues/7758
+	//   - https://redhat-internal.slack.com/archives/C098FU5MRAB/p1770309657097269
+	//
+	// "ECDHE-ECDSA-AES256-SHA384":     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",       // 0xC0,0x24
+	// "ECDHE-RSA-AES256-SHA384":       "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",         // 0xC0,0x28
+	// "AES256-SHA256":                 "TLS_RSA_WITH_AES_256_CBC_SHA256",               // 0x00,0x3D
+	// "DHE-RSA-AES128-GCM-SHA256":     "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",           // 0x00,0x9E
+	// "DHE-RSA-AES256-GCM-SHA384":     "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",           // 0x00,0x9F
+	// "DHE-RSA-CHACHA20-POLY1305":     "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",     // 0xCC,0xAA
+	// "DHE-RSA-AES128-SHA256":         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",           // 0x00,0x67
+	// "DHE-RSA-AES256-SHA256":         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",           // 0x00,0x6B
+
+	// TLS 1
+	"ECDHE-ECDSA-AES128-SHA": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", // 0xC0,0x09
+	"ECDHE-RSA-AES128-SHA":   "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",   // 0xC0,0x13
+	"ECDHE-ECDSA-AES256-SHA": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", // 0xC0,0x0A
+	"ECDHE-RSA-AES256-SHA":   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",   // 0xC0,0x14
+
+	// SSL 3
+	"AES128-SHA":             "TLS_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x2F
+	"AES256-SHA":             "TLS_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x35
+	"DES-CBC3-SHA":           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",       // 0x00,0x0A
+	"ECDHE-RSA-DES-CBC3-SHA": "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", // 0xC0,0x12
+}
+
+// CipherSuitesToNamesOrDie given a list of cipher suites as ints, return their readable names
+func CipherSuitesToNamesOrDie(intVals []uint16) []string {
+	ret := []string{}
+	for _, intVal := range intVals {
+		ret = append(ret, CipherSuiteToNameOrDie(intVal))
+	}
+
+	return ret
+}
+
+// CipherSuiteToNameOrDie given a cipher suite as an int, return its readable name
+func CipherSuiteToNameOrDie(intVal uint16) string {
+	// The following suite ids appear twice in the cipher map (with
+	// and without the _SHA256 suffix) for the purposes of backwards
+	// compatibility. Always return the current rather than the legacy
+	// name.
+	switch intVal {
+	case tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
+		return "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+	case tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
+		return "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+	}
+
+	matches := []string{}
+	for key, version := range ciphers {
+		if version == intVal {
+			matches = append(matches, key)
+		}
+	}
+
+	if len(matches) == 0 {
+		panic(fmt.Sprintf("no name found for %d", intVal))
+	}
+	if len(matches) > 1 {
+		panic(fmt.Sprintf("multiple names found for %d: %v", intVal, matches))
+	}
+	return matches[0]
+}
+
+func CipherSuite(cipherName string) (uint16, error) {
+	if cipher, ok := ciphers[cipherName]; ok {
+		return cipher, nil
+	}
+
+	return 0, fmt.Errorf("unknown cipher name %q", cipherName)
+}
+
+func CipherSuitesOrDie(cipherNames []string) []uint16 {
+	if len(cipherNames) == 0 {
+		return DefaultCiphers()
+	}
+	cipherValues := []uint16{}
+	for _, cipherName := range cipherNames {
+		cipher, err := CipherSuite(cipherName)
+		if err != nil {
+			panic(err)
+		}
+		cipherValues = append(cipherValues, cipher)
+	}
+	return cipherValues
+}
+func ValidCipherSuites() []string {
+	validCipherSuites := []string{}
+	for k := range ciphers {
+		validCipherSuites = append(validCipherSuites, k)
+	}
+	sort.Strings(validCipherSuites)
+	return validCipherSuites
+}
+
+// DefaultTLSProfileType is the intermediate profile type.
+const DefaultTLSProfileType = configv1.TLSProfileIntermediateType
+
+// DefaultCiphers returns the default cipher suites for TLS connections.
+//
+// RECOMMENDATION: Instead of relying on this function directly, consumers should respect
+// TLSSecurityProfile settings from one of the OpenShift API configuration resources:
+//   - For API servers: Use apiserver.config.openshift.io/cluster Spec.TLSSecurityProfile
+//   - For ingress controllers: Use operator.openshift.io/v1 IngressController Spec.TLSSecurityProfile
+//   - For kubelet: Use machineconfiguration.openshift.io/v1 KubeletConfig Spec.TLSSecurityProfile
+//
+// These API resources allow cluster administrators to choose between Old, Intermediate,
+// Modern, or Custom TLS profiles. Components should observe these settings.
+func DefaultCiphers() []uint16 {
+	// Aligned with intermediate profile of the 5.7 version of the Mozilla Server
+	// Side TLS guidelines found at: https://ssl-config.mozilla.org/guidelines/5.7.json
+	//
+	// Latest guidelines: https://ssl-config.mozilla.org/guidelines/latest.json
+	//
+	// This profile provides strong security with wide compatibility.
+	// It requires TLS 1.2+ and uses only AEAD cipher suites (GCM, ChaCha20-Poly1305)
+	// with ECDHE key exchange for perfect forward secrecy.
+	//
+	// All CBC-mode ciphers have been removed due to padding oracle vulnerabilities.
+	// All RSA key exchange ciphers have been removed due to lack of perfect forward secrecy.
+	//
+	// HTTP/2 compliance: All ciphers are compliant with RFC7540, section 9.2.
+	return []uint16{
+		// TLS 1.2 cipher suites with ECDHE + AEAD
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // required by HTTP/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+
+		// TLS 1.3 cipher suites (negotiated automatically, not configurable)
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+}
+
+// SecureTLSConfig enforces the default minimum security settings for the cluster.
+func SecureTLSConfig(config *tls.Config) *tls.Config {
+	if config.MinVersion == 0 {
+		config.MinVersion = DefaultTLSVersion()
+	}
+
+	config.PreferServerCipherSuites = true
+	if len(config.CipherSuites) == 0 {
+		config.CipherSuites = DefaultCiphers()
+	}
+	return config
+}
+
+// OpenSSLToIANACipherSuites maps input OpenSSL Cipher Suite names to their
+// IANA counterparts.
+// Unknown ciphers are left out.
+func OpenSSLToIANACipherSuites(ciphers []string) []string {
+	ianaCiphers := make([]string, 0, len(ciphers))
+
+	for _, c := range ciphers {
+		ianaCipher, found := openSSLToIANACiphersMap[c]
+		if found {
+			ianaCiphers = append(ianaCiphers, ianaCipher)
+		}
+	}
+
+	return ianaCiphers
+}
+
+type TLSCertificateConfig struct {
+	Certs []*x509.Certificate
+	Key   crypto.PrivateKey
+}
+
+type TLSCARoots struct {
+	Roots []*x509.Certificate
+}
+
+func (c *TLSCertificateConfig) WriteCertConfigFile(certFile, keyFile string) error {
+	// ensure parent dir
+	if err := os.MkdirAll(filepath.Dir(certFile), os.FileMode(0755)); err != nil {
+		return err
+	}
+	certFileWriter, err := os.OpenFile(certFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyFile), os.FileMode(0755)); err != nil {
+		return err
+	}
+	keyFileWriter, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	if err := writeCertificates(certFileWriter, c.Certs...); err != nil {
+		return err
+	}
+	if err := writeKeyFile(keyFileWriter, c.Key); err != nil {
+		return err
+	}
+
+	if err := certFileWriter.Close(); err != nil {
+		return err
+	}
+	if err := keyFileWriter.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *TLSCertificateConfig) WriteCertConfig(certFile, keyFile io.Writer) error {
+	if err := writeCertificates(certFile, c.Certs...); err != nil {
+		return err
+	}
+	if err := writeKeyFile(keyFile, c.Key); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *TLSCertificateConfig) GetPEMBytes() ([]byte, []byte, error) {
+	certBytes, err := EncodeCertificates(c.Certs...)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBytes, err := EncodeKey(c.Key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certBytes, keyBytes, nil
+}
+
+func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, error) {
+	if len(certFile) == 0 {
+		return nil, errors.New("certFile missing")
+	}
+	if len(keyFile) == 0 {
+		return nil, errors.New("keyFile missing")
+	}
+
+	certPEMBlock, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := cert.ParseCertsPEM(certPEMBlock)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", certFile, err)
+	}
+
+	keyPEMBlock, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	keyPairCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return nil, err
+	}
+	key := keyPairCert.PrivateKey
+
+	return &TLSCertificateConfig{certs, key}, nil
+}
+
+func GetTLSCertificateConfigFromBytes(certBytes, keyBytes []byte) (*TLSCertificateConfig, error) {
+	if len(certBytes) == 0 {
+		return nil, errors.New("certFile missing")
+	}
+	if len(keyBytes) == 0 {
+		return nil, errors.New("keyFile missing")
+	}
+
+	certs, err := cert.ParseCertsPEM(certBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error reading cert: %s", err)
+	}
+
+	keyPairCert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+	key := keyPairCert.PrivateKey
+
+	return &TLSCertificateConfig{certs, key}, nil
+}
+
+const (
+	DefaultCertificateLifetimeDuration   = time.Hour * 24 * 365 * 2 // 2 years
+	DefaultCACertificateLifetimeDuration = time.Hour * 24 * 365 * 5 // 5 years
+
+	// Default keys are 2048 bits
+	keyBits = 2048
+)
+
+type CA struct {
+	Config *TLSCertificateConfig
+
+	SerialGenerator SerialGenerator
+}
+
+// SerialGenerator is an interface for getting a serial number for the cert.  It MUST be thread-safe.
+type SerialGenerator interface {
+	Next(template *x509.Certificate) (int64, error)
+}
+
+// SerialFileGenerator returns a unique, monotonically increasing serial number and ensures the CA on disk records that value.
+type SerialFileGenerator struct {
+	SerialFile string
+
+	// lock guards access to the Serial field
+	lock   sync.Mutex
+	Serial int64
+}
+
+func NewSerialFileGenerator(serialFile string) (*SerialFileGenerator, error) {
+	// read serial file, it must already exist
+	serial, err := fileToSerial(serialFile)
+	if err != nil {
+		return nil, err
+	}
+
+	generator := &SerialFileGenerator{
+		Serial:     serial,
+		SerialFile: serialFile,
+	}
+
+	// 0 is unused and 1 is reserved for the CA itself
+	// Thus we need to guarantee that the first external call to SerialFileGenerator.Next returns 2+
+	// meaning that SerialFileGenerator.Serial must not be less than 1 (it is guaranteed to be non-negative)
+	if generator.Serial < 1 {
+		// fake a call to Next so the file stays in sync and Serial is incremented
+		if _, err := generator.Next(&x509.Certificate{}); err != nil {
+			return nil, err
+		}
+	}
+
+	return generator, nil
+}
+
+// Next returns a unique, monotonically increasing serial number and ensures the CA on disk records that value.
+func (s *SerialFileGenerator) Next(template *x509.Certificate) (int64, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// do a best effort check to make sure concurrent external writes are not occurring to the underlying serial file
+	serial, err := fileToSerial(s.SerialFile)
+	if err != nil {
+		return 0, err
+	}
+	if serial != s.Serial {
+		return 0, fmt.Errorf("serial file %s out of sync ram=%d disk=%d", s.SerialFile, s.Serial, serial)
+	}
+
+	next := s.Serial + 1
+	s.Serial = next
+
+	// Output in hex, padded to multiples of two characters for OpenSSL's sake
+	serialText := fmt.Sprintf("%X", next)
+	if len(serialText)%2 == 1 {
+		serialText = "0" + serialText
+	}
+	// always add a newline at the end to have a valid file
+	serialText += "\n"
+
+	if err := os.WriteFile(s.SerialFile, []byte(serialText), os.FileMode(0640)); err != nil {
+		return 0, err
+	}
+	return next, nil
+}
+
+func fileToSerial(serialFile string) (int64, error) {
+	serialData, err := os.ReadFile(serialFile)
+	if err != nil {
+		return 0, err
+	}
+
+	// read the file as a single hex number after stripping any whitespace
+	serial, err := strconv.ParseInt(string(bytes.TrimSpace(serialData)), 16, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	if serial < 0 {
+		return 0, fmt.Errorf("invalid negative serial %d in serial file %s", serial, serialFile)
+	}
+
+	return serial, nil
+}
+
+// RandomSerialGenerator returns a serial based on time.Now and the subject
+type RandomSerialGenerator struct {
+}
+
+func (s *RandomSerialGenerator) Next(template *x509.Certificate) (int64, error) {
+	return randomSerialNumber(), nil
+}
+
+// randomSerialNumber returns a random int64 serial number based on
+// time.Now. It is defined separately from the generator interface so
+// that the caller doesn't have to worry about an input template or
+// error - these are unnecessary when creating a random serial.
+func randomSerialNumber() int64 {
+	r := mathrand.New(mathrand.NewSource(time.Now().UTC().UnixNano()))
+	return r.Int63()
+}
+
+// EnsureCA returns a CA, whether it was created (as opposed to pre-existing), and any error
+// if serialFile is empty, a RandomSerialGenerator will be used
+func EnsureCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, bool, error) {
+	if ca, err := GetCA(certFile, keyFile, serialFile); err == nil {
+		return ca, false, err
+	}
+	ca, err := MakeSelfSignedCA(certFile, keyFile, serialFile, name, lifetime)
+	return ca, true, err
+}
+
+// if serialFile is empty, a RandomSerialGenerator will be used
+func GetCA(certFile, keyFile, serialFile string) (*CA, error) {
+	caConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		SerialGenerator: serialGenerator,
+		Config:          caConfig,
+	}, nil
+}
+
+func GetCAFromBytes(certBytes, keyBytes []byte) (*CA, error) {
+	caConfig, err := GetTLSCertificateConfigFromBytes(certBytes, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CA{
+		SerialGenerator: &RandomSerialGenerator{},
+		Config:          caConfig,
+	}, nil
+}
+
+// if serialFile is empty, a RandomSerialGenerator will be used
+func MakeSelfSignedCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, error) {
+	klog.V(2).Infof("Generating new CA for %s cert, and key in %s, %s", name, certFile, keyFile)
+
+	caConfig, err := MakeSelfSignedCAConfig(name, lifetime)
+	if err != nil {
+		return nil, err
+	}
+	if err := caConfig.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		// create / overwrite the serial file with a zero padded hex value (ending in a newline to have a valid file)
+		if err := os.WriteFile(serialFile, []byte("00\n"), 0644); err != nil {
+			return nil, err
+		}
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		SerialGenerator: serialGenerator,
+		Config:          caConfig,
+	}, nil
+}
+
+func MakeSelfSignedCAConfig(name string, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return MakeSelfSignedCAConfigForSubject(subject, lifetime)
+}
+
+func MakeSelfSignedCAConfigForSubject(subject pkix.Name, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	if lifetime <= 0 {
+		lifetime = DefaultCACertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCACertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCACertificateLifetimeDuration)
+	}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, time.Now, lifetime)
+}
+
+func MakeSelfSignedCAConfigForDuration(name string, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, time.Now, caLifetime)
+}
+
+func UnsafeMakeSelfSignedCAConfigForDurationAtTime(name string, currentTime func() time.Time, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, currentTime, caLifetime)
+}
+
+func makeSelfSignedCAConfigForSubjectAndDuration(subject pkix.Name, currentTime func() time.Time, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	// Create CA cert
+	rootcaPublicKey, rootcaPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+	// AuthorityKeyId and SubjectKeyId should match for a self-signed CA
+	authorityKeyId := publicKeyHash
+	subjectKeyId := publicKeyHash
+	rootcaTemplate := newSigningCertificateTemplateForDuration(subject, caLifetime, currentTime, authorityKeyId, subjectKeyId)
+	rootcaCert, err := signCertificate(rootcaTemplate, rootcaPublicKey, rootcaTemplate, rootcaPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	caConfig := &TLSCertificateConfig{
+		Certs: []*x509.Certificate{rootcaCert},
+		Key:   rootcaPrivateKey,
+	}
+	return caConfig, nil
+}
+
+func MakeCAConfigForDuration(name string, caLifetime time.Duration, issuer *CA) (*TLSCertificateConfig, error) {
+	// Create CA cert
+	signerPublicKey, signerPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+	authorityKeyId := issuer.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	signerTemplate := newSigningCertificateTemplateForDuration(pkix.Name{CommonName: name}, caLifetime, time.Now, authorityKeyId, subjectKeyId)
+	signerCert, err := issuer.SignCertificate(signerTemplate, signerPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	signerConfig := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{signerCert}, issuer.Config.Certs...),
+		Key:   signerPrivateKey,
+	}
+	return signerConfig, nil
+}
+
+// EnsureSubCA returns a subCA signed by the `ca`, whether it was created
+// (as opposed to pre-existing), and any error that might occur during the subCA
+// creation.
+// If serialFile is an empty string, a RandomSerialGenerator will be used.
+func (ca *CA) EnsureSubCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, bool, error) {
+	if subCA, err := GetCA(certFile, keyFile, serialFile); err == nil {
+		return subCA, false, err
+	}
+	subCA, err := ca.MakeAndWriteSubCA(certFile, keyFile, serialFile, name, lifetime)
+	return subCA, true, err
+}
+
+// MakeAndWriteSubCA returns a new sub-CA configuration. New cert/key pair is generated
+// while using this function.
+// If serialFile is an empty string, a RandomSerialGenerator will be used.
+func (ca *CA) MakeAndWriteSubCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, error) {
+	klog.V(4).Infof("Generating sub-CA certificate in %s, key in %s, serial in %s", certFile, keyFile, serialFile)
+
+	subCAConfig, err := MakeCAConfigForDuration(name, lifetime, ca)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := subCAConfig.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		// create / overwrite the serial file with a zero padded hex value (ending in a newline to have a valid file)
+		if err := os.WriteFile(serialFile, []byte("00\n"), 0644); err != nil {
+			return nil, err
+		}
+
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		Config:          subCAConfig,
+		SerialGenerator: serialGenerator,
+	}, nil
+}
+
+func (ca *CA) EnsureServerCert(certFile, keyFile string, hostnames sets.Set[string], lifetime time.Duration) (*TLSCertificateConfig, bool, error) {
+	certConfig, err := GetServerCert(certFile, keyFile, hostnames)
+	if err != nil {
+		certConfig, err = ca.MakeAndWriteServerCert(certFile, keyFile, hostnames, lifetime)
+		return certConfig, true, err
+	}
+
+	return certConfig, false, nil
+}
+
+func GetServerCert(certFile, keyFile string, hostnames sets.Set[string]) (*TLSCertificateConfig, error) {
+	server, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	cert := server.Certs[0]
+	certNames := sets.New[string]()
+	for _, ip := range cert.IPAddresses {
+		certNames.Insert(ip.String())
+	}
+	certNames.Insert(cert.DNSNames...)
+	if hostnames.Equal(certNames) {
+		klog.V(4).Infof("Found existing server certificate in %s", certFile)
+		return server, nil
+	}
+
+	return nil, fmt.Errorf("existing server certificate in %s does not match required hostnames", certFile)
+}
+
+func (ca *CA) MakeAndWriteServerCert(certFile, keyFile string, hostnames sets.Set[string], lifetime time.Duration) (*TLSCertificateConfig, error) {
+	klog.V(4).Infof("Generating server certificate in %s, key in %s", certFile, keyFile)
+
+	server, err := ca.MakeServerCert(hostnames, lifetime)
+	if err != nil {
+		return nil, err
+	}
+	if err := server.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return server, err
+	}
+	return server, nil
+}
+
+// CertificateExtensionFunc is passed a certificate that it may extend, or return an error
+// if the extension attempt failed.
+type CertificateExtensionFunc func(*x509.Certificate) error
+
+func (ca *CA) MakeServerCert(hostnames sets.Set[string], lifetime time.Duration, fns ...CertificateExtensionFunc) (*TLSCertificateConfig, error) {
+	serverPublicKey, serverPrivateKey, publicKeyHash, _ := newKeyPairWithHash()
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	serverTemplate := newServerCertificateTemplate(pkix.Name{CommonName: sets.List(hostnames)[0]}, sets.List(hostnames), lifetime, time.Now, authorityKeyId, subjectKeyId)
+	for _, fn := range fns {
+		if err := fn(serverTemplate); err != nil {
+			return nil, err
+		}
+	}
+	serverCrt, err := ca.SignCertificate(serverTemplate, serverPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	server := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{serverCrt}, ca.Config.Certs...),
+		Key:   serverPrivateKey,
+	}
+	return server, nil
+}
+
+func (ca *CA) MakeServerCertForDuration(hostnames sets.Set[string], lifetime time.Duration, fns ...CertificateExtensionFunc) (*TLSCertificateConfig, error) {
+	serverPublicKey, serverPrivateKey, publicKeyHash, _ := newKeyPairWithHash()
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	serverTemplate := newServerCertificateTemplateForDuration(pkix.Name{CommonName: sets.List(hostnames)[0]}, sets.List(hostnames), lifetime, time.Now, authorityKeyId, subjectKeyId)
+	for _, fn := range fns {
+		if err := fn(serverTemplate); err != nil {
+			return nil, err
+		}
+	}
+	serverCrt, err := ca.SignCertificate(serverTemplate, serverPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	server := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{serverCrt}, ca.Config.Certs...),
+		Key:   serverPrivateKey,
+	}
+	return server, nil
+}
+
+func (ca *CA) EnsureClientCertificate(certFile, keyFile string, u user.Info, lifetime time.Duration) (*TLSCertificateConfig, bool, error) {
+	certConfig, err := GetClientCertificate(certFile, keyFile, u)
+	if err != nil {
+		certConfig, err = ca.MakeClientCertificate(certFile, keyFile, u, lifetime)
+		return certConfig, true, err // true indicates we wrote the files.
+	}
+	return certConfig, false, nil
+}
+
+func GetClientCertificate(certFile, keyFile string, u user.Info) (*TLSCertificateConfig, error) {
+	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if subject := certConfig.Certs[0].Subject; subjectChanged(subject, UserToSubject(u)) {
+		return nil, fmt.Errorf("existing client certificate in %s was issued for a different Subject (%s)",
+			certFile, subject)
+	}
+
+	return certConfig, nil
+}
+
+func subjectChanged(existing, expected pkix.Name) bool {
+	sort.Strings(existing.Organization)
+	sort.Strings(expected.Organization)
+
+	return existing.CommonName != expected.CommonName ||
+		existing.SerialNumber != expected.SerialNumber ||
+		!reflect.DeepEqual(existing.Organization, expected.Organization)
+}
+
+func (ca *CA) MakeClientCertificate(certFile, keyFile string, u user.Info, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	klog.V(4).Infof("Generating client cert in %s and key in %s", certFile, keyFile)
+	// ensure parent dirs
+	if err := os.MkdirAll(filepath.Dir(certFile), os.FileMode(0755)); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyFile), os.FileMode(0755)); err != nil {
+		return nil, err
+	}
+
+	clientPublicKey, clientPrivateKey, _ := NewKeyPair()
+	clientTemplate := NewClientCertificateTemplate(UserToSubject(u), lifetime, time.Now)
+	clientCrt, err := ca.SignCertificate(clientTemplate, clientPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certData, err := EncodeCertificates(clientCrt)
+	if err != nil {
+		return nil, err
+	}
+	keyData, err := EncodeKey(clientPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = os.WriteFile(certFile, certData, os.FileMode(0644)); err != nil {
+		return nil, err
+	}
+	if err = os.WriteFile(keyFile, keyData, os.FileMode(0600)); err != nil {
+		return nil, err
+	}
+
+	return GetTLSCertificateConfig(certFile, keyFile)
+}
+
+func (ca *CA) MakeClientCertificateForDuration(u user.Info, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	clientPublicKey, clientPrivateKey, _ := NewKeyPair()
+	clientTemplate := NewClientCertificateTemplateForDuration(UserToSubject(u), lifetime, time.Now)
+	clientCrt, err := ca.SignCertificate(clientTemplate, clientPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certData, err := EncodeCertificates(clientCrt)
+	if err != nil {
+		return nil, err
+	}
+	keyData, err := EncodeKey(clientPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetTLSCertificateConfigFromBytes(certData, keyData)
+}
+
+type sortedForDER []string
+
+func (s sortedForDER) Len() int {
+	return len(s)
+}
+func (s sortedForDER) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedForDER) Less(i, j int) bool {
+	l1 := len(s[i])
+	l2 := len(s[j])
+	if l1 == l2 {
+		return s[i] < s[j]
+	}
+	return l1 < l2
+}
+
+func UserToSubject(u user.Info) pkix.Name {
+	// Ok we are going to order groups in a peculiar way here to workaround a
+	// 2 bugs, 1 in golang (https://github.com/golang/go/issues/24254) which
+	// incorrectly encodes Multivalued RDNs and another in GNUTLS clients
+	// which are too picky (https://gitlab.com/gnutls/gnutls/issues/403)
+	// and try to "correct" this issue when reading client certs.
+	//
+	// This workaround should be killed once Golang's pkix module is fixed to
+	// generate a correct DER encoding.
+	//
+	// The workaround relies on the fact that the first octect that differs
+	// between the encoding of two group RDNs will end up being the encoded
+	// length which is directly related to the group name's length. So we'll
+	// sort such that shortest names come first.
+	ugroups := u.GetGroups()
+	groups := make([]string, len(ugroups))
+	copy(groups, ugroups)
+	sort.Sort(sortedForDER(groups))
+
+	return pkix.Name{
+		CommonName:   u.GetName(),
+		SerialNumber: u.GetUID(),
+		Organization: groups,
+	}
+}
+
+func (ca *CA) SignCertificate(template *x509.Certificate, requestKey crypto.PublicKey) (*x509.Certificate, error) {
+	// Increment and persist serial
+	serial, err := ca.SerialGenerator.Next(template)
+	if err != nil {
+		return nil, err
+	}
+	template.SerialNumber = big.NewInt(serial)
+	return signCertificate(template, requestKey, ca.Config.Certs[0], ca.Config.Key)
+}
+
+func NewKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	return newRSAKeyPair()
+}
+
+func newKeyPairWithHash() (crypto.PublicKey, crypto.PrivateKey, []byte, error) {
+	publicKey, privateKey, err := newRSAKeyPair()
+	var publicKeyHash []byte
+	if err == nil {
+		hash := sha1.New()
+		hash.Write(publicKey.N.Bytes())
+		publicKeyHash = hash.Sum(nil)
+	}
+	return publicKey, privateKey, publicKeyHash, err
+}
+
+func newRSAKeyPair() (*rsa.PublicKey, *rsa.PrivateKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, keyBits)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+// Can be used for CA or intermediate signing certs
+func newSigningCertificateTemplateForDuration(subject pkix.Name, caLifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore: currentTime().Add(-1 * time.Second),
+		NotAfter:  currentTime().Add(caLifetime),
+
+		// Specify a random serial number to avoid the same issuer+serial
+		// number referring to different certs in a chain of trust if the
+		// signing certificate is ever rotated.
+		SerialNumber: big.NewInt(randomSerialNumber()),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+}
+
+// Can be used for ListenAndServeTLS
+func newServerCertificateTemplate(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	if lifetime <= 0 {
+		lifetime = DefaultCertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeDuration)
+	}
+
+	return newServerCertificateTemplateForDuration(subject, hosts, lifetime, currentTime, authorityKeyId, subjectKeyId)
+}
+
+// Can be used for ListenAndServeTLS
+func newServerCertificateTemplateForDuration(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	template := &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    currentTime().Add(-1 * time.Second),
+		NotAfter:     currentTime().Add(lifetime),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+
+	template.IPAddresses, template.DNSNames = IPAddressesDNSNames(hosts)
+
+	return template
+}
+
+func IPAddressesDNSNames(hosts []string) ([]net.IP, []string) {
+	ips := []net.IP{}
+	dns := []string{}
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dns = append(dns, host)
+		}
+	}
+
+	// Include IP addresses as DNS subjectAltNames in the cert as well, for the sake of Python, Windows (< 10), and unnamed other libraries
+	// Ensure these technically invalid DNS subjectAltNames occur after the valid ones, to avoid triggering cert errors in Firefox
+	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1148766
+	for _, ip := range ips {
+		dns = append(dns, ip.String())
+	}
+
+	return ips, dns
+}
+
+func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
+	ok := false
+	certs := []*x509.Certificate{}
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return certs, err
+		}
+
+		certs = append(certs, cert)
+		ok = true
+	}
+
+	if !ok {
+		return certs, errors.New("could not read any certificates")
+	}
+	return certs, nil
+}
+
+// Can be used as a certificate in http.Transport TLSClientConfig
+func NewClientCertificateTemplate(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
+	if lifetime <= 0 {
+		lifetime = DefaultCertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeDuration)
+	}
+
+	return NewClientCertificateTemplateForDuration(subject, lifetime, currentTime)
+}
+
+// Can be used as a certificate in http.Transport TLSClientConfig
+func NewClientCertificateTemplateForDuration(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    currentTime().Add(-1 * time.Second),
+		NotAfter:     currentTime().Add(lifetime),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+}
+
+func warnAboutCertificateLifeTime(name string, defaultLifetimeDuration time.Duration) {
+	defaultLifetimeInYears := defaultLifetimeDuration / 365 / 24
+	fmt.Fprintf(os.Stderr, "WARNING: Validity period of the certificate for %q is greater than %d years!\n", name, defaultLifetimeInYears)
+	fmt.Fprintln(os.Stderr, "WARNING: By security reasons it is strongly recommended to change this period and make it smaller!")
+}
+
+func signCertificate(template *x509.Certificate, requestKey crypto.PublicKey, issuer *x509.Certificate, issuerKey crypto.PrivateKey) (*x509.Certificate, error) {
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuer, requestKey, issuerKey)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) != 1 {
+		return nil, errors.New("expected a single certificate")
+	}
+	return certs[0], nil
+}
+
+func EncodeCertificates(certs ...*x509.Certificate) ([]byte, error) {
+	b := bytes.Buffer{}
+	for _, cert := range certs {
+		if err := pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return []byte{}, err
+		}
+	}
+	return b.Bytes(), nil
+}
+func EncodeKey(key crypto.PrivateKey) ([]byte, error) {
+	b := bytes.Buffer{}
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		keyBytes, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			return []byte{}, err
+		}
+		if err := pem.Encode(&b, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}); err != nil {
+			return b.Bytes(), err
+		}
+	case *rsa.PrivateKey:
+		if err := pem.Encode(&b, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errors.New("unrecognized key type")
+
+	}
+	return b.Bytes(), nil
+}
+
+func writeCertificates(f io.Writer, certs ...*x509.Certificate) error {
+	bytes, err := EncodeCertificates(certs...)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+func writeKeyFile(f io.Writer, key crypto.PrivateKey) error {
+	bytes, err := EncodeKey(key)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/rotation.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/rotation.go
@@ -1,0 +1,20 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+// FilterExpiredCerts checks are all certificates in the bundle valid, i.e. they have not expired.
+// The function returns new bundle with only valid certificates or error if no valid certificate is found.
+func FilterExpiredCerts(certs ...*x509.Certificate) []*x509.Certificate {
+	currentTime := time.Now()
+	var validCerts []*x509.Certificate
+	for _, c := range certs {
+		if c.NotAfter.After(currentTime) {
+			validCerts = append(validCerts, c)
+		}
+	}
+
+	return validCerts
+}

--- a/vendor/k8s.io/utils/buffer/ring_fixed.go
+++ b/vendor/k8s.io/utils/buffer/ring_fixed.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+import (
+	"errors"
+	"io"
+)
+
+// Compile-time check that *TypedRingFixed[byte] implements io.Writer.
+var _ io.Writer = (*TypedRingFixed[byte])(nil)
+
+// ErrInvalidSize indicates size must be > 0
+var ErrInvalidSize = errors.New("size must be positive")
+
+// TypedRingFixed is a fixed-size circular buffer for elements of type T.
+// Writes overwrite older data, keeping only the last N elements.
+// Not thread safe.
+type TypedRingFixed[T any] struct {
+	data        []T
+	size        int
+	writeCursor int
+	written     int64
+}
+
+// NewTypedRingFixed creates a circular buffer with the given capacity (must be > 0).
+func NewTypedRingFixed[T any](size int) (*TypedRingFixed[T], error) {
+	if size <= 0 {
+		return nil, ErrInvalidSize
+	}
+	return &TypedRingFixed[T]{
+		data: make([]T, size),
+		size: size,
+	}, nil
+}
+
+// Write writes p to the buffer, overwriting old data if needed.
+func (r *TypedRingFixed[T]) Write(p []T) (int, error) {
+	originalLen := len(p)
+	r.written += int64(originalLen)
+
+	// If the input is larger than our buffer, only keep the last 'size' elements
+	if originalLen > r.size {
+		p = p[originalLen-r.size:]
+	}
+
+	// Copy data, handling wrap-around
+	n := len(p)
+	remain := r.size - r.writeCursor
+	if n <= remain {
+		copy(r.data[r.writeCursor:], p)
+	} else {
+		copy(r.data[r.writeCursor:], p[:remain])
+		copy(r.data, p[remain:])
+	}
+
+	r.writeCursor = (r.writeCursor + n) % r.size
+	return originalLen, nil
+}
+
+// Slice returns buffer contents in write order. Don't modify the returned slice.
+func (r *TypedRingFixed[T]) Slice() []T {
+	if r.written == 0 {
+		return nil
+	}
+
+	// Buffer hasn't wrapped yet
+	if r.written < int64(r.size) {
+		return r.data[:r.writeCursor]
+	}
+
+	// Buffer has wrapped - need to return data in correct order
+	// Data from writeCursor to end is oldest, data from 0 to writeCursor is newest
+	if r.writeCursor == 0 {
+		return r.data
+	}
+
+	out := make([]T, r.size)
+	copy(out, r.data[r.writeCursor:])
+	copy(out[r.size-r.writeCursor:], r.data[:r.writeCursor])
+	return out
+}
+
+// Size returns the buffer capacity.
+func (r *TypedRingFixed[T]) Size() int {
+	return r.size
+}
+
+// Len returns how many elements are currently in the buffer.
+func (r *TypedRingFixed[T]) Len() int {
+	if r.written < int64(r.size) {
+		return int(r.written)
+	}
+	return r.size
+}
+
+// TotalWritten returns total elements ever written (including overwritten ones).
+func (r *TypedRingFixed[T]) TotalWritten() int64 {
+	return r.written
+}
+
+// Reset clears the buffer.
+func (r *TypedRingFixed[T]) Reset() {
+	r.writeCursor = 0
+	r.written = 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -291,6 +291,9 @@ github.com/openshift/assisted-service/api/v1beta1
 ## explicit; go 1.21
 github.com/openshift/assisted-service/models
 github.com/openshift/assisted-service/models/validations
+# github.com/openshift/controller-runtime-common v0.0.0-20260305203102-d1c60045a455
+## explicit; go 1.24.0
+github.com/openshift/controller-runtime-common/pkg/tls
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
@@ -309,6 +312,9 @@ github.com/openshift/hive/apis/hive/v1/nutanix
 github.com/openshift/hive/apis/hive/v1/openstack
 github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/scheme
+# github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5
+## explicit; go 1.24.0
+github.com/openshift/library-go/pkg/crypto
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
@@ -1198,8 +1204,8 @@ k8s.io/kube-openapi/pkg/validation/errors
 k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
-# k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-## explicit; go 1.18
+# k8s.io/utils v0.0.0-20260108192941-914a6e750570
+## explicit; go 1.23
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/internal/third_party/forked/golang/golang-lru


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The siteconfig-controller's webhook and metrics servers currently use a hardcoded TLS configuration that does not respect the cluster-wide TLS security profile set on the APIServer resource (`config.openshift.io/v1`). This means that when a cluster administrator configures a specific TLS profile (e.g., `Intermediate`, `Modern`, or `Custom`), the siteconfig-controller ignores it, potentially serving connections with cipher suites or TLS versions that violate the cluster's security policy.

Other OpenShift operators have adopted [openshift/controller-runtime-common](https://github.com/openshift/controller-runtime-common) to enforce TLS profile consistency. This change brings siteconfig-controller in line with that standard.

## Changes Made

- Fetch the cluster's APIServer TLS security profile at startup using `openshifttls.FetchAPIServerTLSProfile()` (bounded by a 30-second timeout) and apply it to the manager's webhook and metrics TLS configuration via `openshifttls.NewTLSConfigFromProfile()`
- Register a `SecurityProfileWatcher` controller that monitors the APIServer resource for TLS profile changes and gracefully restarts the controller to pick up new settings
- Create a pre-manager `client.Client` to read the TLS profile before the manager starts (required because the manager's caches are not available until `Start()`)
- Add `configv1` (OpenShift API) to the scheme and add RBAC permissions to get/list/watch `apiservers` in the `config.openshift.io` API group
- Add `github.com/openshift/controller-runtime-common` and `github.com/openshift/library-go` as vendored dependencies
- Refactor signal handling: wrap `ctrl.SetupSignalHandler()` in a cancellable context so the watcher can trigger a restart by cancelling the context
- Refactor `main()` into a `run() error` function so that deferred calls (`logger.Sync()`, context `cancel()`) execute on all error paths — this eliminates `exitAfterDefer` gocritic lint violations without nolint suppression, following the pattern used by controller-runtime's newer examples and stolostron/multicluster-global-hub
- Replace `context.TODO()` with the signal-derived `ctx` in startup ConfigMap initialisation and configuration store setup, so these operations respect shutdown cancellation

## Testing

- Verified `make ci-job` passes (lint, vet, unit tests, bundle check)
- Confirmed controller starts correctly against a cluster with the default (`Intermediate`) TLS profile
- The TLS library (`controller-runtime-common/pkg/tls`) has comprehensive unit tests covering profile fetching, cipher conversion, and watcher behaviour; no additional unit tests are needed for the main.go integration (consistent with all other OpenShift operators consuming this library)
- Code coverage for new code: N/A — changes are in `cmd/main.go` startup wiring, which is not unit-tested (consistent with upstream Kubernetes, kubebuilder, and stolostron conventions)

## JIRA

https://redhat.atlassian.net/browse/ACM-36262

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Implementation of TLS profile integration in `cmd/main.go`, RBAC markers, research into testing best practices across stolostron/kubernetes/openshift ecosystems
- **Level**: Co-development
- **Human Review**: All AI-generated code was reviewed, tested, and validated

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [ ] Unit tests are added/updated and pass
- [ ] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Security**
  * Added support for OpenShift TLS security profiles during startup.
  * Automatically applies TLS changes by restarting the running manager when the API server security profile updates.
  * Disables HTTP/2 when the active security profile requires it.

* **Permissions**
  * Granted read-only access to `config.openshift.io` `apiservers` (`get`, `list`, `watch`) to monitor TLS profile state.

* **Maintenance**
  * Improved startup/shutdown behavior with clearer error propagation and graceful manager cancellation on profile changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->