### PR TITLE
Add NetworkPolicy to OLM bundle and upgrade operator-sdk to v1.42.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.33.0
+OPERATOR_SDK_VERSION ?= v1.42.2
 
 
 # Image URL to use all building/pushing image targets

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=siteconfig
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/siteconfig-controller-manager_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/siteconfig-controller-manager_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: siteconfig
+    app.kubernetes.io/name: siteconfig-controller
+    control-plane: siteconfig-controller-manager
+  name: siteconfig-controller-manager
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: apiserver
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+  ingress:
+  - from:
+    - podSelector: {}
+  - ports:
+    - port: 9443
+      protocol: TCP
+  - ports:
+    - port: 8081
+      protocol: TCP
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: siteconfig
+      app.kubernetes.io/name: siteconfig-controller
+      control-plane: siteconfig-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1136,7 +1136,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.33.0
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: siteconfig.v5.0.0
   namespace: placeholder
@@ -1144,11 +1144,12 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterInstance defines the desired configuration for provisioning
-        an OpenShift cluster. Based on the selected templateRefs and clusterType,
-        the controller renders and applies the Kubernetes resources needed for cluster
-        installation (e.g., ClusterDeployment, ManagedCluster, BareMetalHost, or HostedCluster
-        depending on the installation flow).
+    - description: |-
+        ClusterInstance defines the desired configuration for provisioning an
+        OpenShift cluster. Based on the selected templateRefs and clusterType,
+        the controller renders and applies the Kubernetes resources needed for
+        cluster installation (e.g., ClusterDeployment, ManagedCluster,
+        BareMetalHost, or HostedCluster depending on the installation flow).
       displayName: Cluster Instance
       kind: ClusterInstance
       name: clusterinstances.siteconfig.open-cluster-management.io

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: siteconfig
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/manifests/bases/siteconfig.clusterserviceversion.yaml
+++ b/config/manifests/bases/siteconfig.clusterserviceversion.yaml
@@ -10,11 +10,12 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterInstance defines the desired configuration for provisioning
-        an OpenShift cluster. Based on the selected templateRefs and clusterType,
-        the controller renders and applies the Kubernetes resources needed for cluster
-        installation (e.g., ClusterDeployment, ManagedCluster, BareMetalHost, or HostedCluster
-        depending on the installation flow).
+    - description: |-
+        ClusterInstance defines the desired configuration for provisioning an
+        OpenShift cluster. Based on the selected templateRefs and clusterType,
+        the controller renders and applies the Kubernetes resources needed for
+        cluster installation (e.g., ClusterDeployment, ManagedCluster,
+        BareMetalHost, or HostedCluster depending on the installation flow).
       displayName: Cluster Instance
       kind: ClusterInstance
       name: clusterinstances.siteconfig.open-cluster-management.io


### PR DESCRIPTION
## Problem / Requirement / Reason for change

The NetworkPolicy added in #1190 (`config/manager/siteconfig-controller-networkpolicy.yaml`) restricts ingress and egress traffic for the controller pods as required by ACM/OpenShift security policy. However, it was only included in the Kustomize deployment path — OLM-based deployments did not receive it because the NetworkPolicy was not present in `bundle/manifests/`.

Additionally, operator-sdk v1.33.0 (the previously pinned version) does not support NetworkPolicy as a supplemental bundle object, causing bundle validation to fail when one is included.

## Changes Made

- Add the rendered NetworkPolicy manifest to `bundle/manifests/` so OLM deploys it at install time (following the same pattern used by stolostron/discovery)
- Upgrade `OPERATOR_SDK_VERSION` from v1.33.0 to v1.42.2 to support NetworkPolicy as a valid bundle object during validation
- Regenerate bundle artefacts (`bundle.Dockerfile`, `bundle/metadata/annotations.yaml`, CSV files) to reflect the new operator-sdk version

## Testing

- `make bundle` succeeds and includes the NetworkPolicy in the bundle
- `operator-sdk bundle validate ./bundle` passes with no errors
- `make bundle-check` passes (clean git tree after regeneration)
- No Go code changes; no unit test changes required
- Code coverage for new code: N/A — no Go code added

## JIRA

https://issues.redhat.com/browse/ACM-36264

## AI Assistance

- **Model Used**: Claude Opus 4.6 via Claude Code CLI
- **Scope**: Research into ACM NetworkPolicy patterns across stolostron repos, bundle validation troubleshooting, PR description
- **Level**: Co-development
- **Human Review**: All changes reviewed and validated

---

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [x] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)

/cc @gparvin @dislbenn 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the Operator SDK tooling and bundle metadata to version 1.42.2.
  * Added network policies controlling permitted ingress and egress traffic for the controller.
* **Documentation**
  * Improved the formatting and readability of the `ClusterInstance` resource description in generated metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->