### PR TITLE
WIP: CNF-18296: Use ManagedCluster for HCP status updates

### DIFF
--- a/api/v1alpha1/clusterinstance_types.go
+++ b/api/v1alpha1/clusterinstance_types.go
@@ -685,6 +685,11 @@ type ClusterInstanceStatus struct {
 	// +optional
 	DeploymentConditions []hivev1.ClusterDeploymentCondition `json:"deploymentConditions,omitempty"`
 
+	// ManagedClusterRef references the ManagedCluster for clusters tracked via ManagedCluster status.
+	// Used for HostedControlPlane clusters.
+	// +optional
+	ManagedClusterRef *corev1.LocalObjectReference `json:"managedClusterRef,omitempty"`
+
 	// List of manifests that have been rendered along with their status.
 	// +optional
 	ManifestsRendered []ManifestReference `json:"manifestsRendered,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -254,6 +254,11 @@ func (in *ClusterInstanceStatus) DeepCopyInto(out *ClusterInstanceStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ManagedClusterRef != nil {
+		in, out := &in.ManagedClusterRef, &out.ManagedClusterRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.ManifestsRendered != nil {
 		in, out := &in.ManifestsRendered, &out.ManifestsRendered
 		*out = make([]ManifestReference, len(*in))

--- a/bundle/manifests/siteconfig.clusterserviceversion.yaml
+++ b/bundle/manifests/siteconfig.clusterserviceversion.yaml
@@ -1222,6 +1222,12 @@ spec:
         - apiGroups:
           - cluster.open-cluster-management.io
           resources:
+          - managedclusters/status
+          verbs:
+          - get
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
           - managedclustersets/join
           verbs:
           - create

--- a/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/bundle/manifests/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -900,6 +900,22 @@ spec:
                   - type
                   type: object
                 type: array
+              managedClusterRef:
+                description: |-
+                  ManagedClusterRef references the ManagedCluster for clusters tracked via ManagedCluster status.
+                  Used for HostedControlPlane clusters.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               manifestsRendered:
                 description: List of manifests that have been rendered along with
                   their status.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -302,6 +302,15 @@ func setupControllers(
 		return fmt.Errorf("unable to create controller ClusterDeploymentReconciler: %w", err)
 	}
 
+	// Create ManagedCluster controller for monitoring HostedControlPlane cluster status
+	if err := (&controller.ManagedClusterReconciler{
+		Client: mgr.GetClient(),
+		Log:    logger.Named("ManagedClusterReconciler"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller ManagedClusterReconciler: %w", err)
+	}
+
 	// Create ClusterInstance validating admission webhook
 	if err := (&v1alpha1.ClusterInstance{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create webhook ClusterInstance: %w", err)

--- a/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
+++ b/config/crd/bases/siteconfig.open-cluster-management.io_clusterinstances.yaml
@@ -900,6 +900,22 @@ spec:
                   - type
                   type: object
                 type: array
+              managedClusterRef:
+                description: |-
+                  ManagedClusterRef references the ManagedCluster for clusters tracked via ManagedCluster status.
+                  Used for HostedControlPlane clusters.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               manifestsRendered:
                 description: List of manifests that have been rendered along with
                   their status.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,12 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
+  - managedclusters/status
+  verbs:
+  - get
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
   - managedclustersets/join
   verbs:
   - create

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -78,6 +78,13 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return requeueWithError(err)
 	}
 
+	// Skip ClusterDeployment reconciliation for HostedControlPlane clusters
+	// as they are managed by ManagedClusterReconciler instead
+	if clusterInstance.Spec.ClusterType == v1alpha1.ClusterTypeHostedControlPlane {
+		log.Info("Skipping ClusterDeployment reconciliation for HostedControlPlane cluster")
+		return doNotRequeue(), nil
+	}
+
 	oldStatus := clusterInstance.Status.DeepCopy()
 	patch := client.MergeFrom(clusterInstance.DeepCopy())
 

--- a/internal/controller/managedcluster_reconciler.go
+++ b/internal/controller/managedcluster_reconciler.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"github.com/stolostron/siteconfig/internal/controller/conditions"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters/status,verbs=get
+
+// ManagedClusterReconciler reconciles a ManagedCluster object to
+// update the ClusterInstance provisioned status condition for HostedControlPlane clusters
+type ManagedClusterReconciler struct {
+	client.Client
+	Log    *zap.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	log := r.Log.With(
+		zap.String("name", req.Name),
+	)
+
+	// Get the ManagedCluster CR
+	managedCluster := &clusterv1.ManagedCluster{}
+	if err := r.Get(ctx, req.NamespacedName, managedCluster); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("ManagedCluster not found")
+			return doNotRequeue(), nil
+		}
+		log.Error("Failed to get ManagedCluster", zap.Error(err))
+		// This is likely a case where the API is down, so requeue and try again shortly
+		return requeueWithError(err)
+	}
+
+	// Fetch ClusterInstance associated with ManagedCluster object
+	clusterInstance, err := r.getClusterInstance(ctx, log, managedCluster)
+	if err != nil {
+		return requeueWithError(err)
+	}
+	if clusterInstance == nil {
+		return doNotRequeue(), nil
+	}
+
+	oldStatus := clusterInstance.Status.DeepCopy()
+	patch := client.MergeFrom(clusterInstance.DeepCopy())
+
+	// Initialize ClusterInstance ManagedCluster reference if unset
+	if clusterInstance.Status.ManagedClusterRef == nil || clusterInstance.Status.ManagedClusterRef.Name == "" {
+		clusterInstance.Status.ManagedClusterRef = &corev1.LocalObjectReference{Name: managedCluster.Name}
+	}
+
+	// Initialize ClusterInstance Provisioned status if not found
+	if provisionedStatus := meta.FindStatusCondition(
+		clusterInstance.Status.Conditions,
+		string(v1alpha1.ClusterProvisioned),
+	); provisionedStatus == nil {
+		log.Info("Initializing Provisioned condition", zap.String("ClusterInstance", clusterInstance.Name))
+		conditions.SetStatusCondition(&clusterInstance.Status.Conditions,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Unknown,
+			metav1.ConditionUnknown,
+			"Waiting for ManagedCluster to become available")
+	}
+
+	updateProvisionedStatus(managedCluster, clusterInstance, log)
+
+	if !equality.Semantic.DeepEqual(oldStatus, &clusterInstance.Status) {
+		if updateErr := conditions.PatchCIStatus(ctx, r.Client, clusterInstance, patch); updateErr != nil {
+			return requeueWithError(updateErr)
+		}
+	}
+
+	return doNotRequeue(), nil
+}
+
+// updateProvisionedStatus updates the ClusterInstance Provisioned condition based on ManagedCluster Available status.
+func updateProvisionedStatus(mc *clusterv1.ManagedCluster, ci *v1alpha1.ClusterInstance, log *zap.Logger) {
+
+	// Provisioning is a one-way transition: never downgrade a completed provision
+	// because the ManagedCluster later becomes unavailable.
+	if existing := meta.FindStatusCondition(
+		ci.Status.Conditions, string(v1alpha1.ClusterProvisioned),
+	); existing != nil && existing.Status == metav1.ConditionTrue {
+		return
+	}
+
+	availableCondition := meta.FindStatusCondition(mc.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+
+	if availableCondition == nil {
+		log.Debug("ManagedCluster Available condition not found, setting Provisioned to Unknown")
+		conditions.SetStatusCondition(&ci.Status.Conditions,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Unknown,
+			metav1.ConditionUnknown,
+			"ManagedCluster Available condition not found")
+		return
+	}
+
+	switch availableCondition.Status {
+	case metav1.ConditionTrue:
+		conditions.SetStatusCondition(&ci.Status.Conditions,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Completed,
+			metav1.ConditionTrue,
+			"ManagedCluster is available")
+	case metav1.ConditionFalse:
+		conditions.SetStatusCondition(&ci.Status.Conditions,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.InProgress,
+			metav1.ConditionFalse,
+			"ManagedCluster is not available")
+	case metav1.ConditionUnknown:
+		conditions.SetStatusCondition(&ci.Status.Conditions,
+			v1alpha1.ClusterProvisioned,
+			v1alpha1.Unknown,
+			metav1.ConditionUnknown,
+			"ManagedCluster availability is unknown")
+	}
+}
+
+// isHostedManagedCluster checks if a ManagedCluster is a hosted cluster based on labels and annotations
+func isHostedManagedCluster(labels, annotations map[string]string) bool {
+	return labels["ishosted"] == "true" &&
+		annotations["open-cluster-management/created-via"] == "hypershift"
+}
+
+func (r *ManagedClusterReconciler) getClusterInstance(
+	ctx context.Context,
+	log *zap.Logger,
+	mc *clusterv1.ManagedCluster,
+) (*v1alpha1.ClusterInstance, error) {
+
+	// List all ClusterInstances and find the one matching this ManagedCluster by name
+	clusterInstanceList := &v1alpha1.ClusterInstanceList{}
+	if err := r.List(ctx, clusterInstanceList); err != nil {
+		log.Error("Failed to list ClusterInstances", zap.Error(err))
+		return nil, fmt.Errorf("failed to list ClusterInstances: %w", err)
+	}
+
+	for i := range clusterInstanceList.Items {
+		ci := &clusterInstanceList.Items[i]
+		if ci.Spec.ClusterName == mc.Name && ci.Spec.ClusterType == v1alpha1.ClusterTypeHostedControlPlane {
+			log.Info("Found matching ClusterInstance",
+				zap.String("ClusterInstance", ci.Name),
+				zap.String("namespace", ci.Namespace))
+			return ci, nil
+		}
+	}
+
+	log.Info("No matching HostedControlPlane ClusterInstance found for ManagedCluster")
+	return nil, nil
+}
+
+func (r *ManagedClusterReconciler) mapClusterInstanceToManagedCluster(
+	ctx context.Context,
+	obj *v1alpha1.ClusterInstance,
+) []reconcile.Request {
+
+	// Only map HostedControlPlane clusters
+	if obj.Spec.ClusterType != v1alpha1.ClusterTypeHostedControlPlane {
+		return []reconcile.Request{}
+	}
+
+	// If ManagedClusterRef is set, use it
+	if obj.Status.ManagedClusterRef != nil && obj.Status.ManagedClusterRef.Name != "" {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Name: obj.Status.ManagedClusterRef.Name,
+			},
+		}}
+	}
+
+	// Not yet reconciled: fall back to the expected ManagedCluster name
+	if obj.Spec.ClusterName != "" {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: obj.Spec.ClusterName},
+		}}
+	}
+
+	return []reconcile.Request{}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ManagedClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	//nolint:wrapcheck
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("managedClusterReconciler").
+		For(&clusterv1.ManagedCluster{},
+			// watch for create and update event for ManagedCluster
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isHostedManagedCluster(e.Object.GetLabels(), e.Object.GetAnnotations())
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isHostedManagedCluster(e.ObjectNew.GetLabels(), e.ObjectNew.GetAnnotations())
+				},
+			})).
+		WatchesRawSource(source.TypedKind(mgr.GetCache(),
+			&v1alpha1.ClusterInstance{},
+			handler.TypedEnqueueRequestsFromMapFunc(r.mapClusterInstanceToManagedCluster),
+		)).
+		Complete(r)
+}

--- a/internal/controller/managedcluster_reconciler_test.go
+++ b/internal/controller/managedcluster_reconciler_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/siteconfig/api/v1alpha1"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// createHostedManagedCluster creates a ManagedCluster with hosted cluster labels and annotations
+func createHostedManagedCluster(name string, availableStatus metav1.ConditionStatus, reason, message string) *clusterv1.ManagedCluster {
+	mc := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"ishosted": "true",
+			},
+			Annotations: map[string]string{
+				"open-cluster-management/created-via": "hypershift",
+			},
+		},
+		Status: clusterv1.ManagedClusterStatus{},
+	}
+
+	if availableStatus != "" {
+		mc.Status.Conditions = []metav1.Condition{
+			{
+				Type:               clusterv1.ManagedClusterConditionAvailable,
+				Status:             availableStatus,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+	}
+
+	return mc
+}
+
+var _ = Describe("ManagedClusterReconciler", func() {
+	var (
+		c                client.Client
+		r                *ManagedClusterReconciler
+		ctx              = context.Background()
+		testLogger       = zap.NewNop().Named("Test")
+		clusterName      = "test-hosted-cluster"
+		clusterNamespace = "test-namespace"
+		clusterInstance  *v1alpha1.ClusterInstance
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.ClusterInstance{}).
+			Build()
+		r = &ManagedClusterReconciler{
+			Client: c,
+			Scheme: scheme.Scheme,
+			Log:    testLogger,
+		}
+
+		clusterInstance = &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+			},
+			Spec: v1alpha1.ClusterInstanceSpec{
+				ClusterName:            clusterName,
+				ClusterType:            v1alpha1.ClusterTypeHostedControlPlane,
+				PullSecretRef:          corev1.LocalObjectReference{Name: "pull-secret"},
+				ClusterImageSetNameRef: "testimage:foobar",
+				SSHPublicKey:           "test-ssh",
+				BaseDomain:             "abcd",
+				TemplateRefs: []v1alpha1.TemplateRef{
+					{Name: "test-cluster-template", Namespace: "default"},
+				},
+			},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterNamespace,
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+		Expect(c.Create(ctx, clusterInstance)).To(Succeed())
+	})
+
+	It("doesn't error for a missing ManagedCluster", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+	})
+
+	It("doesn't reconcile when no matching ClusterInstance found", func() {
+		key := types.NamespacedName{
+			Name: "non-existent-cluster",
+		}
+
+		managedCluster := createHostedManagedCluster("non-existent-cluster", metav1.ConditionTrue, "ManagedClusterAvailable", "Cluster is available")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+	})
+
+	It("initializes ManagedClusterRef correctly", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		managedCluster := createHostedManagedCluster(clusterName, metav1.ConditionTrue, "ManagedClusterAvailable", "Cluster is available")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Fetch ClusterInstance and verify ManagedClusterRef is set
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+		Expect(ci.Status.ManagedClusterRef).ToNot(BeNil())
+		Expect(ci.Status.ManagedClusterRef.Name).To(Equal(clusterName))
+	})
+
+	It("initializes Provisioned condition with Unknown status", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		// Create ManagedCluster with no conditions
+		managedCluster := createHostedManagedCluster(clusterName, "", "", "")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Fetch ClusterInstance and verify Provisioned condition is initialized
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+
+		expectedCondition := &metav1.Condition{
+			Type:   string(v1alpha1.ClusterProvisioned),
+			Status: metav1.ConditionUnknown,
+			Reason: string(v1alpha1.Unknown),
+		}
+		provisionedCondition := findCondition(ci.Status.Conditions, string(v1alpha1.ClusterProvisioned))
+		compareToExpectedCondition(provisionedCondition, expectedCondition)
+	})
+
+	It("sets Provisioned to Completed when Available is True", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		managedCluster := createHostedManagedCluster(clusterName, metav1.ConditionTrue, "ManagedClusterAvailable", "Cluster is available")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Fetch ClusterInstance and verify Provisioned condition is Completed
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+
+		expectedCondition := &metav1.Condition{
+			Type:   string(v1alpha1.ClusterProvisioned),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1alpha1.Completed),
+		}
+		provisionedCondition := findCondition(ci.Status.Conditions, string(v1alpha1.ClusterProvisioned))
+		compareToExpectedCondition(provisionedCondition, expectedCondition)
+	})
+
+	It("sets Provisioned to InProgress when Available is False", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		managedCluster := createHostedManagedCluster(clusterName, metav1.ConditionFalse, "ManagedClusterNotAvailable", "Cluster is not available")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Fetch ClusterInstance and verify Provisioned condition is InProgress
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+
+		expectedCondition := &metav1.Condition{
+			Type:   string(v1alpha1.ClusterProvisioned),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1alpha1.InProgress),
+		}
+		provisionedCondition := findCondition(ci.Status.Conditions, string(v1alpha1.ClusterProvisioned))
+		compareToExpectedCondition(provisionedCondition, expectedCondition)
+	})
+
+	It("sets Provisioned to Unknown when Available is Unknown", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		managedCluster := createHostedManagedCluster(clusterName, metav1.ConditionUnknown, "ManagedClusterStatusUnknown", "Cluster status is unknown")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Fetch ClusterInstance and verify Provisioned condition is Unknown
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+
+		expectedCondition := &metav1.Condition{
+			Type:   string(v1alpha1.ClusterProvisioned),
+			Status: metav1.ConditionUnknown,
+			Reason: string(v1alpha1.Unknown),
+		}
+		provisionedCondition := findCondition(ci.Status.Conditions, string(v1alpha1.ClusterProvisioned))
+		compareToExpectedCondition(provisionedCondition, expectedCondition)
+	})
+
+	It("does not update status when conditions are unchanged", func() {
+		key := types.NamespacedName{
+			Name: clusterName,
+		}
+
+		managedCluster := createHostedManagedCluster(clusterName, metav1.ConditionTrue, "ManagedClusterAvailable", "Cluster is available")
+		Expect(c.Create(ctx, managedCluster)).To(Succeed())
+
+		// First reconcile
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Get ClusterInstance and save ResourceVersion
+		ci := &v1alpha1.ClusterInstance{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+		resourceVersionAfterFirst := ci.GetResourceVersion()
+
+		// Second reconcile with no changes
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		// Verify ResourceVersion is unchanged (no status update)
+		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, ci)).To(Succeed())
+		Expect(ci.GetResourceVersion()).To(Equal(resourceVersionAfterFirst))
+	})
+
+	It("maps ClusterInstance to ManagedCluster correctly", func() {
+		// Create a ClusterInstance with ManagedClusterRef already set
+		ci := &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapped-cluster",
+				Namespace: "mapped-namespace",
+			},
+			Spec: v1alpha1.ClusterInstanceSpec{
+				ClusterName: "mapped-cluster",
+				ClusterType: v1alpha1.ClusterTypeHostedControlPlane,
+			},
+			Status: v1alpha1.ClusterInstanceStatus{
+				ManagedClusterRef: &corev1.LocalObjectReference{
+					Name: "mapped-cluster",
+				},
+			},
+		}
+
+		requests := r.mapClusterInstanceToManagedCluster(ctx, ci)
+		Expect(requests).To(HaveLen(1))
+		Expect(requests[0].Name).To(Equal("mapped-cluster"))
+		Expect(requests[0].Namespace).To(Equal(""))
+	})
+
+	It("does not map non-HostedControlPlane ClusterInstance", func() {
+		// Create a non-hosted ClusterInstance
+		ci := &v1alpha1.ClusterInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "standard-cluster",
+				Namespace: "standard-namespace",
+			},
+			Spec: v1alpha1.ClusterInstanceSpec{
+				ClusterName: "standard-cluster",
+				ClusterType: v1alpha1.ClusterTypeSNO,
+			},
+		}
+
+		requests := r.mapClusterInstanceToManagedCluster(ctx, ci)
+		Expect(requests).To(HaveLen(0))
+	})
+})
+
+// findCondition finds a condition by type in a list of conditions
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## HCP Provisioning is not reflected in ClusterInstance .Status

HCP clusters provisioned through SiteConfig do not have their provisioning status updated in any way within the ClusterInstance status field. This causes blockages in ZTP workflows that involve policy manager and TALM.

## Changes Made

ManagedCluster objects are created in the default template set for all cluster types. ManagedCluster will be the source of truth for the "is the cluster provisioning complete?" question.

(WIP because this is TODO within MCE, but there is enough status reflected in the ManagedCluster CR as of now to provide a "control plane is available" status.)

- New ManagedClusterReconciler follows pattern of ClusterDeploymentReconciler
- .status.managedClusterRef set to ManagedCluster associated with HCP cluster
- .status.conditions(type=Provisioned) is updated from the ManagedCluster, true if "available"

This may be easily altered in the future when ManagedCluster is updated to provide better information beyond API availability.

## Testing

- 11 Unit tests added (written first)
- Tested on baremetal cluster, already deployed HC updated ClusterInstance to Provisioned=True on restart of siteconfig with new code.
- 
- Code coverage for new code: ___%

## JIRA

https://redhat.atlassian.net/browse/CNF-18296

## AI Assistance

- **Model Used**: Claude
- **Scope**: Plan, Tests, Code
- **Level**: Code generation
- **Human Review**: Tested and validated, review pending

## Pull Request Checklist

Before submitting your pull request, ensure:

- [x] `make ci-job` passes without errors
- [x] Unit tests are added/updated and pass
- [x] Code coverage meets requirements (70% minimum, 90% target)
- [ ] All commits are signed off with DCO (`git commit --signoff`)
- [x] PR title follows the format: `JIRA-12345: Brief description` or `NO-ISSUE: Brief description`
- [x] PR description is complete and clear
- [x] AI assistance is disclosed (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Breaking changes are clearly documented (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the associated ManagedCluster for HostedControlPlane clusters.
  * HostedControlPlane provisioning status now reflects ManagedCluster availability.
  * Added automatic status updates when the associated ManagedCluster changes.

* **Bug Fixes**
  * Prevented standard ClusterDeployment reconciliation from overriding HostedControlPlane status handling.
  * Improved handling when referenced ManagedCluster resources are unavailable or unmatched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->