### PR TITLE
ACM-38879: Update Go to 1.26 and bump VERSION to 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.16.0
+VERSION ?= 5.0.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the siteconfig-manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1138,7 +1138,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: siteconfig.v2.16.0
+  name: siteconfig.v5.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1370,7 +1370,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/stolostron/siteconfig-operator:2.16.0
+                image: quay.io/stolostron/siteconfig-operator:5.0.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -1483,7 +1483,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 2.16.0
+  version: 5.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/stolostron/siteconfig-operator
-  newTag: 2.16.0
+  newTag: 5.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/siteconfig
 
-go 1.25.9
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="2.12.1"
+VERSION="2.11.4"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then
@@ -19,7 +19,7 @@ function get_tool {
 
     if [ $ret -ne 0 ]; then
         echo "Install from script failed. Trying go install"
-        go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v${VERSION}"
+        go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${VERSION}"
         ret=$?
         if [ $ret -ne 0 ]; then
             echo "Install of golangci-lint failed"

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="2.8.0"
+VERSION="2.12.1"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then

--- a/internal/controller/clusterinstance/validator.go
+++ b/internal/controller/clusterinstance/validator.go
@@ -81,7 +81,7 @@ func validateResources(ctx context.Context, c client.Client, clusterInstance *v1
 func validateTemplateRefs(ctx context.Context, c client.Client, clusterInstance *v1alpha1.ClusterInstance) error {
 
 	// Check the cluster-level template references are defined
-	if (clusterInstance.Spec.TemplateRefs == nil) || (len(clusterInstance.Spec.TemplateRefs) < 1) {
+	if len(clusterInstance.Spec.TemplateRefs) < 1 {
 		return fmt.Errorf("missing cluster-level TemplateRefs")
 	}
 
@@ -97,7 +97,7 @@ func validateTemplateRefs(ctx context.Context, c client.Client, clusterInstance 
 
 	for _, node := range clusterInstance.Spec.Nodes {
 		// Check the ref templates are defined
-		if (node.TemplateRefs == nil) || (len(node.TemplateRefs) < 1) {
+		if len(node.TemplateRefs) < 1 {
 			return fmt.Errorf("missing node-level template refs [Node: Hostname=%s]", node.HostName)
 		}
 		// Verify that the node-level TemplateRefs exist


### PR DESCRIPTION
Resolves [ACM-38879](https://redhat.atlassian.net/browse/ACM-38879)

/cc @cwilkers 

[ACM-38879]: https://redhat.atlassian.net/browse/ACM-38879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated SiteConfig operator/CSV metadata to **5.0.0**, including the controller image tag and published `spec.version`.
* **Build**
  * Switched build toolchain to **Go 1.26**, including container build stages.
  * Updated default release tag version to **5.0.0** for packaging outputs.
* **Tooling**
  * Updated **golangci-lint** to **2.11.4**.
* **Deployment**
  * Updated controller deployment configuration to use the **5.0.0** image tag.
* **Bug Fixes**
  * Improved validation behavior when `TemplateRefs` are missing (nil treated like empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->